### PR TITLE
Issues API: Add support for 'scope' parameter

### DIFF
--- a/lib/Gitlab/Api/Issues.php
+++ b/lib/Gitlab/Api/Issues.php
@@ -10,6 +10,7 @@ class Issues extends AbstractApi
      *     @var string $labels    Comma-separated list of label names, issues must have all labels to be returned.
      *                            No+Label lists all issues with no labels.
      *     @var string $milestone The milestone title.
+     *     @var string scope      Return issues for the given scope: created-by-me, assigned-to-me or all. Defaults to created-by-me
      *     @var int[]  $iids      Return only the issues having the given iid.
      *     @var string $order_by  Return requests ordered by created_at or updated_at fields. Default is created_at.
      *     @var string $sort      Return requests sorted in asc or desc order. Default is desc.
@@ -32,6 +33,9 @@ class Issues extends AbstractApi
             ->setAllowedValues('iids', function (array $value) {
                 return count($value) == count(array_filter($value, 'is_int'));
             })
+        ;
+        $resolver->setDefined('scope')
+            ->setAllowedValues('scope', ['created-by-me', 'assigned-to-me', 'all'])
         ;
         $resolver->setDefined('order_by')
             ->setAllowedValues('order_by', ['created_at', 'updated_at'])


### PR DESCRIPTION
Adds support for the 'scope' parameter introduced in GitLab 9.5 [See Issue API](https://docs.gitlab.com/ee/api/issues.html)