### PR TITLE
Use options resolver almost everywhere

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -27,6 +27,10 @@ See [documentation](doc/customize.md) to know how to customize the client timeou
 * The second argument of `update`, `remove`, `showComments`, `showComment`, `addComment`, `updateComment`, `removeComment`,
  `setTimeEstimate`, `resetTimeEstimate`, `addSpentTime` and `resetSpentTime` methods is now a scoped issue id (iid).
 
+## `Gitlab\Api\IssueBoards` changes
+
+* The `all` method second and subsequent arguments have been replaced by a single associative array of query string parameters.
+
 ## `Gitlab\Api\MergeRequests` changes
 
 * The `getList`, `getByIid`, `merged`, `opened` and `closed` methods have been removed. Use `all` method instead.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,10 @@ See [documentation](doc/customize.md) to know how to customize the client timeou
 * The `setHttpClient` method have been removed. Use a `Gitlab\HttpClient\Builder` instead. 
 * The `getHttpClient` method return type is changed to `Http\Client\Common\HttpMethodsClient`.
 
+## `Gitlab\Api\AbstractApi` changes
+
+* The `PER_PAGE` class constant have been removed.
+
 ## `Gitlab\Api\DeployKeys` changes
 
 * The `all` method now take a single argument which is an associative array of query string parameters.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -23,6 +23,7 @@ See [documentation](doc/customize.md) to know how to customize the client timeou
 * The `visibility_level` parameter have been removed from `create` method. Use `visibility` instead.
 * The `all` method now take a single argument which is an associative array of query string parameters.
 * The `search` method have been removed. Use `all` method instead.
+* The `members` method second and subsequent arguments have been replaced by a single associative array of query string parameters.
 
 ## `Gitlab\Api\Issues` changes
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,6 +21,8 @@ See [documentation](doc/customize.md) to know how to customize the client timeou
 ## `Gitlab\Api\Groups` changes
 
 * The `visibility_level` parameter have been removed from `create` method. Use `visibility` instead.
+* The `all` method now take a single argument which is an associative array of query string parameters.
+* The `search` method have been removed. Use `all` method instead.
 
 ## `Gitlab\Api\Issues` changes
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -43,6 +43,10 @@ See [documentation](doc/customize.md) to know how to customize the client timeou
 * The `all` method now take a single argument which is an associative array of query string parameters.
 * The `getNotes` method now take only two arguments, the project id and the merge request iid.
 
+## `Gitlab\Api\Milestones` changes
+
+* The `all` method second and subsequent arguments have been replaced by a single associative array of query string parameters.
+
 ## `Gitlab\Api\Projects` changes
 
 * The `keys`, `key`, `addKey`, `removeKey`, `disableKey` and `enableKey` methods have been removed.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,10 @@ See [documentation](doc/customize.md) to know how to customize the client timeou
 * The `setHttpClient` method have been removed. Use a `Gitlab\HttpClient\Builder` instead. 
 * The `getHttpClient` method return type is changed to `Http\Client\Common\HttpMethodsClient`.
 
+## `Gitlab\Api\DeployKeys` changes
+
+* The `all` method now take a single argument which is an associative array of query string parameters.
+* The `ORDER_BY` and `SORT` class constants have been removed.
 
 ## `Gitlab\Api\Groups` changes
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -24,6 +24,7 @@ See [documentation](doc/customize.md) to know how to customize the client timeou
 * The `all` method now take a single argument which is an associative array of query string parameters.
 * The `search` method have been removed. Use `all` method instead.
 * The `members` method second and subsequent arguments have been replaced by a single associative array of query string parameters.
+* The `projects` method second and subsequent arguments have been replaced by a single associative array of query string parameters.
 
 ## `Gitlab\Api\Issues` changes
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -78,4 +78,4 @@ Use the `deployKeys`, `deployKey`, `addDeployKey`, `deleteDeployKey`, `removeDep
 
 ## `Gitlab\Model\Snippet` changes
 
-The `expires_at` property have been removed.`
+* The `expires_at` property have been removed.`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -69,6 +69,7 @@ Use the `deployKeys`, `deployKey`, `addDeployKey`, `deleteDeployKey`, `removeDep
 
 * The `commitBuilds` method have been removed. Use `Gitlab\Api\Projects::pipelines` instead.
 * The `commits` method second and subsequent arguments have been replaced by a single associative array of query string parameters.
+* The `commitComments` method third and subsequent arguments have been replaced by a single associative array of query string parameters.
 
 ## `Gitlab\Model\Project` changes
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -79,3 +79,8 @@ Use the `deployKeys`, `deployKey`, `addDeployKey`, `deleteDeployKey`, `removeDep
 ## `Gitlab\Model\Snippet` changes
 
 * The `expires_at` property have been removed.`
