### PR TITLE
Add pagination support for api('groups')->members

### DIFF
--- a/lib/Gitlab/Api/Groups.php
+++ b/lib/Gitlab/Api/Groups.php
@@ -33,7 +33,7 @@ class Groups extends AbstractApi
 	public function members($id, $page = 1, $per_page = self::PER_PAGE)
 	{
 		return $this->get('groups/'.urlencode($id).'/members', array(
-			'page=' => $page,
+			'page' => $page,
 			'per_page' => $per_page
 		));
 	}


### PR DESCRIPTION
api('groups')->members supports pagination, without this change, it is impossible to pull more than 20 members of a given group using the php wrapper to the Gitlab API.
