### PR TITLE
Fix branch endpoints when branch name contains a slash.

### DIFF
--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -18,7 +18,7 @@ class Repositories extends AbstractApi
      */
     public function branch($project_id, $branch_id)
     {
-        return $this->get($this->getProjectPath($project_id, 'repository/branches/'.rawurlencode($branch_id)));
+        return $this->get($this->getProjectPath($project_id, 'repository/branches/'.str_replace('%2F', '/', rawurlencode($branch_id))));
     }
 
     /**
@@ -42,7 +42,7 @@ class Repositories extends AbstractApi
      */
     public function deleteBranch($project_id, $branch_name)
     {
-        return $this->delete($this->getProjectPath($project_id, 'repository/branches/'.rawurlencode($branch_name)));
+        return $this->delete($this->getProjectPath($project_id, 'repository/branches/'.str_replace('%2F', '/', rawurlencode($branch_name))));
     }
 
     /**
@@ -52,7 +52,7 @@ class Repositories extends AbstractApi
      */
     public function protectBranch($project_id, $branch_name)
     {
-        return $this->put($this->getProjectPath($project_id, 'repository/branches/'.rawurlencode($branch_name).'/protect'));
+        return $this->put($this->getProjectPath($project_id, 'repository/branches/'.str_replace('%2F', '/', rawurlencode($branch_name)).'/protect'));
     }
 
     /**
@@ -62,7 +62,7 @@ class Repositories extends AbstractApi
      */
     public function unprotectBranch($project_id, $branch_name)
     {
-        return $this->put($this->getProjectPath($project_id, 'repository/branches/'.rawurlencode($branch_name).'/unprotect'));
+        return $this->put($this->getProjectPath($project_id, 'repository/branches/'.str_replace('%2F', '/', rawurlencode($branch_name)).'/unprotect'));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/RepositoriesTest.php
+++ b/test/Gitlab/Tests/Api/RepositoriesTest.php
@@ -44,6 +44,23 @@ class RepositoriesTest extends ApiTestCase
     /**
      * @test
      */
+    public function shouldGetBranchWithSlash()
+    {
+        $expectedArray = array('name' => 'env/production');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/repository/branches/env/production')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->branch(1, 'env/production'));
+    }
+
+    /**
+     * @test
+     */
     public function shouldCreateBranch()
     {
         $expectedArray = array('name' => 'feature');


### PR DESCRIPTION
This fixes the branch endpoints when the branch name contains a slash.
For example, if there are environment or feature branches named `env/*` or `feature/*`, the current branch endpoints will fail.
An example is included in the updated test case.