+
+## `Gitlab\Model\Users` changes
+
+* The `all` method now take a single argument which is an associative array of query string parameters.
+* The `lookup` and `search` methods have been removed. Use `all` method instead.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -58,6 +58,7 @@ Use the `deployKeys`, `deployKey`, `addDeployKey`, `deleteDeployKey`, `removeDep
 * The `builds` method have been removed. Use `Gitlab\Api\Jobs::all` instead.
 * The `build` method have been removed. Use `Gitlab\Api\Jobs::show` instead.
 * The `events` method second and subsequent arguments have been replaced by a single associative array of query string parameters.
+* The `deployments` method second and subsequent arguments have been replaced by a single associative array of query string parameters.
 
 ## `Gitlab\Api\ProjectNamespaces` changes
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -58,6 +58,11 @@ Use the `deployKeys`, `deployKey`, `addDeployKey`, `deleteDeployKey`, `removeDep
 * The `builds` method have been removed. Use `Gitlab\Api\Jobs::all` instead.
 * The `build` method have been removed. Use `Gitlab\Api\Jobs::show` instead.
 
+## `Gitlab\Api\ProjectNamespaces` changes
+
+* The `search` method have been removed. Use `all` method instead.
+* The `all` method now take a single argument which is an associative array of query string parameters.
+
 ## `Gitlab\Api\Repositories` changes
 
 * The `commits` page argument now start from 1 instead of 0.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -67,8 +67,8 @@ Use the `deployKeys`, `deployKey`, `addDeployKey`, `deleteDeployKey`, `removeDep
 
 ## `Gitlab\Api\Repositories` changes
 
-* The `commits` page argument now start from 1 instead of 0.
 * The `commitBuilds` method have been removed. Use `Gitlab\Api\Projects::pipelines` instead.
+* The `commits` method second and subsequent arguments have been replaced by a single associative array of query string parameters.
 
 ## `Gitlab\Model\Project` changes
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,6 +26,7 @@ See [documentation](doc/customize.md) to know how to customize the client timeou
 
 * The second argument of `update`, `remove`, `showComments`, `showComment`, `addComment`, `updateComment`, `removeComment`,
  `setTimeEstimate`, `resetTimeEstimate`, `addSpentTime` and `resetSpentTime` methods is now a scoped issue id (iid).
+* The `all` method second and subsequent arguments have been replaced by a single associative array of query string parameters.
 
 ## `Gitlab\Api\IssueBoards` changes
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -57,6 +57,7 @@ Use the `deployKeys`, `deployKey`, `addDeployKey`, `deleteDeployKey`, `removeDep
 * The `trace` method have been removed. Use `Gitlab\Api\Jobs::trace` instead.
 * The `builds` method have been removed. Use `Gitlab\Api\Jobs::all` instead.
 * The `build` method have been removed. Use `Gitlab\Api\Jobs::show` instead.
+* The `events` method second and subsequent arguments have been replaced by a single associative array of query string parameters.
 
 ## `Gitlab\Api\ProjectNamespaces` changes
 

