### PR TITLE
Branches containing a slash break v4 branch endpoints. #263

### DIFF
--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -22,7 +22,7 @@ class Repositories extends AbstractApi
      */
     public function branch($project_id, $branch_id)
     {
-        return $this->get($this->getProjectPath($project_id, 'repository/branches/'.$this->encodeBranch($branch_id)));
+        return $this->get($this->getProjectPath($project_id, 'repository/branches/'.$this->encodePath($branch_id)));
     }
 
     /**
@@ -46,7 +46,7 @@ class Repositories extends AbstractApi
      */
     public function deleteBranch($project_id, $branch)
     {
-        return $this->delete($this->getProjectPath($project_id, 'repository/branches/'.$this->encodeBranch($branch)));
+        return $this->delete($this->getProjectPath($project_id, 'repository/branches/'.$this->encodePath($branch)));
     }
 
     /**
@@ -58,7 +58,7 @@ class Repositories extends AbstractApi
      */
     public function protectBranch($project_id, $branch_name, $devPush = false, $devMerge = false)
     {
-        return $this->put($this->getProjectPath($project_id, 'repository/branches/'.$this->encodeBranch($branch_name).'/protect'), array(
+        return $this->put($this->getProjectPath($project_id, 'repository/branches/'.$this->encodePath($branch_name).'/protect'), array(
             'developers_can_push' => $devPush,
             'developers_can_merge' => $devMerge
         ));
@@ -71,7 +71,7 @@ class Repositories extends AbstractApi
      */
     public function unprotectBranch($project_id, $branch_name)
     {
-        return $this->put($this->getProjectPath($project_id, 'repository/branches/'.$this->encodeBranch($branch_name).'/unprotect'));
+        return $this->put($this->getProjectPath($project_id, 'repository/branches/'.$this->encodePath($branch_name).'/unprotect'));
     }
 
     /**
@@ -111,7 +111,7 @@ class Repositories extends AbstractApi
      */
     public function createRelease($project_id, $tag_name, $description)
     {
-        return $this->post($this->getProjectPath($project_id, 'repository/tags/' . $this->encodeBranch($tag_name) . '/release'), array(
+        return $this->post($this->getProjectPath($project_id, 'repository/tags/' . $this->encodePath($tag_name) . '/release'), array(
             'id'          => $project_id,
             'tag_name'    => $tag_name,
             'description' => $description
@@ -127,7 +127,7 @@ class Repositories extends AbstractApi
      */
     public function updateRelease($project_id, $tag_name, $description)
     {
-        return $this->put($this->getProjectPath($project_id, 'repository/tags/' . $this->encodeBranch($tag_name) . '/release'), array(
+        return $this->put($this->getProjectPath($project_id, 'repository/tags/' . $this->encodePath($tag_name) . '/release'), array(
             'id'          => $project_id,
             'tag_name'    => $tag_name,
             'description' => $description
@@ -279,7 +279,7 @@ class Repositories extends AbstractApi
     {
         return $this->get($this->getProjectPath(
             $project_id,
-            'repository/compare?from='.$this->encodeBranch($fromShaOrMaster).'&to='.$this->encodeBranch($toShaOrMaster)
+            'repository/compare?from='.$this->encodePath($fromShaOrMaster).'&to='.$this->encodePath($toShaOrMaster)
         ));
     }
 
@@ -421,16 +421,5 @@ class Repositories extends AbstractApi
     public function archive($project_id, $params = array(), $format = 'tar.gz')
     {
         return $this->get($this->getProjectPath($project_id, 'repository/archive.'.$format), $params);
-    }
-
-    /**
-     * @param string $path
-     * @return string
-     */
-    protected function encodeBranch($path)
-    {
-        $path = $this->encodePath($path);
-
-        return str_replace('%2F', '/', $path);
     }
 }

--- a/test/Gitlab/Tests/Api/RepositoriesTest.php
+++ b/test/Gitlab/Tests/Api/RepositoriesTest.php
@@ -68,11 +68,11 @@ class RepositoriesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('delete')
-            ->with('projects/1/repository/branches/master')
+            ->with('projects/1/repository/branches/feature%2FTEST-15')
             ->will($this->returnValue($expectedBool))
         ;
 
-        $this->assertEquals($expectedBool, $api->deleteBranch(1, 'master'));
+        $this->assertEquals($expectedBool, $api->deleteBranch(1, 'feature/TEST-15'));
     }
 
     /**


### PR DESCRIPTION
Hello.
This is my attempt to fix #263.

I tested only `Delete branch` endpoint, cause this is the only one we are using here right now.
I completely removed `encodeBranch` function being guided by #86 pull request, which we kinda reverting now.

upd:
by "tested" i mean on real gitlab installation, not just unit.