### PR TITLE
Added missing property 'start_date' to Milestone model

### DIFF
--- a/lib/Gitlab/Model/Milestone.php
+++ b/lib/Gitlab/Model/Milestone.php
@@ -11,6 +11,7 @@ use Gitlab\Client;
  * @property-read string $title
  * @property-read string $description
  * @property-read string $due_date
+ * @property-read string $start_date
  * @property-read string $state
  * @property-read bool $closed
  * @property-read string $updated_at
@@ -30,6 +31,7 @@ class Milestone extends AbstractModel
         'title',
         'description',
         'due_date',
+        'start_date',
         'state',
         'closed',
         'updated_at',


### PR DESCRIPTION
`MIlestone` property `start_date` was missed. Documentation: https://docs.gitlab.com/ce/api/milestones.html

This property exists in both v3 and v4 APIs.