### PR TITLE
Minor bug fix in the keys() function on a project.

### DIFF
--- a/lib/Gitlab/Model/Project.php
+++ b/lib/Gitlab/Model/Project.php
@@ -286,7 +286,7 @@ class Project extends AbstractModel
 
         $keys = array();
         foreach ($data as $key) {
-            $hooks[] = Key::fromArray($this->getClient(), $key);
+            $keys[] = Key::fromArray($this->getClient(), $key);
         }
 
         return $keys;


### PR DESCRIPTION
Invalid variable name on the project->keys() function. 