--- a/lib/Gitlab/Api/AbstractApi.php
+++ b/lib/Gitlab/Api/AbstractApi.php
@@ -20,11 +20,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 abstract class AbstractApi implements ApiInterface
 {
     /**
-     * Default entries per page
-     */
-    const PER_PAGE = 20;
-
-    /**
      * The client
      *
      * @var Client

--- a/lib/Gitlab/Api/AbstractApi.php
+++ b/lib/Gitlab/Api/AbstractApi.php
@@ -194,7 +194,7 @@ abstract class AbstractApi implements ApiInterface
     }
 
     /**
-     * Create a new OptionsResolver with page, per_page and sort options.
+     * Create a new OptionsResolver with page and per_page options.
      *
      * @return OptionsResolver
      */
@@ -212,9 +212,6 @@ abstract class AbstractApi implements ApiInterface
             ->setAllowedValues('per_page', function ($value) {
                 return $value > 0 && $value <= 100;
             })
-        ;
-        $resolver->setDefined('sort')
-            ->setAllowedValues('sort', ['asc', 'desc'])
         ;
 
         return $resolver;

--- a/lib/Gitlab/Api/DeployKeys.php
+++ b/lib/Gitlab/Api/DeployKeys.php
@@ -2,23 +2,15 @@
 
 class DeployKeys extends AbstractApi
 {
-    const ORDER_BY = 'id';
-    const SORT = 'asc';
-
     /**
-     * @param int $page
-     * @param int $per_page
-     * @param string $order_by
-     * @param string $sort
+     * @param array $parameters
+     *
      * @return mixed
      */
-    public function all($page = 1, $per_page = self::PER_PAGE, $order_by = self::ORDER_BY, $sort = self::SORT)
+    public function all(array $parameters = [])
     {
-        return $this->get('deploy_keys', array(
-            'page' => $page,
-            'per_page' => $per_page,
-            'order_by' => $order_by,
-            'sort' => $sort
-        ));
+        $resolver = $this->createOptionsResolver();
+
+        return $this->get('deploy_keys', $resolver->resolve($parameters));
     }
 }

--- a/lib/Gitlab/Api/Groups.php
+++ b/lib/Gitlab/Api/Groups.php
@@ -162,15 +162,55 @@ class Groups extends AbstractApi
 
     /**
      * @param $id
-     * @param int $page
-     * @param int $per_page
+     * @param array $parameters (
+     *
+     *     @var bool   $archived   Limit by archived status.
+     *     @var string $visibility Limit by visibility public, internal, or private.
+     *     @var string $order_by   Return projects ordered by id, name, path, created_at, updated_at, or last_activity_at fields.
+     *                             Default is created_at.
+     *     @var string $sort       Return projects sorted in asc or desc order. Default is desc.
+     *     @var string $search     Return list of authorized projects matching the search criteria.
+     *     @var bool   $simple     Return only the ID, URL, name, and path of each project.
+     *     @var bool   $owned      Limit by projects owned by the current user.
+     *     @var bool   $starred    Limit by projects starred by the current user.
+     * )
+     *
      * @return mixed
      */
-    public function projects($id, $page = 1, $per_page = self::PER_PAGE)
+    public function projects($id, array $parameters = [])
     {
-        return $this->get('groups/'.$this->encodePath($id).'/projects', array(
-            'page' => $page,
-            'per_page' => $per_page
-        ));
+        $resolver = $this->createOptionsResolver();
+        $booleanNormalizer = function ($value) {
+            return $value ? 'true' : 'false';
+        };
+
+        $resolver->setDefined('archived')
+            ->setAllowedTypes('archived', 'bool')
+            ->setNormalizer('archived', $booleanNormalizer)
+        ;
+        $resolver->setDefined('visibility')
+            ->setAllowedValues('visibility', ['public', 'internal', 'private'])
+        ;
+        $resolver->setDefined('order_by')
+            ->setAllowedValues('order_by', ['id', 'name', 'path', 'created_at', 'updated_at', 'last_activity_at'])
+        ;
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['asc', 'desc'])
+        ;
+        $resolver->setDefined('search');
+        $resolver->setDefined('simple')
+            ->setAllowedTypes('simple', 'bool')
+            ->setNormalizer('simple', $booleanNormalizer)
+        ;
+        $resolver->setDefined('owned')
+            ->setAllowedTypes('owned', 'bool')
+            ->setNormalizer('owned', $booleanNormalizer)
+        ;
+        $resolver->setDefined('starred')
+            ->setAllowedTypes('starred', 'bool')
+            ->setNormalizer('starred', $booleanNormalizer)
+        ;
+
+        return $this->get('groups/'.$this->encodePath($id).'/projects', $resolver->resolve($parameters));
     }
 }

--- a/lib/Gitlab/Api/Groups.php
+++ b/lib/Gitlab/Api/Groups.php
@@ -107,17 +107,20 @@ class Groups extends AbstractApi
     }
 
     /**
-     * @param int $id
-     * @param int $page
-     * @param int $per_page
+     * @param int   $id
+     * @param array $parameters (
+     *
+     *     @var string $query A query string to search for members.
+     * )
+     *
      * @return mixed
      */
-    public function members($id, $page = 1, $per_page = self::PER_PAGE)
+    public function members($id, array $parameters = [])
     {
-        return $this->get('groups/'.$this->encodePath($id).'/members', array(
-            'page' => $page,
-            'per_page' => $per_page
-        ));
+        $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('query');
+
+        return $this->get('groups/'.$this->encodePath($id).'/members', $resolver->resolve($parameters));
     }
 
     /**

--- a/lib/Gitlab/Api/IssueBoards.php
+++ b/lib/Gitlab/Api/IssueBoards.php
@@ -4,21 +4,17 @@ class IssueBoards extends AbstractApi
 {
     /**
      * @param int $project_id
-     * @param int $page
-     * @param int $per_page
-     * @param array $params
+     * @param array $parameters
+     *
      * @return mixed
      */
-    public function all($project_id = null, $page = 1, $per_page = self::PER_PAGE, array $params = array())
+    public function all($project_id = null, array $parameters = [])
     {
+        $resolver = $this->createOptionsResolver();
+
         $path = $project_id === null ? 'boards' : $this->getProjectPath($project_id, 'boards');
 
-        $params = array_merge(array(
-            'page' => $page,
-            'per_page' => $per_page
-        ), $params);
-
-        return $this->get($path, $params);
+        return $this->get($path, $resolver->resolve($parameters));
     }
 
     /**

--- a/lib/Gitlab/Api/Issues.php
+++ b/lib/Gitlab/Api/Issues.php
@@ -4,22 +4,46 @@ class Issues extends AbstractApi
 {
     /**
      * @param int $project_id
-     * @param int $page
-     * @param int $per_page
-     * @param array $params
+     * @param array $parameters (
+     *
+     *     @var string $state     Return all issues or just those that are opened or closed.
+     *     @var string $labels    Comma-separated list of label names, issues must have all labels to be returned.
+     *                            No+Label lists all issues with no labels.
+     *     @var string $milestone The milestone title.
+     *     @var int[]  $iids      Return only the issues having the given iid.
+     *     @var string $order_by  Return requests ordered by created_at or updated_at fields. Default is created_at.
+     *     @var string $sort      Return requests sorted in asc or desc order. Default is desc.
+     *     @var string $search    Search issues against their title and description.
+     * )
+     *
      * @return mixed
      */
