### PR TITLE
Updating merge request api

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -11,12 +11,14 @@ class MergeRequests extends AbstractApi
     const STATE_CLOSED = 'closed';
 
     /**
-     * @param int   $project_id
+     * @param int|null   $project_id               Return the merge requests for all projects or a specific project
      * @param array $parameters {
      *
      *     @var int[]              $iids           Return the request having the given iid.
      *     @var string             $state          Return all merge requests or just those that are opened, closed, or
      *                                             merged.
+     *     @var string             $scope          Return merge requests for the given scope: created-by-me,
+     *                                             assigned-to-me or all. Defaults to created-by-me.
      *     @var string             $order_by       Return requests ordered by created_at or updated_at fields. Default
      *                                             is created_at.
      *     @var string             $sort           Return requests sorted in asc or desc order. Default is desc.
@@ -33,7 +35,7 @@ class MergeRequests extends AbstractApi
      *
      * @return mixed
      */
-    public function all($project_id, array $parameters = [])
+    public function all($project_id = null, array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
         $datetimeNormalizer = function (\DateTimeInterface $value) {
@@ -45,8 +47,12 @@ class MergeRequests extends AbstractApi
                 return count($value) == count(array_filter($value, 'is_int'));
             })
         ;
+
         $resolver->setDefined('state')
             ->setAllowedValues('state', ['all', 'opened', 'merged', 'closed'])
+        ;
+        $resolver->setDefined('scope')
+            ->setAllowedValues('scope', ['created-by-me', 'assigned-to-me', 'all'])
         ;
         $resolver->setDefined('order_by')
             ->setAllowedValues('order_by', ['created_at', 'updated_at'])
@@ -68,7 +74,9 @@ class MergeRequests extends AbstractApi
             ->setNormalizer('created_before', $datetimeNormalizer)
         ;
 
-        return $this->get($this->getProjectPath($project_id, 'merge_requests'), $resolver->resolve($parameters));
+        $path = $project_id === null ? 'merge_requests' : $this->getProjectPath($project_id, 'merge_requests');
+
+        return $this->get($path, $resolver->resolve($parameters));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -25,6 +25,23 @@ class MergeRequestsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetAllWithNoProject()
+    {
+        $expectedArray = $this->getMultipleMergeRequestsData();
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('merge_requests', array())
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->all());
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetAllWithParams()
     {
         $expectedArray = $this->getMultipleMergeRequestsData();
@@ -32,11 +49,11 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_requests', ['page' => 2, 'per_page' => 5, 'order_by' => 'updated_at', 'sort' => 'desc'])
+            ->with('projects/1/merge_requests', ['page' => 2, 'per_page' => 5, 'order_by' => 'updated_at', 'sort' => 'desc', 'scope' => 'all'])
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->all(1, ['page' => 2, 'per_page' => 5, 'order_by' => 'updated_at', 'sort' => 'desc']));
+        $this->assertEquals($expectedArray, $api->all(1, ['page' => 2, 'per_page' => 5, 'order_by' => 'updated_at', 'sort' => 'desc', 'scope' => 'all']));
     }
 
     /**


### PR DESCRIPTION
Added scope to merge request api and have made project_id optional on the merge request which was added in Gitlab 9.5 https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-requests 