### PR TITLE
Json decode only responses with json content type

### DIFF
--- a/lib/Gitlab/HttpClient/Message/Response.php
+++ b/lib/Gitlab/HttpClient/Message/Response.php
@@ -12,7 +12,7 @@ class Response extends BaseResponse
     public function getContent()
     {
         $response = parent::getContent();
-        if (parent::getHeader("Content-Type") === "application/json") {
+        if ($this->getHeader("Content-Type") === "application/json") {
             $content  = json_decode($response, true);
     
             if (JSON_ERROR_NONE !== json_last_error()) {


### PR DESCRIPTION
When I wanted to get code of JSON file (that exists in repository) using blob API method, I got parsed JSON, but I wanted plain text...
Url: projects/<project id>/repository/commits/<sha>/blob?filepath=<some json file>
