### PR TITLE
Allow to retrieve Merge Requests commits

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -195,4 +195,14 @@ class MergeRequests extends AbstractApi
     {
         return $this->get($this->getProjectPath($project_id, 'merge_requests'), array('iid' => $mr_iid));
     }
+
+    /**
+     * @param int $project_id
+     * @param int $mr_id
+     * @return mixed
+     */
+    public function commits($project_id, $mr_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'merge_request/'.$this->encodePath($mr_id).'/commits'));
+    }
 }


### PR DESCRIPTION
Add a new method to retrieve merge requests commits: http://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr-commits