### PR TITLE
Added support for milestone filter

### DIFF
--- a/lib/Gitlab/Api/Issues.php
+++ b/lib/Gitlab/Api/Issues.php
@@ -13,7 +13,7 @@ class Issues extends AbstractApi
     {
         $path = $project_id === null ? 'issues' : $this->getProjectPath($project_id, 'issues');
 
-        $params = array_intersect_key($params, array('labels' => '', 'state' => '', 'sort' => '', 'order_by' => ''));
+        $params = array_intersect_key($params, array('labels' => '', 'state' => '', 'sort' => '', 'order_by' => '', 'milestone' => ''));
         $params = array_merge(array(
             'page' => $page,
             'per_page' => $per_page


### PR DESCRIPTION
As per the latest docs, a milestone title can be passed as an argument to filter the issues by that milestone (http://docs.gitlab.com/ee/api/issues.html#list-project-issues)

This adds a milestone key to the array of allowed params.