### PR TITLE
Static analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,17 @@ sudo: false
 php:
   - 5.6
   - 7.0
-  - 7.1
+
+matrix:
+  include:
+    - php: 7.1
+      env: STATIC_ANALYSIS=yes
 
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source
+  - if [ "$STATIC_ANALYSIS" != "" ]; then curl -L https://github.com/phpstan/phpstan/releases/download/0.8/phpstan.phar -o phpstan.phar; fi;
 
 script:
   - vendor/bin/phpunit --verbose --coverage-text
+  - if [ "$STATIC_ANALYSIS" != "" ]; then php phpstan.phar analyse --level=4 lib; fi;

--- a/lib/Gitlab/Api/IssueBoards.php
+++ b/lib/Gitlab/Api/IssueBoards.php
@@ -63,16 +63,16 @@ class IssueBoards extends AbstractApi
     /**
      * @param int $project_id
      * @param int $board_id
-     * @param int $label_id
+     * @param int $list_id
      * @param int $position
      * @return mixed
      */
-    public function updateList($project_id, $board_id, $label_id, $position)
+    public function updateList($project_id, $board_id, $list_id, $position)
     {
         $params = array(
             'id' => $project_id,
             'board_id' => $board_id,
-            'label_id' => $label_id,
+            'list_id' => $list_id,
             'position' => $position
         );
 
@@ -82,10 +82,10 @@ class IssueBoards extends AbstractApi
     /**
      * @param int $project_id
      * @param int $board_id
-     * @param int $label_id
+     * @param int $list_id
      * @return mixed
      */
-    public function deleteList($project_id, $board_id, $label_id)
+    public function deleteList($project_id, $board_id, $list_id)
     {
         return $this->delete($this->getProjectPath($project_id, 'boards/'.$this->encodePath($board_id).'/lists/'.$this->encodePath($list_id)));
     }

--- a/lib/Gitlab/Api/Users.php
+++ b/lib/Gitlab/Api/Users.php
@@ -55,6 +55,14 @@ class Users extends AbstractApi
     }
 
     /**
+     * @return mixed
+     */
+    public function user()
+    {
+        return $this->get('user');
+    }
+
+    /**
      * @param string $email
      * @param string $password
      * @param array $params

--- a/lib/Gitlab/Client.php
+++ b/lib/Gitlab/Client.php
@@ -118,6 +118,126 @@ class Client
     }
 
     /**
+     * @return Api\DeployKeys
+     */
+    public function deployKeys()
+    {
+        return new Api\DeployKeys($this);
+    }
+
+    /**
+     * @return Api\Groups
+     */
+    public function groups()
+    {
+        return new Api\Groups($this);
+    }
+
+    /**
+     * @return Api\Issues
+     */
+    public function issues()
+    {
+        return new Api\Issues($this);
+    }
+
+    /**
+     * @return Api\IssueBoards
+     */
+    public function issueBoards()
+    {
+        return new Api\IssueBoards($this);
+    }
+
+    /**
+     * @return Api\Jobs
+     */
+    public function jobs()
+    {
+        return new Api\Jobs($this);
+    }
+
+    /**
+     * @return Api\MergeRequests
+     */
+    public function mergeRequests()
+    {
+       return new Api\MergeRequests($this);
+    }
+
+    /**
+     * @return Api\Milestones
+     */
+    public function milestones()
+    {
+        return new Api\Milestones($this);
+    }
+
+    /**
+     * @return Api\ProjectNamespaces
+     */
+    public function namespaces()
+    {
+        return new Api\ProjectNamespaces($this);
+    }
+
+    /**
+     * @return Api\Projects
+     */
+    public function projects()
+    {
+        return new Api\Projects($this);
+    }
+
+    /**
+     * @return Api\Repositories
+     */
+    public function repositories()
+    {
+       return new Api\Repositories($this);
+    }
+
+    /**
+     * @return Api\Snippets
+     */
+    public function snippets()
+    {
+        return new Api\Snippets($this);
+    }
+
+    /**
+     * @return Api\SystemHooks
+     */
+    public function systemHooks()
+    {
+        return new Api\SystemHooks($this);
+    }
+
+    /**
+     * @return Api\Users
+     */
+    public function users()
+    {
+        return new Api\Users($this);
+    }
+
+    /**
+     * @return Api\Keys
+     */
+    public function keys()
+    {
+        return new Api\Keys($this);
+    }
+
+    /**
+     * @return Api\Tags
+     */
+    public function tags()
+    {
+        return new Api\Tags($this);
+    }
+
+    /**
      * @param string $name
      *
      * @return AbstractApi|mixed
@@ -128,75 +248,58 @@ class Client
         switch ($name) {
 
             case 'deploy_keys':
-                $api = new Api\DeployKeys($this);
-                break;
+                return $this->deployKeys();
 
             case 'groups':
-                $api = new Api\Groups($this);
-                break;
+                return $this->groups();
 
             case 'issues':
-                $api = new Api\Issues($this);
-                break;
+                return $this->issues();
 
             case 'board':
             case 'issue_boards':
-                $api = new Api\IssueBoards($this);
+                return $this->issueBoards();
             case 'jobs':
-                $api = new Api\Jobs($this);
-                break;
+                return $this->jobs();
 
             case 'mr':
             case 'merge_requests':
-                $api = new Api\MergeRequests($this);
-                break;
+                return $this->mergeRequests();
 
             case 'milestones':
             case 'ms':
-                $api = new Api\Milestones($this);
-                break;
+                return $this->milestones();
 
             case 'namespaces':
             case 'ns':
-                $api = new Api\ProjectNamespaces($this);
-                break;
+                return $this->namespaces();
 
             case 'projects':
-                $api = new Api\Projects($this);
-                break;
+                return $this->projects();
 
             case 'repo':
             case 'repositories':
-                $api = new Api\Repositories($this);
-                break;
+                return $this->repositories();
 
             case 'snippets':
-                $api = new Api\Snippets($this);
-                break;
+                return $this->snippets();
 
             case 'hooks':
             case 'system_hooks':
-                $api = new Api\SystemHooks($this);
-                break;
+                return $this->systemHooks();
 
             case 'users':
-                $api = new Api\Users($this);
-                break;
+                return $this->users();
 
             case 'keys':
-                $api = new Api\Keys($this);
-                break;
+                return $this->keys();
 
             case 'tags':
-                $api = new Api\Tags($this);
-                break;
+                return $this->tags();
 
             default:
                 throw new InvalidArgumentException('Invalid endpoint: "'.$name.'"');
-
         }
-
-        return $api;
     }
 
     /**

--- a/lib/Gitlab/HttpClient/Builder.php
+++ b/lib/Gitlab/HttpClient/Builder.php
@@ -31,7 +31,7 @@ class Builder
     /**
      * A HTTP client with all our plugins.
      *
-     * @var PluginClient
+     * @var HttpMethodsClient
      */
     private $pluginClient;
 