-    public function all($project_id = null, $page = 1, $per_page = self::PER_PAGE, array $params = array())
+    public function all($project_id = null, array $parameters = [])
     {
+        $resolver = $this->createOptionsResolver();
+
+        $resolver->setDefined('state')
+            ->setAllowedValues('state', ['opened', 'closed'])
+        ;
+        $resolver->setDefined('labels');
+        $resolver->setDefined('milestone');
+        $resolver->setDefined('iids')
+            ->setAllowedTypes('iids', 'array')
+            ->setAllowedValues('iids', function (array $value) {
+                return count($value) == count(array_filter($value, 'is_int'));
+            })
+        ;
+        $resolver->setDefined('order_by')
+            ->setAllowedValues('order_by', ['created_at', 'updated_at'])
+        ;
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['asc', 'desc'])
+        ;
+        $resolver->setDefined('search');
+
         $path = $project_id === null ? 'issues' : $this->getProjectPath($project_id, 'issues');
 
-        $params = array_intersect_key($params, array('labels' => '', 'state' => '', 'sort' => '', 'order_by' => '', 'milestone' => ''));
-        $params = array_merge(array(
-            'page' => $page,
-            'per_page' => $per_page
-        ), $params);
-
-        return $this->get($path, $params);
+        return $this->get($path, $resolver->resolve($parameters));
     }
 
     /**

--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -51,6 +51,9 @@ class MergeRequests extends AbstractApi
         $resolver->setDefined('order_by')
             ->setAllowedValues('order_by', ['created_at', 'updated_at'])
         ;
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['asc', 'desc'])
+        ;
         $resolver->setDefined('milestone');
         $resolver->setDefined('view')
             ->setAllowedValues('view', ['simple'])

--- a/lib/Gitlab/Api/Milestones.php
+++ b/lib/Gitlab/Api/Milestones.php
@@ -4,16 +4,30 @@ class Milestones extends AbstractApi
 {
     /**
      * @param int $project_id
-     * @param int $page
-     * @param int $per_page
+     * @param array $parameters (
+     *
+     *     @var int[]  $iids   Return only the milestones having the given iids.
+     *     @var string $state  Return only active or closed milestones.
+     *     @var string $search Return only milestones with a title or description matching the provided string.
+     * )
+     *
      * @return mixed
      */
-    public function all($project_id, $page = 1, $per_page = self::PER_PAGE)
+    public function all($project_id, array $parameters = [])
     {
-        return $this->get($this->getProjectPath($project_id, 'milestones'), array(
-            'page' => $page,
-            'per_page' => $per_page
-        ));
+        $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('iids')
+            ->setAllowedTypes('iids', 'array')
+            ->setAllowedValues('iids', function (array $value) {
+                return count($value) == count(array_filter($value, 'is_int'));
+            })
+        ;
+        $resolver->setDefined('state')
+            ->setAllowedValues('state', ['active', 'closed'])
+        ;
+        $resolver->setDefined('search');
+
+        return $this->get($this->getProjectPath($project_id, 'milestones'), $resolver->resolve($parameters));
     }
 
     /**

--- a/lib/Gitlab/Api/ProjectNamespaces.php
+++ b/lib/Gitlab/Api/ProjectNamespaces.php
@@ -3,30 +3,18 @@
 class ProjectNamespaces extends AbstractApi
 {
     /**
-     * @param int $page
-     * @param int $per_page
+     * @param array $parameters (
+     *
+     *     @var string $search Returns a list of namespaces the user is authorized to see based on the search criteria.
+     * )
+     *
      * @return mixed
      */
-    public function all($page = 1, $per_page = self::PER_PAGE)
+    public function all(array $parameters = [])
     {
-        return $this->get('namespaces', array(
-            'page' => $page,
-            'per_page' => $per_page
-        ));
-    }
+        $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('search');
 
-    /**
-     * @param string $terms
-     * @param int $page
-     * @param int $per_page
-     * @return mixed
-     */
-    public function search($terms, $page = 1, $per_page = self::PER_PAGE)
-    {
-        return $this->get('namespaces', array(
-            'search' => $terms,
-            'page' => $page,
-            'per_page' => $per_page
-        ));
+        return $this->get('namespaces', $resolver->resolve($parameters));
     }
 }

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -299,16 +299,15 @@ class Projects extends AbstractApi
 
     /**
      * @param int $project_id
-     * @param int $page
-     * @param int $per_page
+     * @param array $parameters
+     *
      * @return mixed
      */
