### PR TITLE
AuthListener now uses the correct key in the header for HTTP Auth

### DIFF
--- a/lib/Gitlab/HttpClient/Listener/AuthListener.php
+++ b/lib/Gitlab/HttpClient/Listener/AuthListener.php
@@ -55,7 +55,7 @@ class AuthListener implements ListenerInterface
 
         switch ($this->method) {
             case Client::AUTH_HTTP_TOKEN:
-                $request->addHeader('private_token: '.$this->token);
+                $request->addHeader('PRIVATE-TOKEN: '.$this->token);
                 if (!is_null($this->sudo)) {
                     $request->addHeader('SUDO: '.$this->sudo);
                 }


### PR DESCRIPTION
As documented at https://github.com/gitlabhq/gitlabhq/tree/master/doc/api the key in the header for the token must be "PRIVATE-TOKEN". I don't know, if this has changed compared to earlier versions, where "private_token" might have been correct. But in the current stable version of the API, only "PRIVATE-TOKEN" works.
