### PR TITLE
Pagination of project members

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "m4tthumphrey/php-gitlab-api",
+	"name": "psi-dev-group/php-gitlab-api",
 	"type": "library",
 	"description": "GitLab API client",
 	"homepage": "https://github.com/m4tthumphrey/php-gitlab-api",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "psi-dev-group/php-gitlab-api",
+	"name": "m4tthumphrey/php-gitlab-api",
 	"type": "library",
 	"description": "GitLab API client",
 	"homepage": "https://github.com/m4tthumphrey/php-gitlab-api",

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -178,12 +178,16 @@ class Projects extends AbstractApi
     /**
      * @param int $project_id
      * @param string $username_query
+     * @param int $page
+     * @param int $per_page
      * @return mixed
      */
-    public function members($project_id, $username_query = null)
+    public function members($project_id, $username_query = null, $page = 1, $per_page = self::PER_PAGE)
     {
         return $this->get($this->getProjectPath($project_id, 'members'), array(
-            'query' => $username_query
+            'query' => $username_query,
+            'page' => $page,
+            'per_page' => $per_page
         ));
     }
 


### PR DESCRIPTION
GitLab API per default defines 20 items per_page for the returned result. Now if a project has more than 20 members we have an issue with increasing the number of items to max i.e. 100.

Therefore I complemented your code.

Many thanks!