### PR TITLE
Allow to fork a repository in current namespace

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -380,6 +380,15 @@ class Projects extends AbstractApi
 
     /**
      * @param int $project_id
+     * @return mixed
+     */
+    public function fork($project_id)
+    {
+        return $this->post('projects/fork/'.$this->encodePath($project_id));
+    }
+
+    /**
+     * @param int $project_id
      * @param int $forked_project_id
      * @return mixed
      */


### PR DESCRIPTION
Gitlab API has the ability to fork a project: http://docs.gitlab.com/ce/api/projects.html#fork-project

This PR just implement that feature...