-    public function hooks($project_id, $page = 1, $per_page = self::PER_PAGE)
+    public function hooks($project_id, array $parameters = [])
     {
-        return $this->get($this->getProjectPath($project_id, 'hooks'), array(
-            'page' => $page,
-            'per_page' => $per_page
-        ));
+        $resolver = $this->createOptionsResolver();
+
+        return $this->get($this->getProjectPath($project_id, 'hooks'), $resolver->resolve($parameters));
     }
 
     /**

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -609,16 +609,15 @@ class Projects extends AbstractApi
 
     /**
      * @param int $project_id
-     * @param int $page
-     * @param int $per_page
+     * @param array $parameters
+     *
      * @return mixed
      */
-    public function deployments($project_id, $page = 1, $per_page = self::PER_PAGE)
+    public function deployments($project_id, array $parameters = [])
     {
-        return $this->get($this->getProjectPath($project_id, 'deployments'), array(
-            'page' => $page,
-            'per_page' => $per_page
-        ));
+        $resolver = $this->createOptionsResolver();
+
+        return $this->get($this->getProjectPath($project_id, 'deployments'), $resolver->resolve($parameters));
     }
 
     /**

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -413,16 +413,42 @@ class Projects extends AbstractApi
 
     /**
      * @param int $project_id
-     * @param int $page
-     * @param int $per_page
+     * @param array $parameters (
+     *
+     *     @var string             $action      Include only events of a particular action type.
+     *     @var string             $target_type Include only events of a particular target type.
+     *     @var \DateTimeInterface $before      Include only events created before a particular date.
+     *     @var \DateTimeInterface $after       Include only events created after a particular date.
+     *     @var string             $sort        Sort events in asc or desc order by created_at. Default is desc.
+     * )
+     *
      * @return mixed
      */
-    public function events($project_id, $page = 1, $per_page = self::PER_PAGE)
+    public function events($project_id, array $parameters = [])
     {
-        return $this->get($this->getProjectPath($project_id, 'events'), array(
-            'page' => $page,
-            'per_page' => $per_page
-        ));
+        $resolver = $this->createOptionsResolver();
+        $datetimeNormalizer = function (\DateTimeInterface $value) {
+            return $value->format('Y-m-d');
+        };
+
+        $resolver->setDefined('action')
+            ->setAllowedValues('action', ['created', 'updated', 'closed', 'reopened', 'pushed', 'commented', 'merged', 'joined', 'left', 'destroyed', 'expired'])
+        ;
+        $resolver->setDefined('target_type')
+            ->setAllowedValues('target_type', ['issue', 'milestone', 'merge_request', 'note', 'project', 'snippet', 'user'])
+        ;
+        $resolver->setDefined('before')
+            ->setAllowedTypes('before', \DateTimeInterface::class)
+            ->setNormalizer('before', $datetimeNormalizer);
+        $resolver->setDefined('after')
+            ->setAllowedTypes('after', \DateTimeInterface::class)
+            ->setNormalizer('after', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['asc', 'desc'])
+        ;
+
+        return $this->get($this->getProjectPath($project_id, 'events'), $resolver->resolve($parameters));
     }
 
     /**

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -45,6 +45,9 @@ class Projects extends AbstractApi
         $resolver->setDefined('order_by')
             ->setAllowedValues('order_by', ['id', 'name', 'path', 'created_at', 'updated_at', 'last_activity_at'])
         ;
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['asc', 'desc'])
+        ;
         $resolver->setDefined('search');
         $resolver->setDefined('simple')
             ->setAllowedTypes('simple', 'bool')
@@ -186,6 +189,9 @@ class Projects extends AbstractApi
         $resolver->setDefined('username');
         $resolver->setDefined('order_by')
             ->setAllowedValues('order_by', ['id', 'status', 'ref', 'user_id'])
+        ;
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['asc', 'desc'])
         ;
 
         return $this->get($this->getProjectPath($project_id, 'pipelines'), $resolver->resolve($parameters));

--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -169,18 +169,20 @@ class Repositories extends AbstractApi
     }
 
     /**
-     * @param int $project_id
+     * @param int    $project_id
      * @param string $sha
-     * @param int $page
-     * @param int $per_page
+     * @param array  $parameters
+     *
      * @return mixed
      */
-    public function commitComments($project_id, $sha, $page = 0, $per_page = self::PER_PAGE)
+    public function commitComments($project_id, $sha, array $parameters = [])
     {
-        return $this->get($this->getProjectPath($project_id, 'repository/commits/'.$this->encodePath($sha).'/comments'), array(
-            'page' => $page,
-            'per_page' => $per_page
-        ));
+        $resolver = $this->createOptionsResolver();
+
+        return $this->get(
+            $this->getProjectPath($project_id, 'repository/commits/'.$this->encodePath($sha).'/comments'),
+            $resolver->resolve($parameters)
+        );
     }
 
     /**

--- a/lib/Gitlab/Model/Branch.php
+++ b/lib/Gitlab/Model/Branch.php
@@ -1,7 +1,7 @@
 <?php namespace Gitlab\Model;
 
+use Gitlab\Api\Projects;
 use Gitlab\Client;
-use Gitlab\Api\AbstractApi as Api;
 
 /**
  * Class Branch
@@ -95,13 +95,15 @@ class Branch extends AbstractModel
     }
 
     /**
-     * @param int $page
-     * @param int $per_page
+     * @param array $parameters
+     *
+     * @see Projects::commits for available parameters.
+     *
      * @return Commit[]
      */
