### PR TITLE
Add keys endpoint "/keys/:id"

### DIFF
--- a/lib/Gitlab/Api/Keys.php
+++ b/lib/Gitlab/Api/Keys.php
@@ -1,0 +1,13 @@
+<?php namespace Gitlab\Api;
+
+class Keys extends AbstractApi
+{
+    /**
+     * @param int $id
+     * @return mixed
+     */
+    public function show($id)
+    {
+        return $this->get('keys/'.$this->encodePath($id));
+    }
+}

--- a/lib/Gitlab/Client.php
+++ b/lib/Gitlab/Client.php
@@ -30,6 +30,7 @@ use Gitlab\HttpClient\Listener\PaginationListener;
  * @property-read \Gitlab\Api\SystemHooks $hooks
  * @property-read \Gitlab\Api\SystemHooks $system_hooks
  * @property-read \Gitlab\Api\Users $users
+ * @property-read \Gitlab\Api\Keys $keys
  */
 class Client
 {
@@ -148,6 +149,10 @@ class Client
 
             case 'users':
                 $api = new Api\Users($this);
+                break;
+
+            case 'keys':
+                $api = new Api\Keys($this);
                 break;
 
             default:

--- a/test/Gitlab/Tests/Api/KeysTest.php
+++ b/test/Gitlab/Tests/Api/KeysTest.php
@@ -1,0 +1,26 @@
+<?php namespace Gitlab\Tests\Api;
+
+use Gitlab\Api\AbstractApi;
+
+class KeysTest extends ApiTestCase
+{
+    /**
+     * @test
+     */
+    public function shouldShowKey()
+    {
+        $expectedArray = array('id' => 1, 'title' => 'A key', 'key' => 'ssh-rsa key', 'created_at' => '2016-01-01T01:00:00.000Z');
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('keys/1')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->show(1));
+    }
+
+    protected function getApiClass()
+    {
+        return 'Gitlab\Api\Keys';
+    }
+}


### PR DESCRIPTION
Add a endpoint to search by a key id. 
```php
$client = new \Gitlab\Client(GITLAB_URL);

$client->authenticate(GITLAB_KEY, \Gitlab\Client::AUTH_URL_TOKEN);

$key = $client->api('keys')->show(1); 
/*
 {
     "id" : 1,
     "title" : "A key",
     "key" : "key",
     "created_at" : "2016-01-01T01:00:00.000Z",
     "user" : {
          ...
     } 
 }
*/
```