### PR TITLE
File: allow autor for create/update/delete

### DIFF
--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -266,16 +266,20 @@ class Repositories extends AbstractApi
      * @param string $branch_name
      * @param string $commit_message
      * @param string $encoding
+     * @param string $author_email
+     * @param string $author_name
      * @return mixed
      */
-    public function createFile($project_id, $file_path, $content, $branch_name, $commit_message, $encoding = null)
+    public function createFile($project_id, $file_path, $content, $branch_name, $commit_message, $encoding = null, $author_email = null, $author_name = null)
     {
         return $this->post($this->getProjectPath($project_id, 'repository/files'), array(
             'file_path' => $file_path,
             'branch_name' => $branch_name,
             'content' => $content,
             'commit_message' => $commit_message,
-            'encoding' => $encoding
+            'encoding' => $encoding,
+            'author_email' => $author_email,
+            'author_name' => $author_name,
         ));
     }
 
@@ -286,16 +290,20 @@ class Repositories extends AbstractApi
      * @param string $branch_name
      * @param string $commit_message
      * @param string $encoding
+     * @param string $author_email
+     * @param string $author_name
      * @return mixed
      */
-    public function updateFile($project_id, $file_path, $content, $branch_name, $commit_message, $encoding = null)
+    public function updateFile($project_id, $file_path, $content, $branch_name, $commit_message, $encoding = null, $author_email = null, $author_name = null)
     {
         return $this->put($this->getProjectPath($project_id, 'repository/files'), array(
             'file_path' => $file_path,
             'branch_name' => $branch_name,
             'content' => $content,
             'commit_message' => $commit_message,
-            'encoding' => $encoding
+            'encoding' => $encoding,
+            'author_email' => $author_email,
+            'author_name' => $author_name,
         ));
     }
 
@@ -304,14 +312,18 @@ class Repositories extends AbstractApi
      * @param string $file_path
      * @param string $branch_name
      * @param string $commit_message
+     * @param string $author_email
+     * @param string $author_name
      * @return mixed
      */
-    public function deleteFile($project_id, $file_path, $branch_name, $commit_message)
+    public function deleteFile($project_id, $file_path, $branch_name, $commit_message, $author_email = null, $author_name = null)
     {
         return $this->delete($this->getProjectPath($project_id, 'repository/files'), array(
             'file_path' => $file_path,
             'branch_name' => $branch_name,
-            'commit_message' => $commit_message
+            'commit_message' => $commit_message,
+            'author_email' => $author_email,
+            'author_name' => $author_name,
         ));
     }
 

--- a/lib/Gitlab/Model/Project.php
+++ b/lib/Gitlab/Model/Project.php
@@ -141,24 +141,24 @@ class Project extends AbstractModel
 
         return static::fromArray($this->getClient(), $data);
     }
-    
+
     /**
      * @return Project
      */
     public function archive()
     {
         $data = $this->api("projects")->archive($this->id);
-        
+
         return static::fromArray($this->getClient(), $data);
     }
-    
+
     /**
      * @return Project
      */
     public function unarchive()
     {
         $data = $this->api("projects")->unarchive($this->id);
-        
+
         return static::fromArray($this->getClient(), $data);
     }
 
@@ -582,11 +582,13 @@ class Project extends AbstractModel
      * @param string $content
      * @param string $branch_name
      * @param string $commit_message
+     * @param string $author_email
+     * @param string $author_name
      * @return File
      */
-    public function createFile($file_path, $content, $branch_name, $commit_message)
+    public function createFile($file_path, $content, $branch_name, $commit_message, $author_email = null, $author_name = null)
     {
-        $data = $this->api('repo')->createFile($this->id, $file_path, $content, $branch_name, $commit_message);
+        $data = $this->api('repo')->createFile($this->id, $file_path, $content, $branch_name, $commit_message, null, $author_email, $author_name);
 
         return File::fromArray($this->getClient(), $this, $data);
     }
@@ -596,11 +598,13 @@ class Project extends AbstractModel
      * @param string $content
      * @param string $branch_name
      * @param string $commit_message
+     * @param string $author_email
+     * @param string $author_name
      * @return File
      */
-    public function updateFile($file_path, $content, $branch_name, $commit_message)
+    public function updateFile($file_path, $content, $branch_name, $commit_message, $author_email = null, $author_name = null)
     {
-        $data = $this->api('repo')->updateFile($this->id, $file_path, $content, $branch_name, $commit_message);
+        $data = $this->api('repo')->updateFile($this->id, $file_path, $content, $branch_name, $commit_message, null, $author_email, $author_name);
 
         return File::fromArray($this->getClient(), $this, $data);
     }
@@ -609,11 +613,13 @@ class Project extends AbstractModel
      * @param string $file_path
      * @param string $branch_name
      * @param string $commit_message
+     * @param string $author_email
+     * @param string $author_name
      * @return bool
      */
