### PR TITLE
Update MergeRequestsApi for V4 compatibility

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -23,6 +23,10 @@ See [documentation](doc/customize.md) to know how to customize the client timeou
 * The second argument of `update`, `remove`, `showComments`, `showComment`, `addComment`, `updateComment`, `removeComment`,
  `setTimeEstimate`, `resetTimeEstimate`, `addSpentTime` and `resetSpentTime` methods is now a scoped issue id (iid).
 
+## `Gitlab\Api\MergeRequests` changes
+
+* The `getList` method have been removed. Use `all` instead.
+
 ## `Gitlab\Api\Projects` changes
 
 * The `keys`, `key`, `addKey`, `removeKey`, `disableKey` and `enableKey` methods have been removed.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -25,7 +25,10 @@ See [documentation](doc/customize.md) to know how to customize the client timeou
 
 ## `Gitlab\Api\MergeRequests` changes
 
-* The `getList` method have been removed. Use `all` instead.
+* The `getList`, `getByIid`, `merged`, `opened` and `closed` methods have been removed. Use `all` method instead.
+* The `ORDER_BY` and `SORT` class constants have been removed.
+* The `all` method now take a single argument which is an associative array of query string parameters.
+* The `getNotes` method now take only two arguments, the project id and the merge request iid.
 
 ## `Gitlab\Api\Projects` changes
 

--- a/lib/Gitlab/Api/AbstractApi.php
+++ b/lib/Gitlab/Api/AbstractApi.php
@@ -1,7 +1,9 @@
 <?php namespace Gitlab\Api;
 
 use Gitlab\Client;
+use Gitlab\HttpClient\Message\QueryStringBuilder;
 use Gitlab\HttpClient\Message\ResponseMediator;
+use Gitlab\Tests\HttpClient\Message\QueryStringBuilderTest;
 use Http\Discovery\StreamFactoryDiscovery;
 use Http\Message\MultipartStream\MultipartStreamBuilder;
 use Http\Message\StreamFactory;
@@ -216,8 +218,9 @@ abstract class AbstractApi implements ApiInterface
 
     private function preparePath($path, array $parameters = [])
     {
+
         if (count($parameters) > 0) {
-            $path .= '?'.http_build_query($parameters);
+            $path .= '?'.QueryStringBuilder::build($parameters);
         }
 
         return $path;

--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -90,7 +90,7 @@ class MergeRequests extends AbstractApi
      */
     public function show($project_id, $mr_id)
     {
-        return $this->get($this->getProjectPath($project_id, 'merge_request/'.$this->encodePath($mr_id)));
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id)));
     }
 
     /**
@@ -123,7 +123,7 @@ class MergeRequests extends AbstractApi
      */
     public function update($project_id, $mr_id, array $params)
     {
-        return $this->put($this->getProjectPath($project_id, 'merge_request/'.$this->encodePath($mr_id)), $params);
+        return $this->put($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id)), $params);
     }
 
     /**
@@ -140,7 +140,7 @@ class MergeRequests extends AbstractApi
             $params = array('merge_commit_message' => $message);
         }
 
-        return $this->put($this->getProjectPath($project_id, 'merge_request/'.$this->encodePath($mr_id).'/merge'), $params);
+        return $this->put($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id).'/merge'), $params);
     }
 
     /**
@@ -173,7 +173,7 @@ class MergeRequests extends AbstractApi
      */
     public function showComments($project_id, $mr_id)
     {
-        return $this->get($this->getProjectPath($project_id, 'merge_request/'.$this->encodePath($mr_id).'/comments'));
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id).'/comments'));
     }
 
     /**
@@ -184,7 +184,7 @@ class MergeRequests extends AbstractApi
      */
     public function addComment($project_id, $mr_id, $note)
     {
-        return $this->post($this->getProjectPath($project_id, 'merge_request/'.$this->encodePath($mr_id).'/comments'), array(
+        return $this->post($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id).'/comments'), array(
             'note' => $note
         ));
     }
