### PR TITLE
Issues API: Bugfixing in update and show an issue (Issue: #254)

### DIFF
--- a/lib/Gitlab/Model/Issue.php
+++ b/lib/Gitlab/Model/Issue.php
@@ -80,7 +80,7 @@ class Issue extends AbstractModel implements Noteable
      */
     public function show()
     {
-        $data = $this->client->issues()->show($this->project->id, $this->id);
+        $data = $this->client->issues()->show($this->project->id, $this->iid);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }
@@ -91,7 +91,7 @@ class Issue extends AbstractModel implements Noteable
      */
     public function update(array $params)
     {
-        $data = $this->client->issues()->update($this->project->id, $this->id, $params);
+        $data = $this->client->issues()->update($this->project->id, $this->iid, $params);
 
         return static::fromArray($this->getClient(), $this->project, $data);
     }


### PR DESCRIPTION
need the `iid` (not the `id`) for `show()` and `update()`.
See also:
- for show: https://docs.gitlab.com/ee/api/issues.html#single-issue
- for update: https://docs.gitlab.com/ee/api/issues.html#edit-issue