### PR TITLE
Allow to access `Note` id through `__get`

### DIFF
--- a/lib/Gitlab/Model/Note.php
+++ b/lib/Gitlab/Model/Note.php
@@ -19,6 +19,7 @@ class Note extends AbstractModel
      * @var array
      */
     protected static $properties = array(
+        'id',
         'author',
         'body',
         'created_at',


### PR DESCRIPTION
In [gushphp/gush](https://github.com/gushphp/gush), we need to access the comment `id`. The simplest way is to use the `Model` definition to map loaded data.

It's a really simple PR but it'll allow to simplify our code :smile:.