### PR TITLE
allow to paginate merge request notes

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -17,11 +17,12 @@ class MergeRequests extends AbstractApi
      * @param int $per_page
      * @param string $order_by
      * @param string $sort
+     * @param string $object
      * @return mixed
      */
-    public function getList($project_id, $state = self::STATE_ALL, $page = 1, $per_page = self::PER_PAGE, $order_by = self::ORDER_BY, $sort = self::SORT)
+    public function getList($project_id, $state = self::STATE_ALL, $page = 1, $per_page = self::PER_PAGE, $order_by = self::ORDER_BY, $sort = self::SORT, $object = 'merge_requests')
     {
-        return $this->get($this->getProjectPath($project_id, 'merge_requests'), array(
+        return $this->get($this->getProjectPath($project_id, $object), array(
             'page' => $page,
             'per_page' => $per_page,
             'state' => $state,
@@ -147,9 +148,9 @@ class MergeRequests extends AbstractApi
      * @param int $mr_id
      * @return mixed
      */
-    public function showNotes($project_id, $mr_id)
+    public function showNotes($project_id, $mr_id, $page = 1, $per_page = self::PER_PAGE, $order_by = self::ORDER_BY, $sort = 'desc')
     {
-        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id).'/notes'));
+        return $this->getList($project_id, null, $page, $per_page, $order_by, $sort, 'merge_requests/'.$this->encodePath($mr_id).'/notes');
     }
 
     /**


### PR DESCRIPTION
By default the API only return the 20 last entries.
Allow to paginate for retrieve more historical data.