-    public function deleteFile($file_path, $branch_name, $commit_message)
+    public function deleteFile($file_path, $branch_name, $commit_message, $author_email = null, $author_name = null)
     {
-        $this->api('repo')->deleteFile($this->id, $file_path, $branch_name, $commit_message);
+        $this->api('repo')->deleteFile($this->id, $file_path, $branch_name, $commit_message, $author_email, $author_name);
 
         return true;
     }

--- a/test/Gitlab/Tests/Api/RepositoriesTest.php
+++ b/test/Gitlab/Tests/Api/RepositoriesTest.php
@@ -500,7 +500,9 @@ class RepositoriesTest extends ApiTestCase
                 'branch_name' => 'master',
                 'encoding' => null,
                 'content' => 'some contents',
-                'commit_message' => 'Added new file'
+                'commit_message' => 'Added new file',
+                'author_email' => null,
+                'author_name' => null,
             ))
             ->will($this->returnValue($expectedArray))
         ;
@@ -523,12 +525,39 @@ class RepositoriesTest extends ApiTestCase
                 'branch_name' => 'master',
                 'encoding' => 'text',
                 'content' => 'some contents',
-                'commit_message' => 'Added new file'
+                'commit_message' => 'Added new file',
+                'author_email' => null,
+                'author_name' => null,
             ))
             ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->createFile(1, 'dir/file1.txt', 'some contents', 'master', 'Added new file', 'text'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateFileWithAuthor()
+    {
+        $expectedArray = array('file_name' => 'file1.txt', 'file_path' => 'dir/file1.txt');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/repository/files', array(
+                'file_path' => 'dir/file1.txt',
+                'branch_name' => 'master',
+                'encoding' => null,
+                'content' => 'some contents',
+                'commit_message' => 'Added new file',
+                'author_email' => 'gitlab@example.com',
+                'author_name' => 'GitLab User',
+            ))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->createFile(1, 'dir/file1.txt', 'some contents', 'master', 'Added new file', null, 'gitlab@example.com', 'GitLab User'));
     }
 
     /**
@@ -546,7 +575,9 @@ class RepositoriesTest extends ApiTestCase
                 'branch_name' => 'master',
                 'encoding' => null,
                 'content' => 'some new contents',
-                'commit_message' => 'Updated new file'
+                'commit_message' => 'Updated new file',
+                'author_email' => null,
+                'author_name' => null,
             ))
             ->will($this->returnValue($expectedArray))
         ;
@@ -569,12 +600,39 @@ class RepositoriesTest extends ApiTestCase
                 'branch_name' => 'master',
                 'encoding' => 'base64',
                 'content' => 'some new contents',
-                'commit_message' => 'Updated file'
+                'commit_message' => 'Updated file',
+                'author_email' => null,
+                'author_name' => null,
             ))
             ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->updateFile(1, 'dir/file1.txt', 'some new contents', 'master', 'Updated file', 'base64'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUpdateFileWithAuthor()
+    {
+        $expectedArray = array('file_name' => 'file1.txt', 'file_path' => 'dir/file1.txt');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('projects/1/repository/files', array(
+                'file_path' => 'dir/file1.txt',
+                'branch_name' => 'master',
+                'encoding' => null,
+                'content' => 'some new contents',
+                'commit_message' => 'Updated file',
+                'author_email' => 'gitlab@example.com',
+                'author_name' => 'GitLab User',
+            ))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->updateFile(1, 'dir/file1.txt', 'some new contents', 'master', 'Updated file', null, 'gitlab@example.com', 'GitLab User'));
     }
 
     /**
@@ -587,11 +645,40 @@ class RepositoriesTest extends ApiTestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('projects/1/repository/files', array('file_path' => 'dir/file1.txt', 'branch_name' => 'master', 'commit_message' => 'Deleted file'))
+            ->with('projects/1/repository/files', array(
+                'file_path' => 'dir/file1.txt',
+                'branch_name' => 'master',
+                'commit_message' => 'Deleted file',
+                'author_email' => null,
+                'author_name' => null,
+            ))
             ->will($this->returnValue($expectedBool))
         ;
 
         $this->assertEquals($expectedBool, $api->deleteFile(1, 'dir/file1.txt', 'master', 'Deleted file'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldDeleteFileWithAuthor()
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/repository/files', array(
+                'file_path' => 'dir/file1.txt',
+                'branch_name' => 'master',
+                'commit_message' => 'Deleted file',
+                'author_email' => 'gitlab@example.com',
+                'author_name' => 'GitLab User',
+            ))
+            ->will($this->returnValue($expectedBool))
+        ;
+
+        $this->assertEquals($expectedBool, $api->deleteFile(1, 'dir/file1.txt', 'master', 'Deleted file', 'gitlab@example.com', 'GitLab User'));
     }
 
     /**
@@ -618,4 +705,4 @@ class RepositoriesTest extends ApiTestCase
     {
         return 'Gitlab\Api\Repositories';
     }
-} 
+}


### PR DESCRIPTION
File api calls allow 2 additional optional parameters: `author_email` and `author_name`
GitLab documentation for the calls: https://docs.gitlab.com/ee/api/repository_files.html