-    public function commits($page = 1, $per_page = Api::PER_PAGE)
+    public function commits(array $parameters = [])
     {
-        return $this->project->commits($page, $per_page, $this->name);
+        return $this->project->commits($parameters);
     }
 
     /**

--- a/lib/Gitlab/Model/Project.php
+++ b/lib/Gitlab/Model/Project.php
@@ -1,8 +1,8 @@
 <?php namespace Gitlab\Model;
 
-use Gitlab\Api\MergeRequests;
+use Gitlab\Api\Projects;
+use Gitlab\Api\Repositories;
 use Gitlab\Client;
-use Gitlab\Api\AbstractApi as Api;
 
 /**
  * Class Project
@@ -235,13 +235,15 @@ class Project extends AbstractModel
     }
 
     /**
-     * @param int $page
-     * @param int $per_page
+     * @param array $parameters
+     *
+     * @see Projects::hooks() for available parameters.
+     *
      * @return ProjectHook[]
      */
-    public function hooks($page = 1, $per_page = Api::PER_PAGE)
+    public function hooks(array $parameters = [])
     {
-        $data = $this->client->projects()->hooks($this->id, $page, $per_page);
+        $data = $this->client->projects()->hooks($this->id, $parameters);
 
         $hooks = array();
         foreach ($data as $hook) {
@@ -449,14 +451,15 @@ class Project extends AbstractModel
     }
 
     /**
-     * @param int $page
-     * @param int $per_page
-     * @param string $ref_name
+     * @param array $parameters
+     *
+     * @see Repositories::commits() for available parameters.
+     *
      * @return Commit[]
      */
-    public function commits($page = 0, $per_page = Api::PER_PAGE, $ref_name = null)
+    public function commits(array $parameters = [])
     {
-        $data = $this->client->repositories()->commits($this->id, $page, $per_page, $ref_name);
+        $data = $this->client->repositories()->commits($this->id, $parameters);
 
         $commits = array();
         foreach ($data as $commit) {
@@ -479,13 +482,15 @@ class Project extends AbstractModel
 
     /**
      * @param string $ref
-     * @param int $page
-     * @param int $per_page
+     * @param array $parameters
+     *
+     * @see Repositories::commitComments() for available parameters.
+     *
      * @return Commit[]
      */
-    public function commitComments($ref, $page = 0, $per_page = Api::PER_PAGE)
+    public function commitComments($ref, array $parameters = [])
     {
-        $data = $this->client->repositories()->commitComments($this->id, $ref, $page, $per_page);
+        $data = $this->client->repositories()->commitComments($this->id, $ref, $parameters);
 
         $comments = array();
         foreach ($data as $comment) {
@@ -614,13 +619,15 @@ class Project extends AbstractModel
     }
 
     /**
-     * @param int $page
-     * @param int $per_page
+     * @param array $parameters
+     *
+     * @see Projects::events() for available parameters.
+     *
      * @return Event[]
      */
-    public function events($page = 1, $per_page = Api::PER_PAGE)
+    public function events(array $parameters = [])
     {
-        $data = $this->client->projects()->events($this->id, $page, $per_page);
+        $data = $this->client->projects()->events($this->id, $parameters);
 
         $events = array();
         foreach ($data as $event) {
@@ -631,14 +638,15 @@ class Project extends AbstractModel
     }
 
     /**
-     * @param int    $page
-     * @param int    $per_page
-     * @param string $state
+     * @param array $parameters
+     *
+     * @see MergeRequests::all() for available parameters.
+     *
      * @return MergeRequest[]
      */
-    public function mergeRequests($page = 1, $per_page = Api::PER_PAGE, $state = MergeRequests::STATE_ALL)
+    public function mergeRequests(array $parameters = [])
     {
-        $data = $this->client->mergeRequests()->$state($this->id, $page, $per_page);
+        $data = $this->client->mergeRequests()->all($this->id, $parameters);
 
         $mrs = array();
         foreach ($data as $mr) {
@@ -720,13 +728,15 @@ class Project extends AbstractModel
     }
 
     /**
-     * @param int $page
-     * @param int $per_page
+     * @param array $parameters
+     *
+     * @see Issues::all() for available parameters.
+     *
      * @return Issue[]
      */
-    public function issues($page = 1, $per_page = Api::PER_PAGE)
+    public function issues(array $parameters = [])
     {
-        $data = $this->client->issues()->all($this->id, $page, $per_page);
+        $data = $this->client->issues()->all($this->id, $parameters);
 
         $issues = array();
         foreach ($data as $issue) {
@@ -796,13 +806,15 @@ class Project extends AbstractModel
     }
 
     /**
-     * @param int $page
-     * @param int $per_page
+     * @param array $parameters
+     *
+     * @see Milestones::all() for available parameters.
+     *
      * @return Milestone[]
      */
-    public function milestones($page = 1, $per_page = Api::PER_PAGE)
+    public function milestones(array $parameters = [])
     {
-        $data = $this->client->milestones()->all($this->id, $page, $per_page);
+        $data = $this->client->milestones()->all($this->id, $parameters);
 
         $milestones = array();
         foreach ($data as $milestone) {

--- a/test/Gitlab/Tests/Api/DeployKeysTest.php
+++ b/test/Gitlab/Tests/Api/DeployKeysTest.php
@@ -9,21 +9,14 @@ class DeployKeysTest extends TestCase
     {
         $expectedArray = $this->getMultipleDeployKeysData();
 
-        $api = $this->getMultipleDeployKeysRequestMock('deploy_keys', $expectedArray);
-
-        $this->assertEquals($expectedArray, $api->all());
-    }
-
-    protected function getMultipleDeployKeysRequestMock($path, $expectedArray = array(), $page = 1, $per_page = 20, $order_by = 'id', $sort = 'asc')
-    {
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with($path, array('page' => $page, 'per_page' => $per_page, 'order_by' => $order_by, 'sort' => $sort))
+            ->with('deploy_keys', array('page' => 2, 'per_page' => 5))
             ->will($this->returnValue($expectedArray))
         ;
 
-        return $api;
+        $this->assertEquals($expectedArray, $api->all(['page' => 2, 'per_page' => 5]));
     }
 
     protected function getMultipleDeployKeysData()

--- a/test/Gitlab/Tests/Api/GroupsTest.php
+++ b/test/Gitlab/Tests/Api/GroupsTest.php
@@ -21,7 +21,7 @@ class GroupsTest extends TestCase
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->all(1, 10));
+        $this->assertEquals($expectedArray, $api->all(['page' => 1, 'per_page' => 10]));
     }
 
     /**
@@ -37,51 +37,11 @@ class GroupsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('groups', array('page' => 1, 'per_page' => AbstractApi::PER_PAGE))
+            ->with('groups', array())
             ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->all());
-    }
-
-    /**
-     * @test
-     */
-    public function shouldSearchGroups()
-    {
-        $expectedArray = array(
-            array('id' => 1, 'name' => 'A group'),
-            array('id' => 2, 'name' => 'Another group'),
-        );
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('groups?search=some%20group', array('page' => 1, 'per_page' => AbstractApi::PER_PAGE))
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->search('some group'));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldSearchGroupsWithPagination()
-    {
-        $expectedArray = array(
-            array('id' => 1, 'name' => 'A group'),
-            array('id' => 2, 'name' => 'Another group'),
-        );
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('groups?search=group', array('page' => 2, 'per_page' => 5))
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->search('group', 2, 5));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/IssueBoardsTest.php
+++ b/test/Gitlab/Tests/Api/IssueBoardsTest.php
@@ -1,7 +1,5 @@
 <?php namespace Gitlab\Tests\Api;
 
-use Gitlab\Api\AbstractApi;
-
 class IssueBoardsTest extends TestCase
 {
     /**
@@ -17,7 +15,7 @@ class IssueBoardsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('boards', array('page' => 1, 'per_page' => AbstractApi::PER_PAGE))
+            ->with('boards', array())
             ->will($this->returnValue($expectedArray))
         ;
 

--- a/test/Gitlab/Tests/Api/IssuesTest.php
+++ b/test/Gitlab/Tests/Api/IssuesTest.php
@@ -1,7 +1,5 @@
 <?php namespace Gitlab\Tests\Api;
 
-use Gitlab\Api\AbstractApi;
-
 class IssuesTest extends TestCase
 {
     /**
@@ -17,7 +15,7 @@ class IssuesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('issues', array('page' => 1, 'per_page' => AbstractApi::PER_PAGE))
+            ->with('issues', array())
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -41,7 +39,7 @@ class IssuesTest extends TestCase
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->all(1, 2, 5));
+        $this->assertEquals($expectedArray, $api->all(1, ['page' => 2, 'per_page' => 5]));
     }
 
     /**
@@ -57,11 +55,11 @@ class IssuesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/issues', array('page' => 2, 'per_page' => 5, 'order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'open'))
+            ->with('projects/1/issues', array('order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'opened'))
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->all(1, 2, 5, array('order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'open')));
+        $this->assertEquals($expectedArray, $api->all(1, array('order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'opened')));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/JobsTest.php
+++ b/test/Gitlab/Tests/Api/JobsTest.php
@@ -24,7 +24,7 @@ class JobsTest extends TestCase
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->all(1, [Jobs::SCOPE_PENDING]));
+        $this->assertEquals($expectedArray, $api->all(1, ['scope' => Jobs::SCOPE_PENDING]));
     }
 
     /**
@@ -41,12 +41,12 @@ class JobsTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with('projects/1/pipelines/2/jobs', array(
-                'scope' => ['pending']
+                'scope' => ['pending', 'running']
             ))
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->pipelineJobs(1, 2, [Jobs::SCOPE_PENDING]));
+        $this->assertEquals($expectedArray, $api->pipelineJobs(1, 2, ['scope' => [Jobs::SCOPE_PENDING, Jobs::SCOPE_RUNNING]]));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/ProjectNamespacesTest.php
+++ b/test/Gitlab/Tests/Api/ProjectNamespacesTest.php
@@ -17,50 +17,11 @@ class ProjectNamespacesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('namespaces', array('page' => 1, 'per_page' => 10))
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->all(1, 10));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldNotNeedPaginationWhenGettingNamespaces()
-    {
-        $expectedArray = array(
-            array('id' => 1, 'name' => 'bespokes'),
-            array('id' => 2, 'name' => 'internal')
-        );
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('namespaces', array('page' => 1, 'per_page' => AbstractApi::PER_PAGE))
+            ->with('namespaces', array())
             ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->all());
-    }
-    /**
-     * @test
-     */
-    public function shouldSearchNamespaces()
-    {
-        $expectedArray = array(
-            array('id' => 1, 'name' => 'bespokes'),
-            array('id' => 2, 'name' => 'internal')
-        );
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('namespaces', array('search' => 'term', 'page' => 1, 'per_page' => 10))
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->search('term', 1, 10));
     }
 
     protected function getApiClass()

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -930,10 +930,7 @@ class ProjectsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/deployments', array(
-                'page' => 1,
-                'per_page' => AbstractApi::PER_PAGE
-            ))
+            ->with('projects/1/deployments', array())
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -960,7 +957,7 @@ class ProjectsTest extends TestCase
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->deployments(1, 2, 15));
+        $this->assertEquals($expectedArray, $api->deployments(1, ['page' => 2, 'per_page' => 15]));
     }
 
     protected function getMultipleProjectsData()

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -636,10 +636,7 @@ class ProjectsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/events', array(
-                'page' => 1,
-                'per_page' => AbstractApi::PER_PAGE
-            ))
+            ->with('projects/1/events', array())
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -666,7 +663,7 @@ class ProjectsTest extends TestCase
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->events(1, 2, 15));
+        $this->assertEquals($expectedArray, $api->events(1, ['page' => 2, 'per_page' => 15]));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/RepositoriesTest.php
+++ b/test/Gitlab/Tests/Api/RepositoriesTest.php
@@ -230,7 +230,7 @@ class RepositoriesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/repository/commits', array('page' => 1, 'per_page' => AbstractApi::PER_PAGE, 'ref_name' => null))
+            ->with('projects/1/repository/commits', array())
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -254,7 +254,7 @@ class RepositoriesTest extends TestCase
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->commits(1, 2, 25, 'master'));
+        $this->assertEquals($expectedArray, $api->commits(1, ['page' => 2, 'per_page' => 25, 'ref_name' => 'master']));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/UsersTest.php
+++ b/test/Gitlab/Tests/Api/UsersTest.php
@@ -17,11 +17,11 @@ class UsersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('users', array('active' => null, 'page' => 1, 'per_page' => 10))
+            ->with('users', array())
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->all(null, 1, 10));
+        $this->assertEquals($expectedArray, $api->all());
     }
 
     /**
@@ -37,88 +37,11 @@ class UsersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('users', array('active' => true, 'page' => 1, 'per_page' => AbstractApi::PER_PAGE))
+            ->with('users', array('active' => true))
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->all(true));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldNotNeedPaginationWhenGettingUsers()
-    {
-        $expectedArray = array(
-            array('id' => 1, 'name' => 'Matt'),
-            array('id' => 2, 'name' => 'John'),
-        );
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('users', array('active' => null, 'page' => 1, 'per_page' => AbstractApi::PER_PAGE))
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->all());
-    }
-
-    /**
-     * @test
-     */
-    public function shouldSearchUsers()
-    {
-        $expectedArray = array(
-            array('id' => 1, 'name' => 'Matt')
-        );
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('users', array('search' => 'ma', 'active' => null, 'page' => 1, 'per_page' => AbstractApi::PER_PAGE))
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->search('ma'));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldSearchActiveUsers()
-    {
-        $expectedArray = array(
-            array('id' => 1, 'name' => 'Matt')
-        );
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('users', array('search' => 'ma', 'active' => true, 'page' => 1, 'per_page' => AbstractApi::PER_PAGE))
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->search('ma', true));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldSearchActiveUsersWithPagination()
-    {
-        $expectedArray = array(
-            array('id' => 1, 'name' => 'Matt')
-        );
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('users', array('search' => 'ma', 'active' => true, 'page' => 2, 'per_page' => 5))
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->search('ma', true, 2, 5));
+        $this->assertEquals($expectedArray, $api->all(['active' => true]));
     }
 
     /**


### PR DESCRIPTION
This force usage of `OptionsResolver` only where it would break BC. It may be used later in other methods without breaking.

This improve a lot the API quality by avoiding endless method signatures. All the updated methods have their arguments in sync with current v4 API.

This also fix #186.

This is probably better reviewed commit per commit instead of a whole.

## To Do
* [x] Fix the models.