### PR TITLE
fix wrong comments endpoint for merge requests

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -43,9 +43,9 @@ class MergeRequests extends AbstractApi
         return $this->put('projects/'.urlencode($project_id).'/merge_request/'.urlencode($mr_id).'/merge', $params);
     }
 
-    public function showComments($project_id, $issue_id)
+    public function showComments($project_id, $mr_id)
     {
-        return $this->get('projects/'.urlencode($project_id).'/issues/'.urlencode($issue_id).'/notes');
+        return $this->get('projects/'.urlencode($project_id).'/merge_request/'.urlencode($mr_id).'/comments');
     }
 
     public function addComment($project_id, $mr_id, $note)


### PR DESCRIPTION
According to the documentation at http://doc.gitlab.com/ce/api/merge_requests.html#get-the-comments-on-a-mr, endpoint should be `/projects/:id/merge_request/:merge_request_id/comments`. At the same time, variable `$issue_id` was renamed to `$mr_id` to match the rest of the methods.
