### PR TITLE
Add build and trace to Project API

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -150,6 +150,16 @@ class Projects extends AbstractApi
     }
 
     /**
+     * @param $project_id
+     * @param $build_id
+     * @return mixed
+     */
+    public function trace($project_id, $build_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'builds/'.$this->encodePath($build_id).'/trace'));
+    }
+
+    /**
      * @param int $project_id
      * @param string $username_query
      * @return mixed

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -140,6 +140,16 @@ class Projects extends AbstractApi
     }
 
     /**
+     * @param $project_id
+     * @param $build_id
+     * @return mixed
+     */
+    public function build($project_id, $build_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'builds/'.$this->encodePath($build_id)));
+    }
+
+    /**
      * @param int $project_id
      * @param string $username_query
      * @return mixed

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -241,6 +241,23 @@ class ProjectsTest extends ApiTestCase
     /**
      * @test
      */
+    public function shouldGetBuild()
+    {
+        $expectedArray = array('id' => 2);
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/builds/2')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->build(1, 2));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetMembers()
     {
         $expectedArray = array(

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -254,6 +254,23 @@ class ProjectsTest extends ApiTestCase
 
         $this->assertEquals($expectedArray, $api->build(1, 2));
     }
+    
+    /**
+     * @test
+     */
+    public function shouldGetTrace()
+    {
+        $expectedString = 'runner trace of a specific build';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/builds/2/trace')
+            ->will($this->returnValue($expectedString))
+        ;
+
+        $this->assertEquals($expectedString, $api->trace(1, 2));
+    }
 
     /**
      * @test


### PR DESCRIPTION
Get a single build of a project.
Get a trace of a specific build of a project.