### PR TITLE
Pagination of Project Members

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -268,6 +268,7 @@ class Projects extends AbstractApi
             
             return $this->get($this->getProjectPath($project_id, 'members'), $resolver->resolve($parameters));
         } elseif (is_string($parameters)) {
+            @trigger_error("Deprecated: String parameter of the members() function is deprecated.", E_USER_NOTICE);
             return $this->get($this->getProjectPath($project_id, 'members'), array(
                 'query' => $parameters
             ));

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -268,7 +268,6 @@ class Projects extends AbstractApi
             
             return $this->get($this->getProjectPath($project_id, 'members'), $resolver->resolve($parameters));
         } elseif (is_string($parameters)) {
-            trigger_error("Deprecated: String parameter of the members() function is deprecated.", E_USER_NOTICE);
             return $this->get($this->getProjectPath($project_id, 'members'), array(
                 'query' => $parameters
             ));

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -252,7 +252,7 @@ class Projects extends AbstractApi
      *
      * @return mixed
      */
-    public function members($project_id, $parameters)
+    public function members($project_id, $parameters = [])
     {
         if (!is_array($parameters)) {
             @trigger_error("Deprecated: String parameter of the members() function is deprecated.", E_USER_NOTICE);

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -267,7 +267,7 @@ class Projects extends AbstractApi
             $resolver->setDefined('per_page');
 
             return $this->get($this->getProjectPath($project_id, 'members'), $resolver->resolve($parameters));
-        } else if (is_string($parameters)) {
+        } elseif (is_string($parameters)) {
             trigger_error("Deprecated: String parameter of the members() function is deprecated.", E_USER_NOTICE);
             return $this->get($this->getProjectPath($project_id, 'members'), array(
                 'query' => $parameters

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -252,9 +252,9 @@ class Projects extends AbstractApi
      *
      * @return mixed
      */
-    public function members($project_id, $parameters = null)
+    public function members($project_id, $parameters = [])
     {
-        if (is_array($parameters) || is_null($parameters)) {
+        if (is_array($parameters)) {
             $resolver = $this->createOptionsResolver();
 
             $resolver->setDefaults(array(

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -242,12 +242,16 @@ class Projects extends AbstractApi
     /**
      * @param int $project_id
      * @param string $username_query
+     * @param int $page
+     * @param int $per_page
      * @return mixed
      */
-    public function members($project_id, $username_query = null)
+    public function members($project_id, $username_query = null, $page = 1, $per_page = self::PER_PAGE)
     {
         return $this->get($this->getProjectPath($project_id, 'members'), array(
-            'query' => $username_query
+            'query' => $username_query,
+            'page' => $page,
+            'per_page' => $per_page
         ));
     }
 

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -252,9 +252,9 @@ class Projects extends AbstractApi
      *
      * @return mixed
      */
-    public function members($project_id, $parameters = [])
+    public function members($project_id, $parameters = null)
     {
-        if (is_array($parameters)) {
+        if (is_array($parameters) || is_null($parameters)) {
             $resolver = $this->createOptionsResolver();
 
             $resolver->setDefaults(array(
@@ -262,10 +262,10 @@ class Projects extends AbstractApi
                 'per_page' => 20,
             ));
 
-            $resolver->setRequired('query');
+            $resolver->setDefined('query');
             $resolver->setDefined('page');
             $resolver->setDefined('per_page');
-
+            
             return $this->get($this->getProjectPath($project_id, 'members'), $resolver->resolve($parameters));
         } elseif (is_string($parameters)) {
             trigger_error("Deprecated: String parameter of the members() function is deprecated.", E_USER_NOTICE);

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -241,18 +241,38 @@ class Projects extends AbstractApi
 
     /**
      * @param int $project_id
-     * @param string $username_query
-     * @param int $page
-     * @param int $per_page
+     * @param array $parameters (
+     *
+     *     @var string $query           The query you want to search members for.
+     *     @var string $page            The page you want to take members from. (default: 1)
+     *     @var string $per_page        The count of members per page. (default: 20)
+     * )
+     *
+     * @throws MissingOptionsException  If a required option is not provided
+     *
      * @return mixed
      */
-    public function members($project_id, $username_query = null, $page = 1, $per_page = self::PER_PAGE)
+    public function members($project_id, $parameters = null)
     {
-        return $this->get($this->getProjectPath($project_id, 'members'), array(
-            'query' => $username_query,
-            'page' => $page,
-            'per_page' => $per_page
-        ));
+        if (is_array($parameters) || $parameters == null) {
+            $resolver = $this->createOptionsResolver();
+
+            $resolver->setDefaults(array(
+                'page' => 1,
+                'per_page' => 20,
+            ));
+
+            $resolver->setRequired('query');
+            $resolver->setDefined('page');
+            $resolver->setDefined('per_page');
+
+            return $this->get($this->getProjectPath($project_id, 'members'), $resolver->resolve($parameters));
+        } else if (is_string($parameters)) {
+            trigger_error("Deprecated: String parameter of the members() function is deprecated.", E_USER_NOTICE);
+            return $this->get($this->getProjectPath($project_id, 'members'), array(
+                'query' => $parameters
+            ));
+        }
     }
 
     /**

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -252,33 +252,35 @@ class Projects extends AbstractApi
      *
      * @return mixed
      */
-    public function members($project_id, $parameters = [])
+    public function members($project_id, $parameters)
     {
-        if (is_array($parameters)) {
-            $resolver = $this->createOptionsResolver();
-
-            $resolver->setDefaults(array(
-                'page' => 1,
-                'per_page' => 20,
-            ));
-
-            $resolver->setDefined('query')
-                ->setAllowedTypes('query', 'string')
-            ;
-            $resolver->setDefined('page')
-                ->setAllowedTypes('page', 'int')
-            ;
-            $resolver->setDefined('per_page')
-                ->setAllowedTypes('per_page', 'int')
-            ;
-            
-            return $this->get($this->getProjectPath($project_id, 'members'), $resolver->resolve($parameters));
-        } elseif (is_string($parameters)) {
+        if (!is_array($parameters)) {
             @trigger_error("Deprecated: String parameter of the members() function is deprecated.", E_USER_NOTICE);
-            return $this->get($this->getProjectPath($project_id, 'members'), array(
-                'query' => $parameters
-            ));
+            $username_query = $parameters;
+            $parameters = array();
+            if (!empty($username_query)) {
+                $parameters['query'] = $username_query;
+            }
         }
+
+        $resolver = $this->createOptionsResolver();
+
+        $resolver->setDefaults(array(
+            'page' => 1,
+            'per_page' => 20,
+        ));
+
+        $resolver->setDefined('query')
+            ->setAllowedTypes('query', 'string')
+        ;
+        $resolver->setDefined('page')
+            ->setAllowedTypes('page', 'int')
+        ;
+        $resolver->setDefined('per_page')
+            ->setAllowedTypes('per_page', 'int')
+        ;
+
+        return $this->get($this->getProjectPath($project_id, 'members'), $resolver->resolve($parameters));
     }
 
     /**

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -252,9 +252,9 @@ class Projects extends AbstractApi
      *
      * @return mixed
      */
-    public function members($project_id, $parameters = null)
+    public function members($project_id, $parameters = [])
     {
-        if (is_array($parameters) || $parameters == null) {
+        if (is_array($parameters)) {
             $resolver = $this->createOptionsResolver();
 
             $resolver->setDefaults(array(

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -262,9 +262,15 @@ class Projects extends AbstractApi
                 'per_page' => 20,
             ));
 
-            $resolver->setDefined('query');
-            $resolver->setDefined('page');
-            $resolver->setDefined('per_page');
+            $resolver->setDefined('query')
+                ->setAllowedTypes('query', 'string')
+            ;
+            $resolver->setDefined('page')
+                ->setAllowedTypes('page', 'int')
+            ;
+            $resolver->setDefined('per_page')
+                ->setAllowedTypes('per_page', 'int')
+            ;
             
             return $this->get($this->getProjectPath($project_id, 'members'), $resolver->resolve($parameters));
         } elseif (is_string($parameters)) {

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -338,7 +338,7 @@ class ProjectsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/members', array('query' => 'at'))
+            ->with('projects/1/members', array('query' => 'at', 'page' => 1, 'per_page' => 20))
             ->will($this->returnValue($expectedArray))
         ;
 

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -348,6 +348,26 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetMembersWithNullQuery()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'name' => 'Matt'),
+            array('id' => 2, 'name' => 'Bob')
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/members', array('page' => 1, 'per_page' => 20))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->members(1, null));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetMember()
     {
         $expectedArray = array('id' => 2, 'name' => 'Matt');


### PR DESCRIPTION
GitLab API per default defines 20 items per_page for the returned result. Now if a project has more than 20 members we have an issue with increasing the number of items to max i.e. 100.

Therefore I complemented your code.

Many thanks!