### PR TITLE
#242 Gitlab/Model/MergeRequest methods fails on incorrect id usage

### DIFF
--- a/lib/Gitlab/Model/MergeRequest.php
+++ b/lib/Gitlab/Model/MergeRequest.php
@@ -105,7 +105,7 @@ class MergeRequest extends AbstractModel implements Noteable
      */
     public function show()
     {
-        $data = $this->client->mergeRequests()->show($this->project->id, $this->id);
+        $data = $this->client->mergeRequests()->show($this->project->id, $this->iid);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -116,7 +116,7 @@ class MergeRequest extends AbstractModel implements Noteable
      */
     public function update(array $params)
     {
-        $data = $this->client->mergeRequests()->update($this->project->id, $this->id, $params);
+        $data = $this->client->mergeRequests()->update($this->project->id, $this->iid, $params);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -160,7 +160,7 @@ class MergeRequest extends AbstractModel implements Noteable
      */
     public function merge($message = null)
     {
-        $data = $this->client->mergeRequests()->merge($this->project->id, $this->id, array(
+        $data = $this->client->mergeRequests()->merge($this->project->id, $this->iid, array(
             'merge_commit_message' => $message
         ));
 
@@ -183,7 +183,7 @@ class MergeRequest extends AbstractModel implements Noteable
      */
     public function addComment($comment)
     {
-        $data = $this->client->mergeRequests()->addComment($this->project->id, $this->id, $comment);
+        $data = $this->client->mergeRequests()->addComment($this->project->id, $this->iid, $comment);
 
         return Note::fromArray($this->getClient(), $this, $data);
     }
@@ -194,7 +194,7 @@ class MergeRequest extends AbstractModel implements Noteable
     public function showComments()
     {
         $notes = array();
-        $data = $this->client->mergeRequests()->showComments($this->project->id, $this->id);
+        $data = $this->client->mergeRequests()->showComments($this->project->id, $this->iid);
 
         foreach ($data as $note) {
             $notes[] = Note::fromArray($this->getClient(), $this, $note);
@@ -220,7 +220,7 @@ class MergeRequest extends AbstractModel implements Noteable
      */
     public function changes()
     {
-        $data = $this->client->mergeRequests()->changes($this->project->id, $this->id);
+        $data = $this->client->mergeRequests()->changes($this->project->id, $this->iid);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }


### PR DESCRIPTION
* Adjusted the model to use the iid instead of id.