### PR TITLE
Add can_push option to deploy key creation

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -381,13 +381,15 @@ class Projects extends AbstractApi
      * @param int $project_id
      * @param string $title
      * @param string $key
+     * @param bool $canPush
      * @return mixed
      */
-    public function addDeployKey($project_id, $title, $key)
+    public function addDeployKey($project_id, $title, $key, $canPush = false)
     {
         return $this->post($this->getProjectPath($project_id, 'deploy_keys'), array(
             'title' => $title,
-            'key' => $key
+            'key' => $key,
+            'can_push' => $canPush
         ));
     }
 

--- a/lib/Gitlab/Model/Project.php
+++ b/lib/Gitlab/Model/Project.php
@@ -330,11 +330,12 @@ class Project extends AbstractModel
     /**
      * @param string $title
      * @param string $key
+     * @param bool $canPush
      * @return Key
      */
-    public function addDeployKey($title, $key)
+    public function addDeployKey($title, $key, $canPush = false)
     {
-        $data = $this->client->projects()->addDeployKey($this->id, $title, $key);
+        $data = $this->client->projects()->addDeployKey($this->id, $title, $key, $canPush);
 
         return Key::fromArray($this->getClient(), $data);
     }

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -577,16 +577,33 @@ class ProjectsTest extends TestCase
      */
     public function shouldAddKey()
     {
-        $expectedArray = array('id' => 3, 'title' => 'new-key');
+        $expectedArray = array('id' => 3, 'title' => 'new-key', 'can_push' => false);
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('projects/1/deploy_keys', array('title' => 'new-key', 'key' => '...'))
+            ->with('projects/1/deploy_keys', array('title' => 'new-key', 'key' => '...', 'can_push' => false))
             ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->addDeployKey(1, 'new-key', '...'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAddKeyWithPushOption()
+    {
+        $expectedArray = array('id' => 3, 'title' => 'new-key', 'can_push' => true);
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/deploy_keys', array('title' => 'new-key', 'key' => '...', 'can_push' => true))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->addDeployKey(1, 'new-key', '...', true));
     }
 
     /**


### PR DESCRIPTION
Closes #264 

The `can_push` option is set to false as default like the GitLab API behavior.

IMHO, it should be released on a patch version because it's a missing option fix.