### PR TITLE
Add deploy keys to projects api

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -236,6 +236,14 @@ class Projects extends AbstractApi
 
     /**
      * @param int $project_id
+     * @return mixed
+     */
+    public function deployKeys($project_id) {
+        return $this->get($this->getProjectPath($project_id, 'deploy_keys'));
+    }
+
+    /**
+     * @param int $project_id
      * @param int $page
      * @param int $per_page
      * @return mixed

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -238,7 +238,8 @@ class Projects extends AbstractApi
      * @param int $project_id
      * @return mixed
      */
-    public function deployKeys($project_id) {
+    public function deployKeys($project_id)
+    {
         return $this->get($this->getProjectPath($project_id, 'deploy_keys'));
     }
 


### PR DESCRIPTION
I needed the deploy keys for a given project. So I implemented it according to the [documentation](https://docs.gitlab.com/ce/api/deploy_keys.html#list-project-deploy-keys).