### PR TITLE
Add merge method to MR API

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -37,6 +37,11 @@ class MergeRequests extends AbstractApi
         return $this->put('projects/'.urlencode($project_id).'/merge_request/'.urlencode($mr_id), $params);
     }
 
+    public function merge($project_id, $mr_id, array $params)
+    {
+        return $this->put('projects/'.urlencode($project_id).'/merge_request/'.urlencode($mr_id).'/merge', $params);
+    }
+
     public function addComment($project_id, $mr_id, $note)
     {
         return $this->post('projects/'.urlencode($project_id).'/merge_request/'.urlencode($mr_id).'/comments', array(

--- a/lib/Gitlab/Model/MergeRequest.php
+++ b/lib/Gitlab/Model/MergeRequest.php
@@ -80,6 +80,13 @@ class MergeRequest extends AbstractModel
         ));
     }
 
+    public function merge($message = null)
+    {
+        $data = $this->api('mr')->merge($this->project->id, $this->id, array('merge_commit_message' => $message));
+
+        return MergeRequest::fromArray($this->getClient(), $this->project, $data);
+    }
+
     public function merged()
     {
         return $this->update(array(


### PR DESCRIPTION
Since Gitlab CE 6.9.0 it's possible to accept MR through API: this PR adds the required code to use this feature.

I came to this patch while working on https://github.com/gushphp/gush-gitlab-adapter/pull/4. It would be great if this patch gets merged :)