@@ -196,7 +196,7 @@ class MergeRequests extends AbstractApi
      */
     public function changes($project_id, $mr_id)
     {
-        return $this->get($this->getProjectPath($project_id, 'merge_request/'.$this->encodePath($mr_id).'/changes'));
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id).'/changes'));
     }
 
     /**
@@ -216,7 +216,7 @@ class MergeRequests extends AbstractApi
      */
     public function commits($project_id, $mr_id)
     {
-        return $this->get($this->getProjectPath($project_id, 'merge_request/'.$this->encodePath($mr_id).'/commits'));
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id).'/commits'));
     }
 
     /**
@@ -226,7 +226,7 @@ class MergeRequests extends AbstractApi
      */
     public function closesIssues($project_id, $mr_id)
     {
-        return $this->get($this->getProjectPath($project_id, 'merge_request/'.$this->encodePath($mr_id).'/closes_issues'));
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id).'/closes_issues'));
     }
 
     /**

--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -12,27 +12,6 @@ class MergeRequests extends AbstractApi
 
     /**
      * @param int $project_id
-     * @param string $state
-     * @param int $page
-     * @param int $per_page
-     * @param string $order_by
-     * @param string $sort
-     * @param string $object
-     * @return mixed
-     */
-    public function getList($project_id, $state = self::STATE_ALL, $page = 1, $per_page = self::PER_PAGE, $order_by = self::ORDER_BY, $sort = self::SORT, $object = 'merge_requests')
-    {
-        return $this->get($this->getProjectPath($project_id, $object), array(
-            'page' => $page,
-            'per_page' => $per_page,
-            'state' => $state,
-            'order_by' => $order_by,
-            'sort' => $sort
-        ));
-    }
-
-    /**
-     * @param int $project_id
      * @param int $page
      * @param int $per_page
      * @param string $order_by

--- a/lib/Gitlab/HttpClient/Message/QueryStringBuilder.php
+++ b/lib/Gitlab/HttpClient/Message/QueryStringBuilder.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Gitlab\HttpClient\Message;
+
+final class QueryStringBuilder
+{
+    /**
+     * Encode a query as a query string according to RFC 3986. Indexed arrays are encoded using
+     * empty squared brackets ([]) unlike http_build_query.
+     *
+     * @param mixed $query
+     *
+     * @return string
+     */
+    public static function build($query)
+    {
+        if (!is_array($query)) {
+            return rawurlencode($query);
+        }
+        return implode('&', array_map(function ($value, $key) {
+            return static::encode($value, $key);
+        }, $query, array_keys($query)));
+    }
+
+    /**
+     * Encode a value
+     * @param mixed $query
+     * @param string $prefix
+     *
+     * @return string
+     */
+    private static function encode($query, $prefix)
+    {
+        if (!is_array($query)) {
+            return rawurlencode($prefix).'='.rawurlencode($query);
+        }
+
+        $isIndexedArray = static::isIndexedArray($query);
+        return implode('&', array_map(function ($value, $key) use ($prefix, $isIndexedArray) {
+            $prefix = $isIndexedArray ? $prefix.'[]' : $prefix.'['.$key.']';
+            return static::encode($value, $prefix);
+        }, $query, array_keys($query)));
+    }
+
+    /**
+     * Tell if the given array is an indexed one (i.e. contains only sequential integer keys starting from 0).
+     *
+     * @param array $query
+     *
+     * @return bool
+     */
+    public static function isIndexedArray(array $query)
+    {
+        if (empty($query) || !isset($query[0])) {
+            return false;
+        }
+
+        return array_keys($query) === range(0, count($query) - 1);
+    }
+}

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -168,7 +168,7 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_request/2')
+            ->with('projects/1/merge_requests/2')
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -233,7 +233,7 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('projects/1/merge_request/2', array('title' => 'Updated title', 'description' => 'No so many changes now', 'state_event' => 'close'))
+            ->with('projects/1/merge_requests/2', array('title' => 'Updated title', 'description' => 'No so many changes now', 'state_event' => 'close'))
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -254,7 +254,7 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->exactly(2))
             ->method('put')
