### PR TITLE
Deprecate merge request comment related methods

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -162,7 +162,9 @@ class MergeRequests extends AbstractApi
      */
     public function showComments($project_id, $mr_id)
     {
-        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id).'/comments'));
+        @trigger_error(sprintf('The %s() method is deprecated since version 9.1 and will be removed in 10.0. Use the showNotes() method instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->showNotes($project_id, $mr_id);
     }
 
     /**
@@ -173,9 +175,9 @@ class MergeRequests extends AbstractApi
      */
     public function addComment($project_id, $mr_id, $note)
     {
-        return $this->post($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id).'/comments'), array(
-            'note' => $note
-        ));
+        @trigger_error(sprintf('The %s() method is deprecated since version 9.1 and will be removed in 10.0. Use the addNote() method instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->addNote($project_id, $mr_id, $note);
     }
 
     /**

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -166,43 +166,6 @@ class MergeRequestsTest extends TestCase
     /**
      * @test
      */
-    public function shouldGetMergeRequestComments()
-    {
-        $expectedArray = array(
-            array('id' => 1, 'note' => 'A comment'),
-            array('id' => 2, 'note' => 'Another comment')
-        );
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('projects/1/merge_requests/2/comments')
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->showComments(1, 2));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldAddMergeRequestComment()
-    {
-        $expectedArray = array('id' => 2, 'title' => 'A comment');
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('post')
-            ->with('projects/1/merge_requests/2/comments', array('note' => 'A comment'))
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->addComment(1, 2, 'A comment'));
-    }
-
-    /**
-     * @test
-     */
     public function shouldGetMergeRequestChanges()
     {
         $expectedArray = array('id' => 1, 'title' => 'A merge request');


### PR DESCRIPTION
Comments have been removed in V4. We should use notes api instead.