### PR TITLE
Client: allow usage of options

### DIFF
--- a/lib/Gitlab/Client.php
+++ b/lib/Gitlab/Client.php
@@ -73,9 +73,14 @@ class Client
      *
      * @param string               $baseUrl
      * @param null|ClientInterface $httpClient Buzz client
+     * @param array                $options
      */
-    public function __construct($baseUrl, ClientInterface $httpClient = null)
+    public function __construct($baseUrl, ClientInterface $httpClient = null, array $options = array())
     {
+        foreach ($options as $name => $value) {
+            $this->setOption($name, $value);
+        }
+
         $httpClient = $httpClient ?: new Curl();
         $httpClient->setTimeout($this->options['timeout']);
         $httpClient->setVerifyPeer(false);


### PR DESCRIPTION
There is currently no way to change the timeout for the Curl client. Only way to do so is by setting a new client.

Current way:
```php
$client = new \Gitlab\Client('https://gitlab.com/api/v3/');
$client->setOption('timeout', 1);
$client->setHttpClient(new HttpClient($client->getBaseUrl(), ['timeout' => 1], $curl));
```

Once this PR is merged you can simply do:
```php
$client = new \Gitlab\Client('https://gitlab.com/api/v3/', null, ['timeout' => 1]);
```