### PR TITLE
Adding the newer merge request notes API endpoint.

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -147,6 +147,16 @@ class MergeRequests extends AbstractApi
      * @param int $mr_id
      * @return mixed
      */
+    public function showNotes($project_id, $mr_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id).'/notes'));
+    }
+
+    /**
+     * @param int $project_id
+     * @param int $mr_id
+     * @return mixed
+     */
     public function showComments($project_id, $mr_id)
     {
         return $this->get($this->getProjectPath($project_id, 'merge_request/'.$this->encodePath($mr_id).'/comments'));

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -265,6 +265,26 @@ class MergeRequestsTest extends ApiTestCase
     /**
      * @test
      */
+    public function shouldGetMergeRequestNotes()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'body' => 'A comment'),
+            array('id' => 2, 'body' => 'Another comment')
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/merge_requests/2/notes')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->showNotes(1, 2));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetMergeRequestComments()
     {
         $expectedArray = array(


### PR DESCRIPTION
Adds the newer merge request notes endpoint. The notes endpoint is the preferred endpoint to get comments, and returns more data than the old comments endpoint.