### PR TITLE
Add approvals, approve & unapprove API's

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -218,4 +218,37 @@ class MergeRequests extends AbstractApi
     {
         return $this->get($this->getProjectPath($project_id, 'merge_request/'.$this->encodePath($mr_id).'/commits'));
     }
+
+    /**
+     * @param int $project_id
+     * @param int $mr_id
+     *
+     * @return mixed
+     */
+    public function approvals($project_id, $mr_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id).'/approvals'));
+    }
+
+    /**
+     * @param int $project_id
+     * @param int $mr_id
+     *
+     * @return mixed
+     */
+    public function approve($project_id, $mr_id)
+    {
+        return $this->post($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id).'/approve'));
+    }
+
+    /**
+     * @param int $project_id
+     * @param int $mr_id
+     *
+     * @return mixed
+     */
+    public function unApprove($project_id, $mr_id)
+    {
+        return $this->post($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id).'/unapprove'));
+    }
 }

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -353,6 +353,58 @@ class MergeRequestsTest extends ApiTestCase
         $this->assertEquals($expectedArray, $api->getByIid(1, 2));
     }
 
+    /**
+     * @test
+     */
+    public function shouldApproveMergeRequest()
+    {
+        $expectedArray = array('id' => 1, 'title' => 'Approvals API');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/merge_requests/2/approve')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->approve(1, 2));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUnApproveMergeRequest()
+    {
+        $expectedArray = array('id' => 1, 'title' => 'Approvals API');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/merge_requests/2/unapprove')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->unapprove(1, 2));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetMergeRequestApprovals()
+    {
+        $expectedArray = array('id' => 1, 'title' => 'Approvals API');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/merge_requests', array('iid' => 2))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->getByIid(1, 2));
+    }
+
+
     protected function getMultipleMergeRequestsData()
     {
         return array(


### PR DESCRIPTION
Hello @m4tthumphrey ,

It lacks what to for approve or know the state of approval, here is a PR to add these features:
* https://docs.gitlab.com/ee/api/merge_requests.html#merge-request-approvals
* https://docs.gitlab.com/ee/api/merge_requests.html#approve-merge-request
* https://docs.gitlab.com/ee/api/merge_requests.html#unapprove-merge-request

Regards