### PR TITLE
Add ext-xml as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
 	],
 	"require": {
 		"php": "^5.6 || ^7.0",
+		"ext-xml": "*",
 		"php-http/client-common": "^1.5",
 		"php-http/client-implementation": "^1.0",
 		"php-http/discovery": "^1.2",


### PR DESCRIPTION
Without ext-xml a fatal error can occur because of the absence of utf8_encode().

Fixes #260