### PR TITLE
Add visibility level for snippet creation

### DIFF
--- a/lib/Gitlab/Api/Snippets.php
+++ b/lib/Gitlab/Api/Snippets.php
@@ -28,12 +28,13 @@ class Snippets extends AbstractApi
      * @param string $code
      * @return mixed
      */
-    public function create($project_id, $title, $filename, $code)
+    public function create($project_id, $title, $filename, $code, $visibility_level)
     {
         return $this->post($this->getProjectPath($project_id, 'snippets'), array(
             'title' => $title,
             'file_name' => $filename,
-            'code' => $code
+            'code' => $code,
+            'visibility_level' => $visibility_level
         ));
     }
 

--- a/test/Gitlab/Tests/Api/SnippetsTest.php
+++ b/test/Gitlab/Tests/Api/SnippetsTest.php
@@ -49,11 +49,11 @@ class SnippetsTest extends ApiTestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('projects/1/snippets', array('title' => 'A new snippet', 'code' => 'A file', 'file_name' => 'file.txt'))
+            ->with('projects/1/snippets', array('title' => 'A new snippet', 'code' => 'A file', 'file_name' => 'file.txt', 'visibility_level' => 0))
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->create(1, 'A new snippet', 'file.txt', 'A file'));
+        $this->assertEquals($expectedArray, $api->create(1, 'A new snippet', 'file.txt', 'A file', 0));
     }
 
     /**


### PR DESCRIPTION
The visibility level is required (http://doc.gitlab.com/ce/api/project_snippets.html#create-new-snippet).