### PR TITLE
Encode dots in project name

### DIFF
--- a/lib/Gitlab/Api/AbstractApi.php
+++ b/lib/Gitlab/Api/AbstractApi.php
@@ -111,6 +111,6 @@ abstract class AbstractApi
      */
     protected function getProjectPath($id, $path)
     {
-        return 'projects/'.rawurlencode($id).'/'.$path;
+        return 'projects/'.str_replace('.', '%2E', rawurlencode($id)).'/'.$path;
     }
 }


### PR DESCRIPTION
If there are dots in the project name, the GitLab API does not work properly with urlencode only. The dots have to be replaced with %2E. See https://github.com/gitlabhq/gitlabhq/issues/8553