### PR TITLE
Add support for /projects/:id/labels

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -160,6 +160,11 @@ class Projects extends AbstractApi
         return $this->get('projects/'.urlencode($project_id).'/events');
     }
 
+    public function labels($project_id)
+    {
+        return $this->get('projects/'.urlencode($project_id).'/labels');
+    }
+
     public function search($query)
     {
         return $this->get('projects/search/'.urlencode($query));


### PR DESCRIPTION
Adding support for retrieving labels per project as described at http://doc.gitlab.com/ce/api/projects.html#labels.
