### PR TITLE
Fix false boolean query string encoding

### DIFF
--- a/lib/Gitlab/HttpClient/Message/QueryStringBuilder.php
+++ b/lib/Gitlab/HttpClient/Message/QueryStringBuilder.php
@@ -15,7 +15,7 @@ final class QueryStringBuilder
     public static function build($query)
     {
         if (!is_array($query)) {
-            return rawurlencode($query);
+            return static::rawurlencode($query);
         }
         return implode('&', array_map(function ($value, $key) {
             return static::encode($value, $key);
@@ -32,7 +32,7 @@ final class QueryStringBuilder
     private static function encode($query, $prefix)
     {
         if (!is_array($query)) {
-            return rawurlencode($prefix).'='.rawurlencode($query);
+            return static::rawurlencode($prefix).'='.static::rawurlencode($query);
         }
 
         $isIndexedArray = static::isIndexedArray($query);
@@ -56,5 +56,21 @@ final class QueryStringBuilder
         }
 
         return array_keys($query) === range(0, count($query) - 1);
+    }
+
+    /**
+     * Encode a value like rawurlencode, but return "0" when false is given.
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    private static function rawurlencode($value)
+    {
+        if ($value === false) {
+            return '0';
+        }
+
+        return rawurlencode($value);
     }
 }

--- a/test/Gitlab/Tests/HttpClient/Message/QueryStringBuilderTest.php
+++ b/test/Gitlab/Tests/HttpClient/Message/QueryStringBuilderTest.php
@@ -40,6 +40,12 @@ class QueryStringBuilderTest extends \PHPUnit_Framework_TestCase
             'iids%5B0%5D=88&iids%5B2%5D=86'
         ];
 
+        //Boolean encoding
+        yield [
+            ['push_events' => false, 'merge_requests_events' => 1],
+            'push_events=0&merge_requests_events=1'
+        ];
+
         //A deeply nested array.
         yield [
             [


### PR DESCRIPTION
The `QueryStringBuilder` has a bug with encoding the `false` value.

See https://3v4l.org/r4Sqt for the `http_build_query` behavior.