### PR TITLE
Use LSB on class instanciation to ease extending them

### DIFF
--- a/lib/Gitlab/Model/Branch.php
+++ b/lib/Gitlab/Model/Branch.php
@@ -16,7 +16,7 @@ class Branch extends AbstractModel
 
     public static function fromArray(Client $client, Project $project, array $data)
     {
-        $branch = new Branch($project, $data['name'], $client);
+        $branch = new static($project, $data['name'], $client);
 
         if (isset($data['commit'])) {
             $data['commit'] = Commit::fromArray($client, $project, $data['commit']);

--- a/lib/Gitlab/Model/Commit.php
+++ b/lib/Gitlab/Model/Commit.php
@@ -25,7 +25,7 @@ class Commit extends AbstractModel
 
     public static function fromArray(Client $client, Project $project, array $data)
     {
-        $commit = new Commit($project, $data['id'], $client);
+        $commit = new static($project, $data['id'], $client);
 
         if (isset($data['parents'])) {
             $parents = array();

--- a/lib/Gitlab/Model/Event.php
+++ b/lib/Gitlab/Model/Event.php
@@ -20,7 +20,7 @@ class Event extends AbstractModel
 
     public static function fromArray(Client $client, Project $project, array $data)
     {
-        $event = new Event($project, $client);
+        $event = new static($project, $client);
 
         return $event->hydrate($data);
     }

--- a/lib/Gitlab/Model/File.php
+++ b/lib/Gitlab/Model/File.php
@@ -14,7 +14,7 @@ class File extends AbstractModel
 
     public static function fromArray(Client $client, Project $project, array $data)
     {
-        $file = new File($project, $data['file_path'], $client);
+        $file = new static($project, $data['file_path'], $client);
 
         return $file->hydrate($data);
     }

--- a/lib/Gitlab/Model/Group.php
+++ b/lib/Gitlab/Model/Group.php
@@ -16,7 +16,7 @@ class Group extends AbstractModel
 
     public static function fromArray(Client $client, array $data)
     {
-        $group = new Group($data['id'], $client);
+        $group = new static($data['id'], $client);
 
         if (isset($data['projects'])) {
             $projects = array();

--- a/lib/Gitlab/Model/Hook.php
+++ b/lib/Gitlab/Model/Hook.php
@@ -14,7 +14,7 @@ class Hook extends AbstractModel
 
     public static function fromArray(Client $client, array $data)
     {
-        $hook = new Hook($data['id'], $client);
+        $hook = new static($data['id'], $client);
 
         return $hook->hydrate($data);
     }

--- a/lib/Gitlab/Model/Issue.php
+++ b/lib/Gitlab/Model/Issue.php
@@ -25,7 +25,7 @@ class Issue extends AbstractModel
 
     public static function fromArray(Client $client, Project $project, array $data)
     {
-        $issue = new Issue($project, $data['id'], $client);
+        $issue = new static($project, $data['id'], $client);
 
         if (isset($data['author'])) {
             $data['author'] = User::fromArray($client, $data['author']);
@@ -50,14 +50,14 @@ class Issue extends AbstractModel
     {
         $data = $this->api('issues')->show($this->project->id, $this->id);
 
-        return Issue::fromArray($this->getClient(), $this->project, $data);
+        return static::fromArray($this->getClient(), $this->project, $data);
     }
 
     public function update(array $params)
     {
         $data = $this->api('issues')->update($this->project->id, $this->id, $params);
 
-        return Issue::fromArray($this->getClient(), $this->project, $data);
+        return static::fromArray($this->getClient(), $this->project, $data);
     }
 
     public function close($comment = null)

--- a/lib/Gitlab/Model/Key.php
+++ b/lib/Gitlab/Model/Key.php
@@ -15,7 +15,7 @@ class Key extends AbstractModel
 
     public static function fromArray(Client $client, array $data)
     {
-        $key = new Key($client);
+        $key = new static($client);
 
         return $key->hydrate($data);
     }

--- a/lib/Gitlab/Model/MergeRequest.php
+++ b/lib/Gitlab/Model/MergeRequest.php
@@ -27,7 +27,7 @@ class MergeRequest extends AbstractModel
 
     public static function fromArray(Client $client, Project $project, array $data)
     {
-        $mr = new MergeRequest($project, $data['id'], $client);
+        $mr = new static($project, $data['id'], $client);
 
         if (isset($data['author'])) {
             $data['author'] = User::fromArray($client, $data['author']);
@@ -52,14 +52,14 @@ class MergeRequest extends AbstractModel
     {
         $data = $this->api('mr')->show($this->project->id, $this->id);
 
-        return MergeRequest::fromArray($this->getClient(), $this->project, $data);
+        return static::fromArray($this->getClient(), $this->project, $data);
     }
 
     public function update(array $params)
     {
         $data = $this->api('mr')->update($this->project->id, $this->id, $params);
 
-        return MergeRequest::fromArray($this->getClient(), $this->project, $data);
+        return static::fromArray($this->getClient(), $this->project, $data);
     }
 
     public function close($comment = null)

--- a/lib/Gitlab/Model/Milestone.php
+++ b/lib/Gitlab/Model/Milestone.php
@@ -22,7 +22,7 @@ class Milestone extends AbstractModel
 
     public static function fromArray(Client $client, Project $project, array $data)
     {
-        $milestone = new Milestone($project, $data['id'], $client);
+        $milestone = new static($project, $data['id'], $client);
 
         return $milestone->hydrate($data);
     }
@@ -39,14 +39,14 @@ class Milestone extends AbstractModel
     {
         $data = $this->api('milestones')->show($this->project->id, $this->id);
 
-        return Milestone::fromArray($this->getClient(), $this->project, $data);
+        return static::fromArray($this->getClient(), $this->project, $data);
     }
 
     public function update(array $params)
     {
         $data = $this->api('milestones')->update($this->project->id, $this->id, $params);
 
-        return Milestone::fromArray($this->getClient(), $this->project, $data);
+        return static::fromArray($this->getClient(), $this->project, $data);
     }
 
     public function complete()

--- a/lib/Gitlab/Model/Node.php
+++ b/lib/Gitlab/Model/Node.php
@@ -16,7 +16,7 @@ class Node extends AbstractModel
 
     public static function fromArray(Client $client, Project $project, array $data)
     {
-        $node = new Node($project, $data['id'], $client);
+        $node = new static($project, $data['id'], $client);
 
         return $node->hydrate($data);
     }

--- a/lib/Gitlab/Model/Note.php
+++ b/lib/Gitlab/Model/Note.php
@@ -19,7 +19,7 @@ class Note extends AbstractModel
 
     public static function fromArray(Client $client, $type, array $data)
     {
-        $comment = new Note($type, $data['id'], $client);
+        $comment = new static($type, $data['id'], $client);
 
         if (isset($data['author'])) {
             $data['author'] = User::fromArray($client, $data['author']);

--- a/lib/Gitlab/Model/Project.php
+++ b/lib/Gitlab/Model/Project.php
@@ -35,7 +35,7 @@ class Project extends AbstractModel
 
     public static function fromArray(Client $client, array $data)
     {
-        $project = new Project($data['id']);
+        $project = new static($data['id']);
         $project->setClient($client);
 
         if (isset($data['owner'])) {
@@ -53,7 +53,7 @@ class Project extends AbstractModel
     {
         $data = $client->api('projects')->create($name, $params);
 
-        return Project::fromArray($client, $data);
+        return static::fromArray($client, $data);
     }
 
     public function __construct($id = null, Client $client = null)
@@ -66,7 +66,7 @@ class Project extends AbstractModel
     {
         $data = $this->api('projects')->show($this->id);
 
-        return Project::fromArray($this->getClient(), $data);
+        return static::fromArray($this->getClient(), $data);
     }
 
     public function remove()

--- a/lib/Gitlab/Model/ProjectNamespace.php
+++ b/lib/Gitlab/Model/ProjectNamespace.php
@@ -18,7 +18,7 @@ class ProjectNamespace extends AbstractModel
 
     public static function fromArray(Client $client, array $data)
     {
-        $project = new ProjectNamespace($data['id']);
+        $project = new static($data['id']);
         $project->setClient($client);
 
         return $project->hydrate($data);

--- a/lib/Gitlab/Model/Session.php
+++ b/lib/Gitlab/Model/Session.php
@@ -17,7 +17,7 @@ class Session extends AbstractModel
 
     public static function fromArray(Client $client, array $data)
     {
-        $session = new Session($client);
+        $session = new static($client);
 
         return $session->hydrate($data);
     }

--- a/lib/Gitlab/Model/Snippet.php
+++ b/lib/Gitlab/Model/Snippet.php
@@ -19,7 +19,7 @@ class Snippet extends AbstractModel
 
     public static function fromArray(Client $client, Project $project, array $data)
     {
-        $snippet = new Snippet($project, $data['id'], $client);
+        $snippet = new static($project, $data['id'], $client);
 
         if (isset($data['author'])) {
             $data['author'] = User::fromArray($client, $data['author']);
@@ -40,14 +40,14 @@ class Snippet extends AbstractModel
     {
         $data = $this->api('snippets')->show($this->project->id, $this->id);
 
-        return Snippet::fromArray($this->getClient(), $this, $data);
+        return static::fromArray($this->getClient(), $this, $data);
     }
 
     public function update(array $params)
     {
         $data = $this->api('snippets')->update($this->project->id, $this->id, $params);
 
-        return Snippet::fromArray($this->getClient(), $this, $data);
+        return static::fromArray($this->getClient(), $this, $data);
     }
 
     public function content()

--- a/lib/Gitlab/Model/Tag.php
+++ b/lib/Gitlab/Model/Tag.php
@@ -15,7 +15,7 @@ class Tag extends AbstractModel
 
     public static function fromArray(Client $client, Project $project, array $data)
     {
-        $branch = new Tag($project, $data['name'], $client);
+        $branch = new static($project, $data['name'], $client);
 
         if (isset($data['commit'])) {
             $data['commit'] = Commit::fromArray($client, $project, $data['commit']);

--- a/lib/Gitlab/Model/User.php
+++ b/lib/Gitlab/Model/User.php
@@ -35,7 +35,7 @@ class User extends AbstractModel
     {
         $id = isset($data['id']) ? $data['id'] : 0;
 
-        $user = new User($id, $client);
+        $user = new static($id, $client);
 
         return $user->hydrate($data);
     }
@@ -44,7 +44,7 @@ class User extends AbstractModel
     {
         $data = $client->api('users')->create($email, $password, $params);
 
-        return User::fromArray($client, $data);
+        return static::fromArray($client, $data);
     }
 
     public function __construct($id = null, Client $client = null)
@@ -58,14 +58,14 @@ class User extends AbstractModel
     {
         $data = $this->api('users')->show($this->id);
 
-        return User::fromArray($this->getClient(), $data);
+        return static::fromArray($this->getClient(), $data);
     }
 
     public function update(array $params)
     {
         $data = $this->api('users')->update($this->id, $params);
 
-        return User::fromArray($this->getClient(), $data);
+        return static::fromArray($this->getClient(), $data);
     }
 
     public function remove()


### PR DESCRIPTION
While working on https://github.com/gushphp/gush-gitlab-adapter/pull/4 I had some problem extending model classes as they were instancating themselves through static methods using hard coded class names.

I replaced as much as possible this by using LSB (with `static` keyword) so that, when extending models and using their static factory methods, we get instance of the right class.