--- a/lib/Gitlab/Model/Branch.php
+++ b/lib/Gitlab/Model/Branch.php
@@ -57,7 +57,7 @@ class Branch extends AbstractModel
      */
     public function show()
     {
-        $data = $this->api('repositories')->branch($this->project->id, $this->name);
+        $data = $this->client->repositories()->branch($this->project->id, $this->name);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -69,7 +69,7 @@ class Branch extends AbstractModel
      */
     public function protect($devPush = false, $devMerge = false)
     {
-        $data = $this->api('repositories')->protectBranch($this->project->id, $this->name, $devPush, $devMerge);
+        $data = $this->client->repositories()->protectBranch($this->project->id, $this->name, $devPush, $devMerge);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -79,7 +79,7 @@ class Branch extends AbstractModel
      */
     public function unprotect()
     {
-        $data = $this->api('repositories')->unprotectBranch($this->project->id, $this->name);
+        $data = $this->client->repositories()->unprotectBranch($this->project->id, $this->name);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -89,7 +89,7 @@ class Branch extends AbstractModel
      */
     public function delete()
     {
-        $this->api('repositories')->deleteBranch($this->project->id, $this->name);
+        $this->client->repositories()->deleteBranch($this->project->id, $this->name);
 
         return true;
     }
@@ -112,7 +112,7 @@ class Branch extends AbstractModel
      */
     public function createFile($file_path, $content, $commit_message)
     {
-        $data = $this->api('repositories')->createFile($this->project->id, $file_path, $content, $this->name, $commit_message);
+        $data = $this->client->repositories()->createFile($this->project->id, $file_path, $content, $this->name, $commit_message);
 
         return File::fromArray($this->getClient(), $this->project, $data);
     }
@@ -125,7 +125,7 @@ class Branch extends AbstractModel
      */
     public function updateFile($file_path, $content, $commit_message)
     {
-        $data = $this->api('repositories')->updateFile($this->project->id, $file_path, $content, $this->name, $commit_message);
+        $data = $this->client->repositories()->updateFile($this->project->id, $file_path, $content, $this->name, $commit_message);
 
         return File::fromArray($this->getClient(), $this->project, $data);
     }
@@ -137,7 +137,7 @@ class Branch extends AbstractModel
      */
     public function deleteFile($file_path, $commit_message)
     {
-        $this->api('repositories')->deleteFile($this->project->id, $file_path, $this->name, $commit_message);
+        $this->client->repositories()->deleteFile($this->project->id, $file_path, $this->name, $commit_message);
 
         return true;
     }

--- a/lib/Gitlab/Model/Group.php
+++ b/lib/Gitlab/Model/Group.php
@@ -52,7 +52,7 @@ class Group extends AbstractModel
      */
     public static function create(Client $client, $name, $path)
     {
-        $data = $client->api('groups')->create($name, $path);
+        $data = $client->groups()->create($name, $path);
 
         return static::fromArray($client, $data);
     }
@@ -72,7 +72,7 @@ class Group extends AbstractModel
      */
     public function show()
     {
-        $data = $this->api('groups')->show($this->id);
+        $data = $this->client->groups()->show($this->id);
 
         return Group::fromArray($this->getClient(), $data);
     }
@@ -83,7 +83,7 @@ class Group extends AbstractModel
      */
     public function transfer($project_id)
     {
-        $data = $this->api('groups')->transfer($this->id, $project_id);
+        $data = $this->client->groups()->transfer($this->id, $project_id);
 
         return Group::fromArray($this->getClient(), $data);
     }
@@ -93,7 +93,7 @@ class Group extends AbstractModel
      */
     public function members()
     {
-        $data = $this->api('groups')->members($this->id);
+        $data = $this->client->groups()->members($this->id);
 
         $members = array();
         foreach ($data as $member) {
@@ -110,7 +110,7 @@ class Group extends AbstractModel
      */
     public function addMember($user_id, $access_level)
     {
-        $data = $this->api('groups')->addMember($this->id, $user_id, $access_level);
+        $data = $this->client->groups()->addMember($this->id, $user_id, $access_level);
 
         return User::fromArray($this->getClient(), $data);
     }
@@ -121,7 +121,7 @@ class Group extends AbstractModel
      */
     public function removeMember($user_id)
     {
-        $this->api('groups')->removeMember($this->id, $user_id);
+        $this->client->groups()->removeMember($this->id, $user_id);
 
         return true;
     }
@@ -132,7 +132,7 @@ class Group extends AbstractModel
     public function projects()
     {
 
-        $data = $this->api('groups')->projects($this->id);
+        $data = $this->client->groups()->projects($this->id);
 
         return Group::fromArray($this->getClient(),$data);
     }

--- a/lib/Gitlab/Model/Hook.php
+++ b/lib/Gitlab/Model/Hook.php
@@ -39,7 +39,7 @@ class Hook extends AbstractModel
      */
     public static function create(Client $client, $url)
     {
-        $data = $client->api('system_hooks')->create($url);
+        $data = $client->systemHooks()->create($url);
 
         return static::fromArray($client, $data);
     }
@@ -59,7 +59,7 @@ class Hook extends AbstractModel
      */
     public function test()
     {
-        $this->api('system_hooks')->test($this->id);
+        $this->client->systemHooks()->test($this->id);
 
         return true;
     }
@@ -69,7 +69,7 @@ class Hook extends AbstractModel
      */
     public function delete()
     {
-        $this->api('system_hooks')->remove($this->id);
+        $this->client->systemHooks()->remove($this->id);
 
         return true;
     }

--- a/lib/Gitlab/Model/Issue.php
+++ b/lib/Gitlab/Model/Issue.php
@@ -80,7 +80,7 @@ class Issue extends AbstractModel implements Noteable
      */
     public function show()
     {
-        $data = $this->api('issues')->show($this->project->id, $this->id);
+        $data = $this->client->issues()->show($this->project->id, $this->id);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -91,7 +91,7 @@ class Issue extends AbstractModel implements Noteable
      */
     public function update(array $params)
     {
-        $data = $this->api('issues')->update($this->project->id, $this->id, $params);
+        $data = $this->client->issues()->update($this->project->id, $this->id, $params);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -135,7 +135,7 @@ class Issue extends AbstractModel implements Noteable
      */
     public function addComment($comment)
     {
-        $data = $this->api('issues')->addComment($this->project->id, $this->id, array(
+        $data = $this->client->issues()->addComment($this->project->id, $this->id, array(
             'body' => $comment
         ));
 
@@ -148,7 +148,7 @@ class Issue extends AbstractModel implements Noteable
     public function showComments()
     {
         $notes = array();
-        $data = $this->api('issues')->showComments($this->project->id, $this->id);
+        $data = $this->client->issues()->showComments($this->project->id, $this->id);
 
         foreach ($data as $note) {
             $notes[] = Note::fromArray($this->getClient(), $this, $note);

--- a/lib/Gitlab/Model/MergeRequest.php
+++ b/lib/Gitlab/Model/MergeRequest.php
@@ -105,7 +105,7 @@ class MergeRequest extends AbstractModel implements Noteable
      */
     public function show()
     {
-        $data = $this->api('mr')->show($this->project->id, $this->id);
+        $data = $this->client->mergeRequests()->show($this->project->id, $this->id);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -116,7 +116,7 @@ class MergeRequest extends AbstractModel implements Noteable
      */
     public function update(array $params)
     {
-        $data = $this->api('mr')->update($this->project->id, $this->id, $params);
+        $data = $this->client->mergeRequests()->update($this->project->id, $this->id, $params);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -160,7 +160,7 @@ class MergeRequest extends AbstractModel implements Noteable
      */
     public function merge($message = null)
     {
-        $data = $this->api('mr')->merge($this->project->id, $this->id, array(
+        $data = $this->client->mergeRequests()->merge($this->project->id, $this->id, array(
             'merge_commit_message' => $message
         ));
 
@@ -183,7 +183,7 @@ class MergeRequest extends AbstractModel implements Noteable
      */
     public function addComment($comment)
     {
-        $data = $this->api('mr')->addComment($this->project->id, $this->id, $comment);
+        $data = $this->client->mergeRequests()->addComment($this->project->id, $this->id, $comment);
 
         return Note::fromArray($this->getClient(), $this, $data);
     }
@@ -194,7 +194,7 @@ class MergeRequest extends AbstractModel implements Noteable
     public function showComments()
     {
         $notes = array();
-        $data = $this->api('mr')->showComments($this->project->id, $this->id);
+        $data = $this->client->mergeRequests()->showComments($this->project->id, $this->id);
 
         foreach ($data as $note) {
             $notes[] = Note::fromArray($this->getClient(), $this, $note);
@@ -220,7 +220,7 @@ class MergeRequest extends AbstractModel implements Noteable
      */
     public function changes()
     {
-        $data = $this->api('mr')->changes($this->project->id, $this->id);
+        $data = $this->client->mergeRequests()->changes($this->project->id, $this->id);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }

--- a/lib/Gitlab/Model/Milestone.php
+++ b/lib/Gitlab/Model/Milestone.php
@@ -66,7 +66,7 @@ class Milestone extends AbstractModel
      */
     public function show()
     {
-        $data = $this->api('milestones')->show($this->project->id, $this->id);
+        $data = $this->client->milestones()->show($this->project->id, $this->id);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -77,7 +77,7 @@ class Milestone extends AbstractModel
      */
     public function update(array $params)
     {
-        $data = $this->api('milestones')->update($this->project->id, $this->id, $params);
+        $data = $this->client->milestones()->update($this->project->id, $this->id, $params);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -103,7 +103,7 @@ class Milestone extends AbstractModel
      */
     public function issues()
     {
-        $data = $this->api('milestones')->issues($this->project->id, $this->id);
+        $data = $this->client->milestones()->issues($this->project->id, $this->id);
 
         $issues = array();
         foreach ($data as $issue) {

--- a/lib/Gitlab/Model/Pipeline.php
+++ b/lib/Gitlab/Model/Pipeline.php
@@ -26,7 +26,7 @@ class Pipeline extends AbstractModel
      * @param Client  $client
      * @param Project $project
      * @param array   $data
-     * @return Commit
+     * @return Pipeline
      */
     public static function fromArray(Client $client, Project $project, array $data)
     {

--- a/lib/Gitlab/Model/Project.php
+++ b/lib/Gitlab/Model/Project.php
@@ -93,7 +93,7 @@ class Project extends AbstractModel
      */
     public static function create(Client $client, $name, array $params = array())
     {
-        $data = $client->api('projects')->create($name, $params);
+        $data = $client->projects()->create($name, $params);
 
         return static::fromArray($client, $data);
     }
@@ -107,7 +107,7 @@ class Project extends AbstractModel
      */
     public static function createForUser($user_id, Client $client, $name, array $params = array())
     {
-        $data = $client->api('projects')->createForUser($user_id, $name, $params);
+        $data = $client->projects()->createForUser($user_id, $name, $params);
 
         return static::fromArray($client, $data);
     }
@@ -126,7 +126,7 @@ class Project extends AbstractModel
      */
     public function show()
     {
-        $data = $this->api('projects')->show($this->id);
+        $data = $this->client->projects()->show($this->id);
 
         return static::fromArray($this->getClient(), $data);
     }
@@ -137,7 +137,7 @@ class Project extends AbstractModel
      */
     public function update(array $params)
     {
-        $data = $this->api('projects')->update($this->id, $params);
+        $data = $this->client->projects()->update($this->id, $params);
 
         return static::fromArray($this->getClient(), $data);
     }
@@ -147,7 +147,7 @@ class Project extends AbstractModel
      */
     public function archive()
     {
-        $data = $this->api("projects")->archive($this->id);
+        $data = $this->client->projects()->archive($this->id);
 
         return static::fromArray($this->getClient(), $data);
     }
@@ -157,7 +157,7 @@ class Project extends AbstractModel
      */
     public function unarchive()
     {
-        $data = $this->api("projects")->unarchive($this->id);
+        $data = $this->client->projects()->unarchive($this->id);
 
         return static::fromArray($this->getClient(), $data);
     }
@@ -167,7 +167,7 @@ class Project extends AbstractModel
      */
     public function remove()
     {
-        $this->api('projects')->remove($this->id);
+        $this->client->projects()->remove($this->id);
 
         return true;
     }
@@ -178,7 +178,7 @@ class Project extends AbstractModel
      */
     public function members($username_query = null)
     {
-        $data = $this->api('projects')->members($this->id, $username_query);
+        $data = $this->client->projects()->members($this->id, $username_query);
 
         $members = array();
         foreach ($data as $member) {
@@ -194,7 +194,7 @@ class Project extends AbstractModel
      */
     public function member($user_id)
     {
-        $data = $this->api('projects')->member($this->id, $user_id);
+        $data = $this->client->projects()->member($this->id, $user_id);
 
         return User::fromArray($this->getClient(), $data);
     }
@@ -206,7 +206,7 @@ class Project extends AbstractModel
      */
     public function addMember($user_id, $access_level)
     {
-        $data = $this->api('projects')->addMember($this->id, $user_id, $access_level);
+        $data = $this->client->projects()->addMember($this->id, $user_id, $access_level);
 
         return User::fromArray($this->getClient(), $data);
     }
@@ -218,7 +218,7 @@ class Project extends AbstractModel
      */
     public function saveMember($user_id, $access_level)
     {
-        $data = $this->api('projects')->saveMember($this->id, $user_id, $access_level);
+        $data = $this->client->projects()->saveMember($this->id, $user_id, $access_level);
 
         return User::fromArray($this->getClient(), $data);
     }
@@ -229,7 +229,7 @@ class Project extends AbstractModel
      */
     public function removeMember($user_id)
     {
-        $this->api('projects')->removeMember($this->id, $user_id);
+        $this->client->projects()->removeMember($this->id, $user_id);
 
         return true;
     }
@@ -241,7 +241,7 @@ class Project extends AbstractModel
      */
     public function hooks($page = 1, $per_page = Api::PER_PAGE)
     {
-        $data = $this->api('projects')->hooks($this->id, $page, $per_page);
+        $data = $this->client->projects()->hooks($this->id, $page, $per_page);
 
         $hooks = array();
         foreach ($data as $hook) {
@@ -269,7 +269,7 @@ class Project extends AbstractModel
      */
     public function addHook($url, array $events = array())
     {
-        $data = $this->api('projects')->addHook($this->id, $url, $events);
+        $data = $this->client->projects()->addHook($this->id, $url, $events);
 
         return ProjectHook::fromArray($this->getClient(), $this, $data);
     }
@@ -302,7 +302,7 @@ class Project extends AbstractModel
      */
     public function deployKeys()
     {
-        $data = $this->api('projects')->deployKeys($this->id);
+        $data = $this->client->projects()->deployKeys($this->id);
 
         $keys = array();
         foreach ($data as $key) {
@@ -318,7 +318,7 @@ class Project extends AbstractModel
      */
     public function deployKey($key_id)
     {
-        $data = $this->api('projects')->deployKey($this->id, $key_id);
+        $data = $this->client->projects()->deployKey($this->id, $key_id);
 
         return Key::fromArray($this->getClient(), $data);
     }
@@ -330,7 +330,7 @@ class Project extends AbstractModel
      */
     public function addDeployKey($title, $key)
     {
-        $data = $this->api('projects')->addDeployKey($this->id, $title, $key);
+        $data = $this->client->projects()->addDeployKey($this->id, $title, $key);
 
         return Key::fromArray($this->getClient(), $data);
     }
@@ -341,7 +341,7 @@ class Project extends AbstractModel
      */
     public function deleteDeployKey($key_id)
     {
-        $this->api('projects')->deleteDeployKey($this->id, $key_id);
+        $this->client->projects()->deleteDeployKey($this->id, $key_id);
 
         return true;
     }
@@ -352,7 +352,7 @@ class Project extends AbstractModel
      */
     public function enableDeployKey($key_id)
     {
-        $this->api('projects')->enableDeployKey($this->id, $key_id);
+        $this->client->projects()->enableDeployKey($this->id, $key_id);
 
         return true;
     }
@@ -364,7 +364,7 @@ class Project extends AbstractModel
      */
     public function createBranch($name, $ref)
     {
-        $data = $this->api('repositories')->createBranch($this->id, $name, $ref);
+        $data = $this->client->repositories()->createBranch($this->id, $name, $ref);
 
         return Branch::fromArray($this->getClient(), $this, $data);
     }
@@ -375,7 +375,7 @@ class Project extends AbstractModel
      */
     public function deleteBranch($name)
     {
-        $this->api('repositories')->deleteBranch($this->id, $name);
+        $this->client->repositories()->deleteBranch($this->id, $name);
 
         return true;
     }
@@ -385,7 +385,7 @@ class Project extends AbstractModel
      */
     public function branches()
     {
-        $data = $this->api('repo')->branches($this->id);
+        $data = $this->client->repositories()->branches($this->id);
 
         $branches = array();
         foreach ($data as $branch) {
@@ -438,7 +438,7 @@ class Project extends AbstractModel
      */
     public function tags()
     {
-        $data = $this->api('repo')->tags($this->id);
+        $data = $this->client->repositories()->tags($this->id);
 
         $tags = array();
         foreach ($data as $tag) {
@@ -456,7 +456,7 @@ class Project extends AbstractModel
      */
     public function commits($page = 0, $per_page = Api::PER_PAGE, $ref_name = null)
     {
-        $data = $this->api('repo')->commits($this->id, $page, $per_page, $ref_name);
+        $data = $this->client->repositories()->commits($this->id, $page, $per_page, $ref_name);
 
         $commits = array();
         foreach ($data as $commit) {
@@ -472,7 +472,7 @@ class Project extends AbstractModel
      */
     public function commit($sha)
     {
-        $data = $this->api('repo')->commit($this->id, $sha);
+        $data = $this->client->repositories()->commit($this->id, $sha);
 
         return Commit::fromArray($this->getClient(), $this, $data);
     }
@@ -485,7 +485,7 @@ class Project extends AbstractModel
      */
     public function commitComments($ref, $page = 0, $per_page = Api::PER_PAGE)
     {
-        $data = $this->api('repo')->commitComments($this->id, $ref, $page, $per_page);
+        $data = $this->client->repositories()->commitComments($this->id, $ref, $page, $per_page);
 
         $comments = array();
         foreach ($data as $comment) {
@@ -503,7 +503,7 @@ class Project extends AbstractModel
      */
     public function createCommitComment($ref, $note, array $params = array())
     {
-        $data = $this->api('repo')->createCommitComment($this->id, $ref, $note, $params);
+        $data = $this->client->repositories()->createCommitComment($this->id, $ref, $note, $params);
 
         return CommitNote::fromArray($this->getClient(), $data);
     }
@@ -514,7 +514,7 @@ class Project extends AbstractModel
      */
     public function diff($sha)
     {
-        return $this->api('repo')->diff($this->id, $sha);
+        return $this->client->repositories()->diff($this->id, $sha);
     }
 
     /**
@@ -524,7 +524,7 @@ class Project extends AbstractModel
      */
     public function compare($from, $to)
     {
-        $data = $this->api('repo')->compare($this->id, $from, $to);
+        $data = $this->client->repositories()->compare($this->id, $from, $to);
 
         return Comparison::fromArray($this->getClient(), $this, $data);
     }
@@ -535,7 +535,7 @@ class Project extends AbstractModel
      */
     public function tree(array $params = array())
     {
-        $data = $this->api('repo')->tree($this->id, $params);
+        $data = $this->client->repositories()->tree($this->id, $params);
 
         $tree = array();
         foreach ($data as $node) {
@@ -552,7 +552,7 @@ class Project extends AbstractModel
      */
     public function blob($sha, $filepath)
     {
-        return $this->api('repo')->blob($this->id, $sha, $filepath);
+        return $this->client->repositories()->blob($this->id, $sha, $filepath);
     }
 
     /**
@@ -563,7 +563,7 @@ class Project extends AbstractModel
      */
     public function getFile($sha, $filepath)
     {
-        return $this->api('repo')->getFile($this->id, $filepath, $sha);
+        return $this->client->repositories()->getFile($this->id, $filepath, $sha);
     }
 
     /**
@@ -577,7 +577,7 @@ class Project extends AbstractModel
      */
     public function createFile($file_path, $content, $branch_name, $commit_message, $author_email = null, $author_name = null)
     {
-        $data = $this->api('repo')->createFile($this->id, $file_path, $content, $branch_name, $commit_message, null, $author_email, $author_name);
+        $data = $this->client->repositories()->createFile($this->id, $file_path, $content, $branch_name, $commit_message, null, $author_email, $author_name);
 
         return File::fromArray($this->getClient(), $this, $data);
     }
@@ -593,7 +593,7 @@ class Project extends AbstractModel
      */
     public function updateFile($file_path, $content, $branch_name, $commit_message, $author_email = null, $author_name = null)
     {
-        $data = $this->api('repo')->updateFile($this->id, $file_path, $content, $branch_name, $commit_message, null, $author_email, $author_name);
+        $data = $this->client->repositories()->updateFile($this->id, $file_path, $content, $branch_name, $commit_message, null, $author_email, $author_name);
 
         return File::fromArray($this->getClient(), $this, $data);
     }
@@ -608,7 +608,7 @@ class Project extends AbstractModel
      */
     public function deleteFile($file_path, $branch_name, $commit_message, $author_email = null, $author_name = null)
     {
-        $this->api('repo')->deleteFile($this->id, $file_path, $branch_name, $commit_message, $author_email, $author_name);
+        $this->client->repositories()->deleteFile($this->id, $file_path, $branch_name, $commit_message, $author_email, $author_name);
 
         return true;
     }
@@ -620,7 +620,7 @@ class Project extends AbstractModel
      */
     public function events($page = 1, $per_page = Api::PER_PAGE)
     {
-        $data = $this->api('projects')->events($this->id, $page, $per_page);
+        $data = $this->client->projects()->events($this->id, $page, $per_page);
 
         $events = array();
         foreach ($data as $event) {
@@ -638,7 +638,7 @@ class Project extends AbstractModel
      */
     public function mergeRequests($page = 1, $per_page = Api::PER_PAGE, $state = MergeRequests::STATE_ALL)
     {
-        $data = $this->api('mr')->$state($this->id, $page, $per_page);
+        $data = $this->client->mergeRequests()->$state($this->id, $page, $per_page);
 
         $mrs = array();
         foreach ($data as $mr) {
@@ -669,7 +669,7 @@ class Project extends AbstractModel
      */
     public function createMergeRequest($source, $target, $title, $assignee = null, $description = null)
     {
-        $data = $this->api('mr')->create($this->id, $source, $target, $title, $assignee, null, $description);
+        $data = $this->client->mergeRequests()->create($this->id, $source, $target, $title, $assignee, null, $description);
 
         return MergeRequest::fromArray($this->getClient(), $this, $data);
     }
@@ -726,7 +726,7 @@ class Project extends AbstractModel
      */
     public function issues($page = 1, $per_page = Api::PER_PAGE)
     {
-        $data = $this->api('issues')->all($this->id, $page, $per_page);
+        $data = $this->client->issues()->all($this->id, $page, $per_page);
 
         $issues = array();
         foreach ($data as $issue) {
@@ -744,7 +744,7 @@ class Project extends AbstractModel
     public function createIssue($title, array $params = array())
     {
         $params['title'] = $title;
-        $data = $this->api('issues')->create($this->id, $params);
+        $data = $this->client->issues()->create($this->id, $params);
 
         return Issue::fromArray($this->getClient(), $this, $data);
     }
@@ -802,7 +802,7 @@ class Project extends AbstractModel
      */
     public function milestones($page = 1, $per_page = Api::PER_PAGE)
     {
-        $data = $this->api('milestones')->all($this->id, $page, $per_page);
+        $data = $this->client->milestones()->all($this->id, $page, $per_page);
 
         $milestones = array();
         foreach ($data as $milestone) {
@@ -820,7 +820,7 @@ class Project extends AbstractModel
     public function createMilestone($title, array $params = array())
     {
         $params['title'] = $title;
-        $data = $this->api('milestones')->create($this->id, $params);
+        $data = $this->client->milestones()->create($this->id, $params);
 
         return Milestone::fromArray($this->getClient(), $this, $data);
     }
@@ -864,7 +864,7 @@ class Project extends AbstractModel
      */
     public function snippets()
     {
-        $data = $this->api('snippets')->all($this->id);
+        $data = $this->client->snippets()->all($this->id);
 
         $snippets = array();
         foreach ($data as $snippet) {
@@ -878,12 +878,11 @@ class Project extends AbstractModel
      * @param string $title
      * @param string $filename
      * @param string $code
-     * @param string $lifetime
      * @return Snippet
      */
-    public function createSnippet($title, $filename, $code, $lifetime = null)
+    public function createSnippet($title, $filename, $code)
     {
-        $data = $this->api('snippets')->create($this->id, $title, $filename, $code, $lifetime);
+        $data = $this->client->snippets()->create($this->id, $title, $filename, $code);
 
         return Snippet::fromArray($this->getClient(), $this, $data);
     }
@@ -901,7 +900,7 @@ class Project extends AbstractModel
 
     /**
      * @param int $id
-     * @return Snippet
+     * @return string
      */
     public function snippetContent($id)
     {
@@ -950,7 +949,7 @@ class Project extends AbstractModel
      */
     public function forkTo($id)
     {
-        $data = $this->api('projects')->createForkRelation($id, $this->id);
+        $data = $this->client->projects()->createForkRelation($id, $this->id);
 
         return Project::fromArray($this->getClient(), $data);
     }
@@ -970,7 +969,7 @@ class Project extends AbstractModel
      */
     public function createForkRelation($id)
     {
-        $data = $this->api('projects')->createForkRelation($this->id, $id);
+        $data = $this->client->projects()->createForkRelation($this->id, $id);
 
         return Project::fromArray($this->getClient(), $data);
     }
@@ -980,7 +979,7 @@ class Project extends AbstractModel
      */
     public function removeForkRelation()
     {
-        $this->api('projects')->removeForkRelation($this->id);
+        $this->client->projects()->removeForkRelation($this->id);
 
         return true;
     }
@@ -992,7 +991,7 @@ class Project extends AbstractModel
      */
     public function setService($service_name, array $params = array())
     {
-        $this->api('projects')->setService($this->id, $service_name, $params);
+        $this->client->projects()->setService($this->id, $service_name, $params);
 
         return true;
     }
@@ -1003,7 +1002,7 @@ class Project extends AbstractModel
      */
     public function removeService($service_name)
     {
-        $this->api('projects')->removeService($this->id, $service_name);
+        $this->client->projects()->removeService($this->id, $service_name);
 
         return true;
     }
@@ -1013,7 +1012,7 @@ class Project extends AbstractModel
      */
     public function labels()
     {
-        $data = $this->api('projects')->labels($this->id);
+        $data = $this->client->projects()->labels($this->id);
 
         $labels = array();
         foreach ($data as $label) {
@@ -1030,7 +1029,7 @@ class Project extends AbstractModel
      */
     public function addLabel($name, $color)
     {
-        $data = $this->api('projects')->addLabel($this->id, array(
+        $data = $this->client->projects()->addLabel($this->id, array(
             'name' => $name,
             'color' => $color
         ));
@@ -1051,7 +1050,7 @@ class Project extends AbstractModel
 
         $params['name'] = $name;
 
-        $data = $this->api('projects')->updateLabel($this->id, $params);
+        $data = $this->client->projects()->updateLabel($this->id, $params);
 
         return Label::fromArray($this->getClient(), $this, $data);
     }
@@ -1062,7 +1061,7 @@ class Project extends AbstractModel
      */
     public function removeLabel($name)
     {
-        $this->api('projects')->removeLabel($this->id, $name);
+        $this->client->projects()->removeLabel($this->id, $name);
 
         return true;
     }
@@ -1072,7 +1071,7 @@ class Project extends AbstractModel
      */
     public function contributors()
     {
-        $data = $this->api('repo')->contributors($this->id);
+        $data = $this->client->repositories()->contributors($this->id);
 
         $contributors = array();
         foreach ($data as $contributor) {
@@ -1088,7 +1087,7 @@ class Project extends AbstractModel
      */
     public function jobs(array $scopes = [])
     {
-        $data = $this->api('jobs')->jobs($this->id, $scopes);
+        $data = $this->client->jobs()->all($this->id, $scopes);
 
         $jobs = array();
         foreach ($data as $job) {
@@ -1105,7 +1104,7 @@ class Project extends AbstractModel
      */
     public function pipelineJobs($pipeline_id, array $scopes = [])
     {
-        $data = $this->api('jobs')->pipelineJobs($this->id, $pipeline_id, $scopes);
+        $data = $this->client->jobs()->pipelineJobs($this->id, $pipeline_id, $scopes);
 
         $jobs = array();
         foreach ($data as $job) {
@@ -1121,7 +1120,7 @@ class Project extends AbstractModel
      */
     public function job($job_id)
     {
-        $data = $this->api('jobs')->show($this->id, $job_id);
+        $data = $this->client->jobs()->show($this->id, $job_id);
 
         return Job::fromArray($this->getClient(), $this, $data);
     }

--- a/lib/Gitlab/Model/ProjectHook.php
+++ b/lib/Gitlab/Model/ProjectHook.php
@@ -64,7 +64,7 @@ class ProjectHook extends AbstractModel
      */
     public function show()
     {
-        $data = $this->api('projects')->hook($this->project->id, $this->id);
+        $data = $this->client->projects()->hook($this->project->id, $this->id);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -74,7 +74,7 @@ class ProjectHook extends AbstractModel
      */
     public function delete()
     {
-        $this->api('projects')->removeHook($this->project->id, $this->id);
+        $this->client->projects()->removeHook($this->project->id, $this->id);
 
         return true;
     }
@@ -93,7 +93,7 @@ class ProjectHook extends AbstractModel
      */
     public function update(array $params)
     {
-        $data = $this->api('projects')->updateHook($this->project->id, $this->id, $params);
+        $data = $this->client->projects()->updateHook($this->project->id, $this->id, $params);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }

--- a/lib/Gitlab/Model/Session.php
+++ b/lib/Gitlab/Model/Session.php
@@ -51,7 +51,7 @@ class Session extends AbstractModel
      */
     public function me()
     {
-        $data = $this->api('users')->show();
+        $data = $this->client->users()->user();
 
         return User::fromArray($this->getClient(), $data);
     }
@@ -59,11 +59,11 @@ class Session extends AbstractModel
     /**
      * @param string $email
      * @param string $password
-     * @return $this
+     * @return Session
      */
     public function login($email, $password)
     {
-        $data = $this->api('users')->session($email, $password);
+        $data = $this->client->users()->session($email, $password);
 
         return $this->hydrate($data);
     }

--- a/lib/Gitlab/Model/Snippet.php
+++ b/lib/Gitlab/Model/Snippet.php
@@ -62,7 +62,7 @@ class Snippet extends AbstractModel
      */
     public function show()
     {
-        $data = $this->api('snippets')->show($this->project->id, $this->id);
+        $data = $this->client->snippets()->show($this->project->id, $this->id);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -73,7 +73,7 @@ class Snippet extends AbstractModel
      */
     public function update(array $params)
     {
-        $data = $this->api('snippets')->update($this->project->id, $this->id, $params);
+        $data = $this->client->snippets()->update($this->project->id, $this->id, $params);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -83,7 +83,7 @@ class Snippet extends AbstractModel
      */
     public function content()
     {
-        return $this->api('snippets')->content($this->project->id, $this->id);
+        return $this->client->snippets()->content($this->project->id, $this->id);
     }
 
     /**
@@ -91,7 +91,7 @@ class Snippet extends AbstractModel
      */
     public function remove()
     {
-        $this->api('snippets')->remove($this->project->id, $this->id);
+        $this->client->snippets()->remove($this->project->id, $this->id);
 
         return true;
     }

--- a/lib/Gitlab/Model/User.php
+++ b/lib/Gitlab/Model/User.php
@@ -86,7 +86,7 @@ class User extends AbstractModel
      */
     public static function create(Client $client, $email, $password, array $params = array())
     {
-        $data = $client->api('users')->create($email, $password, $params);
+        $data = $client->users()->create($email, $password, $params);
 
         return static::fromArray($client, $data);
     }
@@ -106,7 +106,7 @@ class User extends AbstractModel
      */
     public function show()
     {
-        $data = $this->api('users')->show($this->id);
+        $data = $this->client->users()->show($this->id);
 
         return static::fromArray($this->getClient(), $data);
     }
@@ -117,7 +117,7 @@ class User extends AbstractModel
      */
     public function update(array $params)
     {
-        $data = $this->api('users')->update($this->id, $params);
+        $data = $this->client->users()->update($this->id, $params);
 
         return static::fromArray($this->getClient(), $data);
     }
@@ -127,7 +127,7 @@ class User extends AbstractModel
      */
     public function remove()
     {
-        $this->api('users')->remove($this->id);
+        $this->client->users()->remove($this->id);
 
         return true;
     }
@@ -137,7 +137,7 @@ class User extends AbstractModel
      */
     public function block()
     {
-        $this->api('users')->block($this->id);
+        $this->client->users()->block($this->id);
 
         return true;
     }
@@ -147,7 +147,7 @@ class User extends AbstractModel
      */
     public function unblock()
     {
-        $this->api('users')->unblock($this->id);
+        $this->client->users()->unblock($this->id);
 
         return true;
     }
@@ -157,7 +157,7 @@ class User extends AbstractModel
      */
     public function keys()
     {
-        $data = $this->api('users')->keys();
+        $data = $this->client->users()->keys();
 
         $keys = array();
         foreach ($data as $key) {
@@ -174,7 +174,7 @@ class User extends AbstractModel
      */
     public function createKey($title, $key)
     {
-        $data = $this->api('users')->createKey($title, $key);
+        $data = $this->client->users()->createKey($title, $key);
 
         return Key::fromArray($this->getClient(), $data);
     }
@@ -186,7 +186,7 @@ class User extends AbstractModel
      */
     public function createKeyForUser($user_id, $title, $key)
     {
-        $data = $this->api('users')->createKeyForUser($user_id, $title, $key);
+        $data = $this->client->users()->createKeyForUser($user_id, $title, $key);
 
         return Key::fromArray($this->getClient(), $data);
     }
@@ -197,7 +197,7 @@ class User extends AbstractModel
      */
     public function removeKey($id)
     {
-        $this->api('users')->removeKey($id);
+        $this->client->users()->removeKey($id);
 
         return true;
     }


### PR DESCRIPTION
This fix level 4 errors reported by https://github.com/phpstan/phpstan.

This improve code safety.

I introduced explicit methods to get API endpoints in the Client. In near future, we could deprecate the `api` and `__get` magic methods from `Gitlab\Client` which does not add any value.

phpstan is now run on travis-ci.