### PR TITLE
Implement multi-file commits

### DIFF
--- a/lib/Gitlab/Api/AbstractApi.php
+++ b/lib/Gitlab/Api/AbstractApi.php
@@ -60,7 +60,7 @@ abstract class AbstractApi implements ApiInterface
      * @param array $files
      * @return mixed
      */
-    protected function post($path, array $parameters = array(), $requestHeaders = array(), array $files = array())
+    protected function post($path, $parameters = array(), $requestHeaders = array(), array $files = array())
     {
         $response = $this->client->getHttpClient()->post($path, $parameters, $requestHeaders, $files);
 

--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -363,6 +363,6 @@ class Repositories extends AbstractApi
         $data->commit_message = $commit_message;
         $data->encoding = $encoding;
         $data->actions = $actions;
-        return $this->post($this->getProjectPath($project_id, 'repository/commits'), json_encode($data), ["Content-Type: application/json"]);
+        return $this->post($this->getProjectPath($project_id, 'repository/commits'), json_encode($data), array("Content-Type: application/json"));
     }
 }

--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -347,4 +347,22 @@ class Repositories extends AbstractApi
 
         return str_replace('%2F', '/', $path);
     }
+
+    /**
+     * @param int $project_id
+     * @param object array $actions
+     * @param string $branch_name
+     * @param string $commit_message
+     * @param string $encoding
+     * @return mixed
+     */
+    public function actions($project_id, $actions, $branch_name, $commit_message, $encoding = null)
+    {
+        $data = new \stdClass();
+        $data->branch_name = $branch_name;
+        $data->commit_message = $commit_message;
+        $data->encoding = $encoding;
+        $data->actions = $actions;
+        return $this->post($this->getProjectPath($project_id, 'repository/commits'), json_encode($data), ["Content-Type: application/json"]);
+    }
 }

--- a/lib/Gitlab/HttpClient/HttpClient.php
+++ b/lib/Gitlab/HttpClient/HttpClient.php
@@ -114,7 +114,7 @@ class HttpClient implements HttpClientInterface
     /**
      * {@inheritDoc}
      */
-    public function post($path, array $parameters = array(), array $headers = array(), array $files = array())
+    public function post($path, $parameters = array(), array $headers = array(), array $files = array())
     {
         return $this->request($path, $parameters, 'POST', $headers, $files);
     }
@@ -146,7 +146,7 @@ class HttpClient implements HttpClientInterface
     /**
      * {@inheritDoc}
      */
-    public function request($path, array $parameters = array(), $httpMethod = 'GET', array $headers = array(), array $files = array())
+    public function request($path, $parameters = array(), $httpMethod = 'GET', array $headers = array(), array $files = array())
     {
         $path = trim($this->baseUrl.$path, '/');
 
@@ -211,7 +211,12 @@ class HttpClient implements HttpClientInterface
         if (empty($files)) {
             $request = new Request($httpMethod);
             $request->setContent(http_build_query($parameters));
-        } else {
+            if (is_array($parameters)) {
+                $request->setContent(http_build_query($parameters));
+            } else {
+                $request->setContent($parameters);
+            }
+         } else {
             $request = new FormRequest($httpMethod);
             foreach ($parameters as $name => $value) {
                 $request->setField($name, $value);

--- a/lib/Gitlab/HttpClient/HttpClientInterface.php
+++ b/lib/Gitlab/HttpClient/HttpClientInterface.php
@@ -31,7 +31,7 @@ interface HttpClientInterface
      *
      * @return array Data
      */
-    public function post($path, array $parameters = array(), array $headers = array(), array $files = array());
+    public function post($path, $parameters = array(), array $headers = array(), array $files = array());
 
     /**
      * Send a PATCH request
@@ -77,7 +77,7 @@ interface HttpClientInterface
      *
      * @return array Data
      */
-    public function request($path, array $parameters = array(), $httpMethod = 'GET', array $headers = array());
+    public function request($path, $parameters = array(), $httpMethod = 'GET', array $headers = array());
 
     /**
      * Change an option value.


### PR DESCRIPTION
First, thanks for the API, it has been super helpful to my current project.

< backstory>
I have recently updated my GitLab and noticed an super helpful feature: Committing multiple files at once!
Until now I have been running a loop to add files to a repository. But this will create problems for runners (queuing up multiple for each single-file commit) which means in addition, I would have to remove and re-add the ci.yml.
<\backstory>

Anyway, they have added a new "[Create a commit with multiple files and actions](https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions)" option, and I have added a new function to Repositories.php to utilise it.
This new api call, however, requires JSON be sent, so I had to remove Your array typecasting in the httpclient. Not sure if this will upset something I am not currently using.

Here is how I am calling the new function and creating the data contents:
(Not sure if You would want to include an Action model somewhere?)

```
$files = ['install.yml', 'setup.yml'];

try {
    // Create the $actions array
    $actions = [];
    foreach ($files as $file) {
        // Make a new action class
        $action = new \stdClass();
        // Fill required properties
        $action->action = "update";
        $action->file_path = $file;
        $action->content = "Test Content";
        // Add to actions array
        array_push($actions, $action);
    }
    // Call actions function with required parameters
    // Is converted to JSON in actions()
    return GitLab::api('repo')->actions($id, $actions, 'develop', 'multipletest');
} catch (Exception $e) {
    $this->streamUpdate(0, $e->getMessage());
}
```

Let me know if I have to change anything. Or if it can be improved. =)