### PR TITLE
Add user email listing

### DIFF
--- a/lib/Gitlab/Api/Users.php
+++ b/lib/Gitlab/Api/Users.php
@@ -207,4 +207,21 @@ class Users extends AbstractApi
     {
         return $this->delete('users/'.$this->encodePath($user_id).'/keys/'.$this->encodePath($key_id));
     }
+
+    /**
+     * @return mixed
+     */
+    public function emails()
+    {
+        return $this->get('user/emails');
+    }
+
+    /**
+     * @param $id
+     * @return mixed
+     */
+    public function email($id)
+    {
+        return $this->get('user/emails/'.$this->encodePath($id));
+    }
 }

--- a/test/Gitlab/Tests/Api/UsersTest.php
+++ b/test/Gitlab/Tests/Api/UsersTest.php
@@ -417,6 +417,41 @@ class UsersTest extends ApiTestCase
         $this->assertEquals($expectedArray, $api->login('matt', 'password'));
     }
 
+    /**
+     * @test
+     */
+    public function shouldGetUserEmails()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'email' => 'foo@bar.baz'),
+            array('id' => 2, 'email' => 'foo@bar.qux'),
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('user/emails')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->emails());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetSpecificUserEmail()
+    {
+        $expectedArray = array('id' => 1, 'email' => 'foo@bar.baz');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('user/emails/1')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->email(1));
+    }
+
     protected function getApiClass()
     {
         return 'Gitlab\Api\Users';


### PR DESCRIPTION
Added 
- listing of all emails (current user)
- method for getting specific email by id (current user)
- tests for both

see https://docs.gitlab.com/ce/api/users.html#list-emails