### PR TITLE
Suggest OAuth2-GitLab client

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ Framework Integrations
 
 If you have integrated GitLab into a popular PHP framework, let us know!
 
+OAuth2 authentication
+---------------------
+If you want to access the API on behalf of a specific user, use https://github.com/omines/oauth2-gitlab to get an access
+token via OAuth2. 
+
 Contributing
 ------------
 


### PR DESCRIPTION
Since many use cases of the API client involve acting on behalf of a consenting user the manual should recommend how to do that.