### PR TITLE
Adding the Jobs API

### DIFF
--- a/lib/Gitlab/Api/AbstractApi.php
+++ b/lib/Gitlab/Api/AbstractApi.php
@@ -5,6 +5,7 @@ use Gitlab\HttpClient\Message\ResponseMediator;
 use Http\Discovery\StreamFactoryDiscovery;
 use Http\Message\MultipartStream\MultipartStreamBuilder;
 use Http\Message\StreamFactory;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Abstract class for Api classes
@@ -52,6 +53,21 @@ abstract class AbstractApi implements ApiInterface
     }
 
     /**
+     * Performs a GET query and returns the response as a PSR-7 response object.
+     *
+     * @param string $path
+     * @param array $parameters
+     * @param array $requestHeaders
+     * @return ResponseInterface
+     */
+    protected function getAsResponse($path, array $parameters = array(), $requestHeaders = array())
+    {
+        $path = $this->preparePath($path, $parameters);
+
+        return $this->client->getHttpClient()->get($path, $requestHeaders);
+    }
+
+    /**
      * @param string $path
      * @param array $parameters
      * @param array $requestHeaders
@@ -59,11 +75,7 @@ abstract class AbstractApi implements ApiInterface
      */
     protected function get($path, array $parameters = array(), $requestHeaders = array())
     {
-        $path = $this->preparePath($path, $parameters);
-
-        $response = $this->client->getHttpClient()->get($path, $requestHeaders);
-
-        return ResponseMediator::getContent($response);
+        return ResponseMediator::getContent($this->getAsResponse($path, $parameters, $requestHeaders));
     }
 
     /**

--- a/lib/Gitlab/Api/Jobs.php
+++ b/lib/Gitlab/Api/Jobs.php
@@ -1,5 +1,7 @@
 <?php namespace Gitlab\Api;
 
+use Psr\Http\Message\StreamInterface;
+
 class Jobs extends AbstractApi
 {
     const SCOPE_CREATED = 'created';
@@ -49,24 +51,24 @@ class Jobs extends AbstractApi
     /**
      * @param int|string $project_id
      * @param int $job_id
-     * @return string
+     * @return StreamInterface
      */
     public function artifacts($project_id, $job_id)
     {
-        return $this->get("projects/".$this->encodePath($project_id)."/jobs/".$this->encodePath($job_id)."/artifacts");
+        return $this->getAsResponse("projects/".$this->encodePath($project_id)."/jobs/".$this->encodePath($job_id)."/artifacts")->getBody();
     }
 
     /**
      * @param int|string $project_id
      * @param string $ref_name
      * @param string $job_name
-     * @return string
+     * @return StreamInterface
      */
     public function artifactsByRefName($project_id, $ref_name, $job_name)
     {
-        return $this->get("projects/".$this->encodePath($project_id)."/jobs/artifacts/".$this->encodePath($ref_name)."/download", array(
+        return $this->getAsResponse("projects/".$this->encodePath($project_id)."/jobs/artifacts/".$this->encodePath($ref_name)."/download", array(
             'job' => $job_name
-        ));
+        ))->getBody();
     }
 
     /**

--- a/lib/Gitlab/Api/Jobs.php
+++ b/lib/Gitlab/Api/Jobs.php
@@ -18,7 +18,7 @@ class Jobs extends AbstractApi
      * @param array $scope
      * @return mixed
      */
