### PR TITLE
Projects API: Change urlencode to rawurlencode

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -60,7 +60,7 @@ class Projects extends AbstractApi
      */
     public function search($query, $page = 1, $per_page = self::PER_PAGE, $order_by = self::ORDER_BY, $sort = self::SORT)
     {
-        return $this->get('projects/search/'.urlencode($query), array(
+        return $this->get('projects/search/'.rawurlencode($query), array(
             'page' => $page,
             'per_page' => $per_page,
             'order_by' => $order_by,
@@ -74,7 +74,7 @@ class Projects extends AbstractApi
      */
     public function show($project_id)
     {
-        return $this->get('projects/'.urlencode($project_id));
+        return $this->get('projects/'.rawurlencode($project_id));
     }
 
     /**
@@ -99,7 +99,7 @@ class Projects extends AbstractApi
     {
         $params['name'] = $name;
 
-        return $this->post('projects/user/'.urlencode($user_id), $params);
+        return $this->post('projects/user/'.rawurlencode($user_id), $params);
     }
 
     /**
@@ -109,7 +109,7 @@ class Projects extends AbstractApi
      */
     public function update($project_id, array $params)
     {
-        return $this->put('projects/'.urlencode($project_id), $params);
+        return $this->put('projects/'.rawurlencode($project_id), $params);
     }
 
     /**
@@ -118,7 +118,7 @@ class Projects extends AbstractApi
      */
     public function remove($project_id)
     {
-        return $this->delete('projects/'.urlencode($project_id));
+        return $this->delete('projects/'.rawurlencode($project_id));
     }
 
     /**
@@ -140,7 +140,7 @@ class Projects extends AbstractApi
      */
     public function member($project_id, $user_id)
     {
-        return $this->get($this->getProjectPath($project_id, 'members/'.urlencode($user_id)));
+        return $this->get($this->getProjectPath($project_id, 'members/'.rawurlencode($user_id)));
     }
 
     /**
@@ -201,7 +201,7 @@ class Projects extends AbstractApi
      */
     public function hook($project_id, $hook_id)
     {
-        return $this->get($this->getProjectPath($project_id, 'hooks/'.urlencode($hook_id)));
+        return $this->get($this->getProjectPath($project_id, 'hooks/'.rawurlencode($hook_id)));
     }
 
     /**
@@ -229,7 +229,7 @@ class Projects extends AbstractApi
      */
     public function updateHook($project_id, $hook_id, array $params)
     {
-        return $this->put($this->getProjectPath($project_id, 'hooks/'.urlencode($hook_id)), $params);
+        return $this->put($this->getProjectPath($project_id, 'hooks/'.rawurlencode($hook_id)), $params);
     }
 
     /**
@@ -239,7 +239,7 @@ class Projects extends AbstractApi
      */
     public function removeHook($project_id, $hook_id)
     {
-        return $this->delete($this->getProjectPath($project_id, 'hooks/'.urlencode($hook_id)));
+        return $this->delete($this->getProjectPath($project_id, 'hooks/'.rawurlencode($hook_id)));
     }
 
     /**
@@ -258,7 +258,7 @@ class Projects extends AbstractApi
      */
     public function key($project_id, $key_id)
     {
-        return $this->get($this->getProjectPath($project_id, 'keys/'.urlencode($key_id)));
+        return $this->get($this->getProjectPath($project_id, 'keys/'.rawurlencode($key_id)));
     }
 
     /**
@@ -282,7 +282,7 @@ class Projects extends AbstractApi
      */
     public function removeKey($project_id, $key_id)
     {
-        return $this->delete($this->getProjectPath($project_id, 'keys/'.urlencode($key_id)));
+        return $this->delete($this->getProjectPath($project_id, 'keys/'.rawurlencode($key_id)));
     }
 
     /**
@@ -342,7 +342,7 @@ class Projects extends AbstractApi
      */
     public function createForkRelation($project_id, $forked_project_id)
     {
-        return $this->post($this->getProjectPath($project_id, 'fork/'.urlencode($forked_project_id)));
+        return $this->post($this->getProjectPath($project_id, 'fork/'.rawurlencode($forked_project_id)));
     }
 
     /**
@@ -362,7 +362,7 @@ class Projects extends AbstractApi
      */
     public function setService($project_id, $service_name, array $params = array())
     {
-        return $this->put($this->getProjectPath($project_id, 'services/'.urlencode($service_name)), $params);
+        return $this->put($this->getProjectPath($project_id, 'services/'.rawurlencode($service_name)), $params);
     }
 
     /**
@@ -372,6 +372,6 @@ class Projects extends AbstractApi
      */
     public function removeService($project_id, $service_name)
     {
-        return $this->delete($this->getProjectPath($project_id, 'services/'.urlencode($service_name)));
+        return $this->delete($this->getProjectPath($project_id, 'services/'.rawurlencode($service_name)));
     }
 }

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -77,7 +77,7 @@ class ProjectsTest extends ApiTestCase
     {
         $expectedArray = $this->getMultipleProjectsData();
 
-        $api = $this->getMultipleProjectsRequestMock('projects/search/a+project', $expectedArray);
+        $api = $this->getMultipleProjectsRequestMock('projects/search/a%20project', $expectedArray);
 
         $this->assertEquals($expectedArray, $api->search('a project'));
     }


### PR DESCRIPTION
Trying to search a project like this: "Test project" it gets converted to "Test+Project", instead RedmineAPI expect the space encoded as "%20", which is correctly handled by rawurlencode function.