### PR TITLE
Multi files commit

### DIFF
--- a/lib/Gitlab/Api/AbstractApi.php
+++ b/lib/Gitlab/Api/AbstractApi.php
@@ -89,7 +89,7 @@ abstract class AbstractApi implements ApiInterface
 
         $body = null;
         if (empty($files) && !empty($parameters)) {
-            $body = $this->streamFactory->createStream(http_build_query($parameters));
+            $body = $this->streamFactory->createStream(QueryStringBuilder::build($parameters));
             $requestHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
         } elseif (!empty($files)) {
             $builder = new MultipartStreamBuilder($this->streamFactory);

--- a/test/Gitlab/Tests/Api/RepositoriesTest.php
+++ b/test/Gitlab/Tests/Api/RepositoriesTest.php
@@ -277,6 +277,40 @@ class RepositoriesTest extends TestCase
     /**
      * @test
      */
+    public function shouldCreateCommit()
+    {
+        $expectedArray = array('title' => 'Initial commit.', 'author_name' => 'John Doe', 'author_email' => 'john@example.com');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/repository/commits')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->createCommit(1, [
+            'branch' => 'master',
+            'commit_message' => 'Initial commit.',
+            'actions' => [
+                [
+                    'action' => 'create',
+                    'file_path' => 'README.md',
+                    'content' => '# My new project',
+                ],
+                [
+                    'action' => 'create',
+                    'file_path' => 'LICENSE',
+                    'content' => 'MIT License...',
+                ],
+            ],
+            'author_name' => 'John Doe',
+            'author_email' => 'john@example.com',
+        ]));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetCommitComments()
     {
         $expectedArray = array(


### PR DESCRIPTION
This add [multi file commit](https://docs.gitlab.com/ee/api/commits.html#create-a-commit-with-multiple-files-and-actions) method.

Fix #209 and close #158.

## To do
- [x] Tests.