### PR TITLE
ErrorListener: Fixed wrong parameter being passed to the RuntimeException

### DIFF
--- a/lib/Gitlab/HttpClient/Listener/ErrorListener.php
+++ b/lib/Gitlab/HttpClient/Listener/ErrorListener.php
@@ -48,7 +48,16 @@ class ErrorListener implements ListenerInterface
                 }
             }
 
-            throw new RuntimeException(isset($content['message']) ? $content['message'] : $content, $response->getStatusCode());
+            $errorMessage = null;
+            if (isset($content['error'])) {
+                $errorMessage = implode("\n", $content['error']);
+            } else if (isset($content['message'])) {
+                $errorMessage = $content['message'];
+            } else {
+                $errorMessage = $content;
+            }
+
+            throw new RuntimeException($errorMessage, $response->getStatusCode());
         }
     }
 }


### PR DESCRIPTION
Fixed wrong exception throwing

**PHP Error**

> Fatal error:  Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]]) in 
> \lib\Gitlab\HttpClient\Listener\ErrorListener.php</b> on line 60

**Request that throwed the error**

``` php
// Gitlab throwed an error because the source and target branch are the same
$project->createMergeRequest("samebranchname", "samebranchname", "Some text");
```
