### PR TITLE
Fixes uncaught RuntimeException 'Property "xyz" does not exist

### DIFF
--- a/lib/Gitlab/Model/AbstractModel.php
+++ b/lib/Gitlab/Model/AbstractModel.php
@@ -35,7 +35,9 @@ abstract class AbstractModel
     {
         if (!empty($data)) {
             foreach ($data as $k => $v) {
-                $this->$k = $v;
+                if (in_array($k, static::$_properties)) {
+                    $this->$k = $v;
+                }
             }
         }
 


### PR DESCRIPTION
Fatal error:  Uncaught exception 'Gitlab\Exception\RuntimeException' with message 'Property "iid" does not exist for Gitlab\Model\MergeRequest object' in lib\Gitlab\Model\AbstractModel.php:50

New properties have been added in some Gitlab API models, for example "iid" for merge requests.

This change should make php-gitlab-api more flexible when new properties are added in Gitlab.
