### PR TITLE
add target_project_id to create merge request

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -17,13 +17,18 @@ class MergeRequests extends AbstractApi
         return $this->get('projects/'.urlencode($project_id).'/merge_request/'.urlencode($mr_id));
     }
 
-    public function create($project_id, $source, $target, $title, $assignee = null)
+    public function create($project_id, $source, $target, $title, $assignee = null, $target_project_id = null)
     {
+        if ($target_project_id && ! is_numeric($target_project_id)) {
+            throw new InvalidArgumentException('target_project_id should be numeric, the project name is not allowed');
+        }
+
         return $this->post('projects/'.urlencode($project_id).'/merge_requests', array(
             'source_branch' => $source,
             'target_branch' => $target,
             'title' => $title,
-            'assignee_id' => $assignee
+            'assignee_id' => $assignee,
+            'target_project_id' => $target_project_id
         ));
     }
 


### PR DESCRIPTION
Make it possible to create a cross project merge request using the API.
Gitlab supports this from at least version 6.0.1 (what we are currently running).

I added the parameter as the last one for backwards compatibility, however next
to $project_id would make a more logical order. If you would like a change from
the current pull request, please let me know.
