### PR TITLE
Added API for creating/updating a tag release

### DIFF
--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -91,6 +91,36 @@ class Repositories extends AbstractApi
     }
 
     /**
+     * @param int    $project_id
+     * @param string $tag_name
+     * @param string $description
+     *
+     * @return mixed
+     */
+    public function createRelease( $project_id, $tag_name, $description ) {
+        return $this->post( $this->getProjectPath( $project_id, 'repository/tags/' . $this->encodeBranch( $tag_name ) . '/release' ), array(
+            'id'          => $project_id,
+            'tag_name'    => $tag_name,
+            'description' => $description
+        ) );
+    }
+
+    /**
+     * @param int    $project_id
+     * @param string $tag_name
+     * @param string $description
+     *
+     * @return mixed
+     */
+    public function updateRelease( $project_id, $tag_name, $description ) {
+        return $this->put( $this->getProjectPath( $project_id, 'repository/tags/' . $this->encodeBranch( $tag_name ) . '/release' ), array(
+            'id'          => $project_id,
+            'tag_name'    => $tag_name,
+            'description' => $description
+        ) );
+    }
+
+    /**
      * @param int $project_id
      * @param string $sha
      * @param string $scope

--- a/test/Gitlab/Tests/Api/RepositoriesTest.php
+++ b/test/Gitlab/Tests/Api/RepositoriesTest.php
@@ -150,6 +150,54 @@ class RepositoriesTest extends ApiTestCase
         $this->assertEquals($expectedArray, $api->createTag(1, '1.0', 'abcd1234', '1.0 release'));
     }
 
+	/**
+	 * @test
+	 */
+	public function shouldCreateRelease() {
+		$project_id  = 1;
+		$tagName     = 'sometag';
+		$description = '1.0 release';
+
+		$expectedArray = array( 'name' => $tagName );
+
+		$api = $this->getApiMock();
+		$api->expects( $this->once())
+		    ->method('post')
+		    ->with( 'projects/' . $project_id . '/repository/tags/' . $tagName . '/release', array(
+			    'id' => $project_id,
+			    'tag_name' => $tagName,
+			    'description' => $description
+		    ))
+		    ->will($this->returnValue($expectedArray))
+		;
+
+		$this->assertEquals( $expectedArray, $api->createRelease( $project_id, $tagName, $description ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function shouldUpdateRelease() {
+		$project_id  = 1;
+		$tagName     = 'sometag';
+		$description = '1.0 release';
+
+		$expectedArray = array( 'description' => $tagName );
+
+		$api = $this->getApiMock();
+		$api->expects( $this->once())
+		    ->method('put')
+		    ->with( 'projects/' . $project_id . '/repository/tags/' . $tagName . '/release', array(
+			    'id' => $project_id,
+			    'tag_name' => $tagName,
+			    'description' => $description
+		    ))
+		    ->will($this->returnValue($expectedArray))
+		;
+
+		$this->assertEquals( $expectedArray, $api->updateRelease( $project_id, $tagName, $description ) );
+	}
+
     /**
      * @test
      */


### PR DESCRIPTION
I couldn't find these APIs, so I've added them :)

Documented [here](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/api/tags.md#create-a-new-release) and [here](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/api/tags.md#update-a-release).

Also added unit tests.

/cc @m4tthumphrey 