-    public function jobs($project_id, array $scope = [])
+    public function all($project_id, array $scope = [])
     {
         return $this->get("projects/".$this->encodePath($project_id)."/jobs", array(
             'scope' => $scope

--- a/lib/Gitlab/Api/Jobs.php
+++ b/lib/Gitlab/Api/Jobs.php
@@ -1,0 +1,131 @@
+<?php namespace Gitlab\Api;
+
+class Jobs extends AbstractApi
+{
+    const SCOPE_CREATED = 'created';
+    const SCOPE_PENDING = 'pending';
+    const SCOPE_RUNNING = 'running';
+    const SCOPE_FAILED = 'failed';
+    const SCOPE_SUCCESS = 'success';
+    const SCOPE_CANCELED = 'canceled';
+    const SCOPE_SKIPPED = 'skipped';
+    const SCOPE_MANUAL = 'manual';
+
+    /**
+     * @param int|string $project_id
+     * @param array $scope
+     * @return mixed
+     */
+    public function jobs($project_id, array $scope = [])
+    {
+        return $this->get("projects/".$this->encodePath($project_id)."/jobs", array(
+            'scope' => $scope
+        ));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int $pipeline_id
+     * @param array $scope
+     * @return mixed
+     */
+    public function pipelineJobs($project_id, $pipeline_id, array $scope = [])
+    {
+        return $this->get("projects/".$this->encodePath($project_id)."/pipelines/".$this->encodePath($pipeline_id)."/jobs", array(
+            'scope' => $scope
+        ));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int $job_id
+     * @return mixed
+     */
+    public function show($project_id, $job_id)
+    {
+        return $this->get("projects/".$this->encodePath($project_id)."/jobs/".$this->encodePath($job_id));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int $job_id
+     * @return string
+     */
+    public function artifacts($project_id, $job_id)
+    {
+        return $this->get("projects/".$this->encodePath($project_id)."/jobs/".$this->encodePath($job_id)."/artifacts");
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param string $ref_name
+     * @param string $job_name
+     * @return string
+     */
+    public function artifactsByRefName($project_id, $ref_name, $job_name)
+    {
+        return $this->get("projects/".$this->encodePath($project_id)."/jobs/artifacts/".$this->encodePath($ref_name)."/download", array(
+            'job' => $job_name
+        ));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int $job_id
+     * @return string
+     */
+    public function trace($project_id, $job_id)
+    {
+        return $this->get("projects/".$this->encodePath($project_id)."/jobs/".$this->encodePath($job_id)."/trace");
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int $job_id
+     * @return mixed
+     */
+    public function cancel($project_id, $job_id)
+    {
+        return $this->post("projects/".$this->encodePath($project_id)."/jobs/".$this->encodePath($job_id)."/cancel");
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int $job_id
+     * @return mixed
+     */
+    public function retry($project_id, $job_id)
+    {
+        return $this->post("projects/".$this->encodePath($project_id)."/jobs/".$this->encodePath($job_id)."/retry");
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int $job_id
+     * @return mixed
+     */
+    public function erase($project_id, $job_id)
+    {
+        return $this->post("projects/".$this->encodePath($project_id)."/jobs/".$this->encodePath($job_id)."/erase");
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int $job_id
+     * @return mixed
+     */
+    public function keepArtifacts($project_id, $job_id)
+    {
+        return $this->post("projects/".$this->encodePath($project_id)."/jobs/".$this->encodePath($job_id)."/artifacts/keep");
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int $job_id
+     * @return mixed
+     */
+    public function play($project_id, $job_id)
+    {
+        return $this->post("projects/".$this->encodePath($project_id)."/jobs/".$this->encodePath($job_id)."/play");
+    }
+}

--- a/lib/Gitlab/Client.php
+++ b/lib/Gitlab/Client.php
@@ -21,6 +21,7 @@ use Http\Discovery\UriFactoryDiscovery;
  *
  * @property-read \Gitlab\Api\Groups $groups
  * @property-read \Gitlab\Api\Issues $issues
+ * @property-read \Gitlab\Api\Jobs $jobs
  * @property-read \Gitlab\Api\MergeRequests $merge_requests
  * @property-read \Gitlab\Api\MergeRequests $mr
  * @property-read \Gitlab\Api\Milestones $milestones
@@ -136,6 +137,10 @@ class Client
 
             case 'issues':
                 $api = new Api\Issues($this);
+                break;
+
+            case 'jobs':
+                $api = new Api\Jobs($this);
                 break;
 
             case 'mr':

--- a/lib/Gitlab/Model/Job.php
+++ b/lib/Gitlab/Model/Job.php
@@ -1,0 +1,83 @@
+<?php namespace Gitlab\Model;
+
+use Gitlab\Client;
+
+/**
+ * Class Commit
+ *
+ * @property-read Commit $commit
+ * @property-read int $id
+ * @property-read string $coverage
+ * @property-read string $created_at
+ * @property-read string $artifacts_file
+ * @property-read string $finished_at
+ * @property-read string $name
+ * @property-read Pipeline $pipeline
+ * @property-read string $ref
+ * @property-read string $runner
+ * @property-read string $stage
+ * @property-read string $started_at
+ * @property-read string $status
+ * @property-read string|bool $tag
+ * @property-read User $user
+ */
+class Job extends AbstractModel
+{
+    /**
+     * @var array
+     */
+    protected static $properties = array(
+        'id',
+        'commit',
+        'coverage',
+        'created_at',
+        'artifacts_file',
+        'finished_at',
+        'name',
+        'pipeline',
+        'ref',
+        'runner',
+        'stage',
+        'started_at',
+        'status',
+        'tag',
+        'user'
+    );
+
+    /**
+     * @param Client  $client
+     * @param Project $project
+     * @param array   $data
+     * @return Job
+     */
+    public static function fromArray(Client $client, Project $project, array $data)
+    {
+        $job = new static($project, $data['id'], $client);
+
+        if (isset($data['user'])) {
+            $data['user'] = User::fromArray($client, $data['user']);
+        }
+
+        if (isset($data['commit'])) {
+            $data['commit'] = Commit::fromArray($client, $project, $data['commit']);
+        }
+
+        if (isset($data['pipeline'])) {
+            $data['pipeline'] = Pipeline::fromArray($client, $project, $data['pipeline']);
+        }
+
+        return $job->hydrate($data);
+    }
+
+    /**
+     * @param Project $project
+     * @param int $id
+     * @param Client  $client
+     */
+    public function __construct(Project $project, $id = null, Client $client = null)
+    {
+        $this->setClient($client);
+        $this->setData('project', $project);
+        $this->setData('id', $id);
+    }
+}

--- a/lib/Gitlab/Model/Pipeline.php
+++ b/lib/Gitlab/Model/Pipeline.php
@@ -1,0 +1,49 @@
+<?php namespace Gitlab\Model;
+
+use Gitlab\Client;
+
+/**
+ * Class Commit
+ *
+ * @property-read int $id
+ * @property-read string $ref
+ * @property-read string $sha
+ * @property-read string $status
+ */
+class Pipeline extends AbstractModel
+{
+    /**
+     * @var array
+     */
+    protected static $properties = array(
+        'id',
+        'ref',
+        'sha',
+        'status'
+    );
+
+    /**
+     * @param Client  $client
+     * @param Project $project
+     * @param array   $data
+     * @return Commit
+     */
+    public static function fromArray(Client $client, Project $project, array $data)
+    {
+        $pipeline = new static($project, $data['id'], $client);
+
+        return $job->hydrate($data);
+    }
+
+    /**
+     * @param Project $project
+     * @param int $id
+     * @param Client  $client
+     */
+    public function __construct(Project $project, $id = null, Client $client = null)
+    {
+        $this->setClient($client);
+        $this->setData('project', $project);
+        $this->setData('id', $id);
+    }
+}

--- a/lib/Gitlab/Model/Pipeline.php
+++ b/lib/Gitlab/Model/Pipeline.php
@@ -32,7 +32,7 @@ class Pipeline extends AbstractModel
     {
         $pipeline = new static($project, $data['id'], $client);
 
-        return $job->hydrate($data);
+        return $pipeline->hydrate($data);
     }
 
     /**

--- a/lib/Gitlab/Model/Project.php
+++ b/lib/Gitlab/Model/Project.php
@@ -1092,4 +1092,49 @@ class Project extends AbstractModel
 
         return $contributors;
     }
+
+    /**
+     * @param array $scopes
+     * @return Job[]
+     */
+    public function jobs(array $scopes)
+    {
+        $data = $this->api('jobs')->jobs($this->id, $scopes);
+
+        $jobs = array();
+        foreach ($data as $job) {
+            $jobs[] = Job::fromArray($this->getClient(), $this, $job);
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * @param int $pipeline_id
+     * @param array $scopes
+     * @return Job[]
+     */
+    public function pipelineJobs($pipeline_id, array $scopes = [])
+    {
+        $data = $this->api('jobs')->pipelineJobs($this->id, $pipeline_id, $scopes);
+
+        $jobs = array();
+        foreach ($data as $job) {
+            $jobs[] = Job::fromArray($this->getClient(), $this, $job);
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * @param int $job_id
+     * @return Job
+     */
+    public function job($job_id)
+    {
+        $data = $this->api('jobs')->show($this->id, $job_id);
+
+        return Job::fromArray($this->getClient(), $this, $data);
+    }
+
 }

--- a/lib/Gitlab/Model/Project.php
+++ b/lib/Gitlab/Model/Project.php
@@ -1097,7 +1097,7 @@ class Project extends AbstractModel
      * @param array $scopes
      * @return Job[]
      */
-    public function jobs(array $scopes)
+    public function jobs(array $scopes = [])
     {
         $data = $this->api('jobs')->jobs($this->id, $scopes);
 

--- a/test/Gitlab/Tests/Api/JobsTest.php
+++ b/test/Gitlab/Tests/Api/JobsTest.php
@@ -24,7 +24,7 @@ class JobsTest extends TestCase
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->jobs(1, [Jobs::SCOPE_PENDING]));
+        $this->assertEquals($expectedArray, $api->all(1, [Jobs::SCOPE_PENDING]));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/JobsTest.php
+++ b/test/Gitlab/Tests/Api/JobsTest.php
@@ -1,8 +1,9 @@
 <?php namespace Gitlab\Tests\Api;
 
 use Gitlab\Api\Jobs;
+use GuzzleHttp\Psr7\Response;
 
-class JobsTest extends ApiTestCase
+class JobsTest extends TestCase
 {
     /**
      * @test
@@ -70,16 +71,16 @@ class JobsTest extends ApiTestCase
      */
     public function shouldGetArtifacts()
     {
-        $expectedString = "some file content";
+        $returnedStream = new Response(200, [], 'foobar');
 
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
+            ->method('getAsResponse')
             ->with('projects/1/jobs/3/artifacts')
-            ->will($this->returnValue($expectedString))
+            ->will($this->returnValue($returnedStream))
         ;
 
-        $this->assertEquals($expectedString, $api->artifacts(1, 3));
+        $this->assertEquals('foobar', $api->artifacts(1, 3)->getContents());
     }
 
     /**
@@ -87,18 +88,18 @@ class JobsTest extends ApiTestCase
      */
     public function shouldGetArtifactsByRefName()
     {
-        $expectedString = "some file content";
+        $returnedStream = new Response(200, [], 'foobar');
 
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('get')
+            ->method('getAsResponse')
             ->with('projects/1/jobs/artifacts/master/download', array(
                 'job' => 'job_name'
             ))
-            ->will($this->returnValue($expectedString))
+            ->will($this->returnValue($returnedStream))
         ;
 
-        $this->assertEquals($expectedString, $api->artifactsByRefName(1, 'master', 'job_name'));
+        $this->assertEquals('foobar', $api->artifactsByRefName(1, 'master', 'job_name')->getContents());
     }
 
     /**

--- a/test/Gitlab/Tests/Api/JobsTest.php
+++ b/test/Gitlab/Tests/Api/JobsTest.php
@@ -1,0 +1,210 @@
+<?php namespace Gitlab\Tests\Api;
+
+use Gitlab\Api\Jobs;
+
+class JobsTest extends ApiTestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllJobs()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'name' => 'A job'),
+            array('id' => 2, 'name' => 'Another job'),
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/jobs', array(
+                'scope' => ['pending']
+            ))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->jobs(1, [Jobs::SCOPE_PENDING]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetPipelineJobs()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'name' => 'A job'),
+            array('id' => 2, 'name' => 'Another job'),
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/pipelines/2/jobs', array(
+                'scope' => ['pending']
+            ))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->pipelineJobs(1, 2, [Jobs::SCOPE_PENDING]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetJob()
+    {
+        $expectedArray = array('id' => 3, 'name' => 'A job');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/jobs/3')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->show(1, 3));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetArtifacts()
+    {
+        $expectedString = "some file content";
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/jobs/3/artifacts')
+            ->will($this->returnValue($expectedString))
+        ;
+
+        $this->assertEquals($expectedString, $api->artifacts(1, 3));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetArtifactsByRefName()
+    {
+        $expectedString = "some file content";
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/jobs/artifacts/master/download', array(
+                'job' => 'job_name'
+            ))
+            ->will($this->returnValue($expectedString))
+        ;
+
+        $this->assertEquals($expectedString, $api->artifactsByRefName(1, 'master', 'job_name'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetTrace()
+    {
+        $expectedString = "some trace";
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/jobs/3/trace')
+            ->will($this->returnValue($expectedString))
+        ;
+
+        $this->assertEquals($expectedString, $api->trace(1, 3));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCancel()
+    {
+        $expectedArray = array('id' => 3, 'name' => 'A job');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/jobs/3/cancel')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->cancel(1, 3));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRetry()
+    {
+        $expectedArray = array('id' => 3, 'name' => 'A job');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/jobs/3/retry')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->retry(1, 3));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldErase()
+    {
+        $expectedArray = array('id' => 3, 'name' => 'A job');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/jobs/3/erase')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->erase(1, 3));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldKeepArtifacts()
+    {
+        $expectedArray = array('id' => 3, 'name' => 'A job');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/jobs/3/artifacts/keep')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->keepArtifacts(1, 3));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldPlay()
+    {
+        $expectedArray = array('id' => 3, 'name' => 'A job');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/jobs/3/play')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->play(1, 3));
+    }
+
+    protected function getApiClass()
+    {
+        return 'Gitlab\Api\Jobs';
+    }
+}

--- a/test/Gitlab/Tests/Api/TestCase.php
+++ b/test/Gitlab/Tests/Api/TestCase.php
@@ -28,7 +28,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         $client = Client::createWithHttpClient($httpClient);
 
         return $this->getMockBuilder($this->getApiClass())
-            ->setMethods(array_merge(array('get', 'post', 'postRaw', 'patch', 'delete', 'put', 'head'), $methods))
+            ->setMethods(array_merge(array('getAsResponse', 'get', 'post', 'postRaw', 'patch', 'delete', 'put', 'head'), $methods))
             ->setConstructorArgs(array($client))
             ->getMock();
     }


### PR DESCRIPTION
Hey guys,

Here is a PR to add support for the Jobs API (https://docs.gitlab.com/ce/api/jobs.html)

I wrote this PR because I needed a way to download artifacts files. This should replace the PR #164 that is based on old APIs methods that are no more documented.

One important point: since php-gitlab-api uses Buzz (until #191 is closed), I used Buzz to fetch the files. Buzz does not have the notion of streams... so the whole artifacts file is loaded into a PHP string. This is ok for relatively small files, but if you have an artifacts file that is a gigabyte large, this will certainly be a problem.

Should php-gitlab-api migrate to http-client (please do!), I highly recommend adding additional methods in the Jobs class like: `artifactsAsStream` that returns a stream instead of a string. This way, we can cope with very large artifacts files too.

Note: I've been testing this PR in [the washingmachine](https://github.com/thecodingmachine/washingmachine/pull/9) and it seems to be working.

Do not hesitate if you have any comments.