### PR TITLE
Adds the new property "iid" to the MergeRequest Model

### DIFF
--- a/lib/Gitlab/Model/MergeRequest.php
+++ b/lib/Gitlab/Model/MergeRequest.php
@@ -8,6 +8,7 @@ class MergeRequest extends AbstractModel
 {
     protected static $_properties = array(
         'id',
+        'iid',
         'target_branch',
         'source_branch',
         'project_id',


### PR DESCRIPTION
This property has been added with Gitlab 6.2 and contains the internal merge request ID.
Afaik it is only needed when you want to generate links to Gitlab mergerequests yourself.