-            ->with('projects/1/merge_request/2/merge', array('merge_commit_message' => 'Accepted'))
+            ->with('projects/1/merge_requests/2/merge', array('merge_commit_message' => 'Accepted'))
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -295,7 +295,7 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_request/2/comments')
+            ->with('projects/1/merge_requests/2/comments')
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -312,7 +312,7 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('projects/1/merge_request/2/comments', array('note' => 'A comment'))
+            ->with('projects/1/merge_requests/2/comments', array('note' => 'A comment'))
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -329,7 +329,7 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_request/2/changes')
+            ->with('projects/1/merge_requests/2/changes')
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -347,7 +347,7 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_request/2/closes_issues')
+            ->with('projects/1/merge_requests/2/closes_issues')
             ->will($this->returnValue($expectedArray))
         ;
 

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -8,31 +8,14 @@ class MergeRequestsTest extends TestCase
     /**
      * @test
      */
-    public function shouldGetMergeRequestListWithDefaultParams()
+    public function shouldGetAll()
     {
         $expectedArray = $this->getMultipleMergeRequestsData();
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_requests', array('page' => 1, 'per_page' => AbstractApi::PER_PAGE, 'state' => MergeRequests::STATE_ALL, 'order_by' => MergeRequests::ORDER_BY, 'sort' => MergeRequests::SORT))
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->getList(1));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldGetAll()
-    {
-        $expectedArray = $this->getMultipleMergeRequestsData();
-
-        $api = $this->getApiMock(array('getList'));
-        $api->expects($this->once())
-            ->method('getList')
-            ->with(1, MergeRequests::STATE_ALL, 1, AbstractApi::PER_PAGE, MergeRequests::ORDER_BY, MergeRequests::SORT)
+            ->with('projects/1/merge_requests', array())
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -46,116 +29,14 @@ class MergeRequestsTest extends TestCase
     {
         $expectedArray = $this->getMultipleMergeRequestsData();
 
-        $api = $this->getApiMock(array('getList'));
+        $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('getList')
-            ->with(1, MergeRequests::STATE_ALL, 2, 5, 'title', 'desc')
+            ->method('get')
+            ->with('projects/1/merge_requests', ['page' => 2, 'per_page' => 5, 'order_by' => 'updated_at', 'sort' => 'desc'])
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->all(1, 2, 5, 'title', 'desc'));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldGetMerged()
-    {
-        $expectedArray = $this->getMultipleMergeRequestsData();
-
-        $api = $this->getApiMock(array('getList'));
-        $api->expects($this->once())
-            ->method('getList')
-            ->with(1, MergeRequests::STATE_MERGED, 1, AbstractApi::PER_PAGE, MergeRequests::ORDER_BY, MergeRequests::SORT)
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->merged(1));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldGetMergedWithParams()
-    {
-        $expectedArray = $this->getMultipleMergeRequestsData();
-
-        $api = $this->getApiMock(array('getList'));
-        $api->expects($this->once())
-            ->method('getList')
-            ->with(1, MergeRequests::STATE_MERGED, 3, 15, 'updated_at', 'asc')
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->merged(1, 3, 15, 'updated_at', 'asc'));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldGetOpened()
-    {
-        $expectedArray = $this->getMultipleMergeRequestsData();
-
-        $api = $this->getApiMock(array('getList'));
-        $api->expects($this->once())
-            ->method('getList')
-            ->with(1, MergeRequests::STATE_OPENED, 1, AbstractApi::PER_PAGE, MergeRequests::ORDER_BY, MergeRequests::SORT)
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->opened(1));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldGetOpenedWithParams()
-    {
-        $expectedArray = $this->getMultipleMergeRequestsData();
-
-        $api = $this->getApiMock(array('getList'));
-        $api->expects($this->once())
-            ->method('getList')
-            ->with(1, MergeRequests::STATE_OPENED, 2, 4, 'title', 'desc')
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->opened(1, 2, 4, 'title', 'desc'));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldGetClosed()
-    {
-        $expectedArray = $this->getMultipleMergeRequestsData();
-
-        $api = $this->getApiMock(array('getList'));
-        $api->expects($this->once())
-            ->method('getList')
-            ->with(1, MergeRequests::STATE_CLOSED, 1, AbstractApi::PER_PAGE, MergeRequests::ORDER_BY, MergeRequests::SORT)
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->closed(1));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldGetClosedWithParams()
-    {
-        $expectedArray = $this->getMultipleMergeRequestsData();
-
-        $api = $this->getApiMock(array('getList'));
-        $api->expects($this->once())
-            ->method('getList')
-            ->with(1, MergeRequests::STATE_CLOSED, 2, 4, 'title', 'desc')
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->closed(1, 2, 4, 'title', 'desc'));
+        $this->assertEquals($expectedArray, $api->all(1, ['page' => 2, 'per_page' => 5, 'order_by' => 'updated_at', 'sort' => 'desc']));
     }
 
     /**
@@ -364,11 +245,11 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_requests', array('iid' => 2))
+            ->with('projects/1/merge_requests', array('iids' => [2]))
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->getByIid(1, 2));
+        $this->assertEquals($expectedArray, $api->all(1, ['iids' => [2]]));
     }
 
     /**
@@ -415,11 +296,11 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_requests', array('iid' => 2))
+            ->with('projects/1/merge_requests', array('iids' => [2]))
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->getByIid(1, 2));
+        $this->assertEquals($expectedArray, $api->all(1, ['iids' => [2]]));
     }
 
 

--- a/test/Gitlab/Tests/HttpClient/Message/QueryStringBuilderTest.php
+++ b/test/Gitlab/Tests/HttpClient/Message/QueryStringBuilderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+
+namespace Gitlab\Tests\HttpClient\Message;
+
+use Gitlab\HttpClient\Message\QueryStringBuilder;
+
+class QueryStringBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider queryStringProvider
+     *
+     * @param mixed  $query
+     * @param string $expected
+     */
+    public function testBuild($query, $expected)
+    {
+        $this->assertEquals($expected, QueryStringBuilder::build($query));
+    }
+
+    public function queryStringProvider()
+    {
+        //Scalar value.
+        yield [
+            'a project',
+            'a%20project',
+        ];
+
+        //Indexed array.
+        yield [
+            ['iids' => [88, 86]],
+            //iids[]=88&iids[]=86
+            'iids%5B%5D=88&iids%5B%5D=86',
+        ];
+
+        //Non indexed array with only numeric keys.
+        yield [
+            ['iids' => [0 => 88, 2 => 86]],
+            //iids[0]=88&iids[2]=86
+            'iids%5B0%5D=88&iids%5B2%5D=86'
+        ];
+
+        //A deeply nested array.
+        yield [
+            [
+                'search' => 'a project',
+                'owned' => 'true',
+                'iids' => [88, 86],
+                'assoc' => [
+                    'a' => 'b',
+                    'c' => [
+                        'd' => 'e',
+                        'f' => 'g',
+                    ],
+                ],
+                'nested' => [
+                    'a' => [
+                        [
+                            'b' => 'c',
+                        ],
+                        [
+                            'd' => 'e',
+                            'f' => [
+                                'g' => 'h',
+                                'i' => 'j',
+                                'k' => [87, 89],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            //search=a project
+            //&owned=true
+            //&iids[]=88&iids[]=86
+            //&assoc[a]=b&assoc[c][d]=e&assoc[c][f]=g
+            //&nested[a][][b]=c&nested[a][][d]=e
+            //&nested[a][][f][g]=h&nested[a][][f][i]=j
+            //&nested[a][][f][k][]=87&nested[a][][f][k][]=89
+            'search=a%20project'.
+            '&owned=true'.
+            '&iids%5B%5D=88&iids%5B%5D=86'.
+            '&assoc%5Ba%5D=b&assoc%5Bc%5D%5Bd%5D=e&assoc%5Bc%5D%5Bf%5D=g'.
+            '&nested%5Ba%5D%5B%5D%5Bb%5D=c&nested%5Ba%5D%5B%5D%5Bd%5D=e'.
+            '&nested%5Ba%5D%5B%5D%5Bf%5D%5Bg%5D=h&nested%5Ba%5D%5B%5D%5Bf%5D%5Bi%5D=j'.
+            '&nested%5Ba%5D%5B%5D%5Bf%5D%5Bk%5D%5B%5D=87&nested%5Ba%5D%5B%5D%5Bf%5D%5Bk%5D%5B%5D=89'
+            ,
+        ];
+    }
+}


### PR DESCRIPTION
This carry changes for [!8793](https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/8793).

I introduced a QueryStringBuilder class to replace `http_build_query`. The only difference is that indexed arrays are encoded using `[]` instead of `[0]`.