### PR TITLE
Add description field to the MergeRequest model

### DIFF
--- a/lib/Gitlab/Model/MergeRequest.php
+++ b/lib/Gitlab/Model/MergeRequest.php
@@ -11,6 +11,7 @@ use Gitlab\Client;
  * @property-read string $source_branch
  * @property-read int $project_id
  * @property-read string $title
+ * @property-read string $description
  * @property-read bool $closed
  * @property-read bool $merged
  * @property-read string $state
@@ -37,6 +38,7 @@ class MergeRequest extends AbstractModel implements Noteable
         'source_branch',
         'project_id',
         'title',
+        'description',
         'closed',
         'merged',
         'author',


### PR DESCRIPTION
Hey there,

Ran into an issue running Gitlab 7.10 where description was coming back from the API for merge requests, but description was not in the list of properties in Gitlab\Model\MergeRequest. As a result, Gitlab\Model\MergeRequest::fromArray (calling Gitlab\Model\AbstractModel::hydrate) was throwing an exception.

This pull request adds the description key to the list of properties in Gitlab\Model\MergeRequest.

It looks like the current documentation for the Gitlab API lists description as a field, so this shouldn't be a old API version issue, probably will be this way going forward. The list of properties I referenced is available here for review: http://doc.gitlab.com/ee/api/merge_requests.html#get-single-mr

Hope this helps!

Take care,
JB