### PR TITLE
Add missing requirement for PHP's XML extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
 	"require": {
 		"php":                ">=5.3.2",
 		"ext-curl":           "*",
+		"ext-xml":            "*",
 		"kriswallsmith/buzz": ">=0.7"
 	},
 	"require-dev": {


### PR DESCRIPTION
ext-xml is required by utf_encode() used in this library