### PR TITLE
Projects collection consolidation

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -27,6 +27,9 @@ See [documentation](doc/customize.md) to know how to customize the client timeou
 
 * The `keys`, `key`, `addKey`, `removeKey`, `disableKey` and `enableKey` methods have been removed.
 Use the `deployKeys`, `deployKey`, `addDeployKey`, `deleteDeployKey`, `removeDeployKey` and `enableDeployKey` instead.
+* The `ORDER_BY` and `SORT` class constants have been removed.
+* The `accessible`, `owned` and `search` methods have been removed. Use `all` method instead.
+* The `all` method now take a single argument which is an associative array of query string parameters.
 
 ## `Gitlab\Api\Repositories` changes
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
 		"php-http/client-implementation": "^1.0",
 		"php-http/discovery": "^1.2",
 		"php-http/httplug": "^1.1",
-		"php-http/multipart-stream-builder": "^1.0"
+		"php-http/multipart-stream-builder": "^1.0",
+		"symfony/options-resolver": "^2.6 || ^3.0"
 	},
 	"require-dev": {
 		"guzzlehttp/psr7": "^1.2",

--- a/lib/Gitlab/Api/AbstractApi.php
+++ b/lib/Gitlab/Api/AbstractApi.php
@@ -6,6 +6,7 @@ use Http\Discovery\StreamFactoryDiscovery;
 use Http\Message\MultipartStream\MultipartStreamBuilder;
 use Http\Message\StreamFactory;
 use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Abstract class for Api classes
@@ -188,6 +189,29 @@ abstract class AbstractApi implements ApiInterface
         $path = rawurlencode($path);
 
         return str_replace('.', '%2E', $path);
+    }
+
+    /**
+     * Create a new OptionsResolver with page, per_page and sort options.
+     *
+     * @return OptionsResolver
+     */
+    protected function createOptionsResolver()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefined('page')
+            ->setAllowedTypes('page', 'int')
+            ->setAllowedValues('page', function ($value) { return $value > 0; })
+        ;
+        $resolver->setDefined('per_page')
+            ->setAllowedTypes('per_page', 'int')
+            ->setAllowedValues('per_page', function ($value) { return $value > 0 && $value <= 100; })
+        ;
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['asc', 'desc'])
+        ;
+
+        return $resolver;
     }
 
     private function preparePath($path, array $parameters = [])

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -1,78 +1,81 @@
 <?php namespace Gitlab\Api;
 
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+
 class Projects extends AbstractApi
 {
-    const ORDER_BY = 'created_at';
-    const SORT = 'asc';
-
     /**
-     * @param int $page
-     * @param int $per_page
-     * @param string $order_by
-     * @param string $sort
+     * @param array $parameters {
+     *
+     *     @var bool   $archived                    Limit by archived status.
+     *     @var string $visibility                  Limit by visibility public, internal, or private.
+     *     @var string $order_by                    Return projects ordered by id, name, path, created_at, updated_at,
+     *                                              or last_activity_at fields. Default is created_at.
+     *     @var string $sort                        Return projects sorted in asc or desc order. Default is desc.
+     *     @var string $search                      Return list of projects matching the search criteria.
+     *     @var bool   $simple                      Return only the ID, URL, name, and path of each project.
+     *     @var bool   $owned                       Limit by projects owned by the current user.
+     *     @var bool   $membership                  Limit by projects that the current user is a member of.
+     *     @var bool   $starred                     Limit by projects starred by the current user.
+     *     @var bool   $statistics                  Include project statistics.
+     *     @var bool   $with_issues_enabled         Limit by enabled issues feature.
+     *     @var bool   $with_merge_requests_enabled Limit by enabled merge requests feature.
+     * }
+     *
+     * @throws UndefinedOptionsException If an option name is undefined
+     * @throws InvalidOptionsException   If an option doesn't fulfill the
+     *                                   specified validation rules
+     *
      * @return mixed
      */
-    public function all($page = 1, $per_page = self::PER_PAGE, $order_by = self::ORDER_BY, $sort = self::SORT)
+    public function all(array $parameters = [])
     {
-        return $this->get('projects/all', array(
-            'page' => $page,
-            'per_page' => $per_page,
-            'order_by' => $order_by,
-            'sort' => $sort
-        ));
-    }
+        $resolver = $this->createOptionsResolver();
+        $booleanNormalizer = function ($value) {
+            return $value ? 'true' : 'false';
+        };
+        $resolver->setDefined('archived')
+            ->setAllowedTypes('archived', 'bool')
+            ->setNormalizer('archived', $booleanNormalizer)
+        ;
+        $resolver->setDefined('visibility')
+            ->setAllowedValues('visibility', ['public', 'internal', 'private'])
+        ;
+        $resolver->setDefined('order_by')
+            ->setAllowedValues('order_by', ['id', 'name', 'path', 'created_at', 'updated_at', 'last_activity_at'])
+        ;
+        $resolver->setDefined('search');
+        $resolver->setDefined('simple')
+            ->setAllowedTypes('simple', 'bool')
+            ->setNormalizer('simple', $booleanNormalizer)
+        ;
+        $resolver->setDefined('owned')
+            ->setAllowedTypes('owned', 'bool')
+            ->setNormalizer('owned', $booleanNormalizer)
+        ;
+        $resolver->setDefined('membership')
+            ->setAllowedTypes('membership', 'bool')
+            ->setNormalizer('membership', $booleanNormalizer)
+        ;
+        $resolver->setDefined('starred')
+            ->setAllowedTypes('starred', 'bool')
+            ->setNormalizer('starred', $booleanNormalizer)
+        ;
+        $resolver->setDefined('statistics')
+            ->setAllowedTypes('statistics', 'bool')
+            ->setNormalizer('statistics', $booleanNormalizer)
+        ;
+        $resolver->setDefined('with_issues_enabled')
+            ->setAllowedTypes('with_issues_enabled', 'bool')
+            ->setNormalizer('with_issues_enabled', $booleanNormalizer)
+        ;
+        $resolver->setDefined('with_merge_requests_enabled')
+            ->setAllowedTypes('with_merge_requests_enabled', 'bool')
+            ->setNormalizer('with_merge_requests_enabled', $booleanNormalizer)
+        ;
 
-    /**
-     * @param int $page
-     * @param int $per_page
-     * @param string $order_by
-     * @param string $sort
-     * @return mixed
-     */
-    public function accessible($page = 1, $per_page = self::PER_PAGE, $order_by = self::ORDER_BY, $sort = self::SORT)
-    {
-        return $this->get('projects', array(
-            'page' => $page,
-            'per_page' => $per_page,
-            'order_by' => $order_by,
-            'sort' => $sort
-        ));
-    }
-
-    /**
-     * Get projects owned by the current user
-     * @param int $page
-     * @param int $per_page
-     * @param string $order_by
-     * @param string $sort
-     * @return mixed
-     */
-    public function owned($page = 1, $per_page = self::PER_PAGE, $order_by = self::ORDER_BY, $sort = self::SORT)
-    {
-        return $this->get('projects?owned=1', array(
-            'page' => $page,
-            'per_page' => $per_page,
-            'order_by' => $order_by,
-            'sort' => $sort
-        ));
-    }
-
-    /**
-     * @param string $query
-     * @param int $page
-     * @param int $per_page
-     * @param string $order_by
-     * @param string $sort
-     * @return mixed
-     */
-    public function search($query, $page = 1, $per_page = self::PER_PAGE, $order_by = self::ORDER_BY, $sort = self::SORT)
-    {
-        return $this->get('projects/search/'.$this->encodePath($query), array(
-            'page' => $page,
-            'per_page' => $per_page,
-            'order_by' => $order_by,
-            'sort' => $sort
-        ));
+        return $this->get('projects', $resolver->resolve($parameters));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -12,7 +12,7 @@ class ProjectsTest extends TestCase
     {
         $expectedArray = $this->getMultipleProjectsData();
 
-        $api = $this->getMultipleProjectsRequestMock('projects/all', $expectedArray);
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray);
 
         $this->assertEquals($expectedArray, $api->all());
     }
@@ -24,9 +24,9 @@ class ProjectsTest extends TestCase
     {
         $expectedArray = $this->getMultipleProjectsData();
 
-        $api = $this->getMultipleProjectsRequestMock('projects/all', $expectedArray, 1, 5, 'name', 'asc');
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['page' => 1, 'per_page' => 5, 'order_by' => 'name', 'sort' => 'asc']);
 
-        $this->assertEquals($expectedArray, $api->all(1, 5, 'name'));
+        $this->assertEquals($expectedArray, $api->all(['page' => 1, 'per_page' => 5, 'order_by' => 'name', 'sort' => 'asc']));
     }
 
     /**
@@ -39,7 +39,7 @@ class ProjectsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/all', array('page' => 1, 'per_page' => AbstractApi::PER_PAGE, 'order_by' => Projects::ORDER_BY, 'sort' => Projects::SORT))
+            ->with('projects')
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -53,9 +53,9 @@ class ProjectsTest extends TestCase
     {
         $expectedArray = $this->getMultipleProjectsData();
 
-        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, 2, 7);
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray);
 
-        $this->assertEquals($expectedArray, $api->accessible(2, 7));
+        $this->assertEquals($expectedArray, $api->all());
     }
 
     /**
@@ -65,11 +65,10 @@ class ProjectsTest extends TestCase
     {
         $expectedArray = $this->getMultipleProjectsData();
 
-        $api = $this->getMultipleProjectsRequestMock('projects?owned=1', $expectedArray, 3, 50);
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['owned' => 'true']);
 
-        $this->assertEquals($expectedArray, $api->owned(3, 50));
+        $this->assertEquals($expectedArray, $api->all(['owned' => true]));
     }
-
 
     /**
      * @test
@@ -78,14 +77,8 @@ class ProjectsTest extends TestCase
     {
         $expectedArray = $this->getMultipleProjectsData();
 
-        $api = $this->getMultipleProjectsRequestMock('projects/search/a%20project', $expectedArray);
-        $this->assertEquals($expectedArray, $api->search('a project'));
-
-        $api = $this->getMultipleProjectsRequestMock('projects/search/a%2Eproject', $expectedArray);
-        $this->assertEquals($expectedArray, $api->search('a.project'));
-
-        $api = $this->getMultipleProjectsRequestMock('projects/search/a%2Fproject', $expectedArray);
-        $this->assertEquals($expectedArray, $api->search('a/project'));
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['search' => 'a project']);
+        $this->assertEquals($expectedArray, $api->all(['search' => 'a project']));
     }
 
     /**
@@ -1008,12 +1001,12 @@ class ProjectsTest extends TestCase
         $this->assertEquals($expectedBool, $api->removeVariable(1, 'ftp_password'));
     }
 
-    protected function getMultipleProjectsRequestMock($path, $expectedArray = array(), $page = 1, $per_page = 20, $order_by = 'created_at', $sort = 'asc')
+    protected function getMultipleProjectsRequestMock($path, $expectedArray = array(), $expectedParameters = array())
     {
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with($path, array('page' => $page, 'per_page' => $per_page, 'order_by' => $order_by, 'sort' => $sort))
+            ->with($path, $expectedParameters)
             ->will($this->returnValue($expectedArray))
         ;
 


### PR DESCRIPTION
This contains changes for [!8962](https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/8962), [!8877](https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/8877) and [!9674](https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/9674).

I introduced the `OptionsResolver` to validate and sanitize parameters. If we agree with this, the same pattern could be applied everywhere.