### PR TITLE
add environment & deployment class to api + add stop environment function

### DIFF
--- a/lib/Gitlab/Api/Environments.php
+++ b/lib/Gitlab/Api/Environments.php
@@ -45,4 +45,14 @@ class Environments extends AbstractApi
     {
         return $this->delete($this->getProjectPath($project_id, 'environments/' . $environment_id));
     }
+
+    /**
+     * @param int $project_id
+     * @param string $environment_id
+     * @return mixed
+     */
+    public function stop($project_id, $environment_id)
+    {
+        return $this->post($this->getProjectPath($project_id, 'environments/'.$this->encodePath($environment_id).'/stop'));
+    }
 }

--- a/lib/Gitlab/Client.php
+++ b/lib/Gitlab/Client.php
@@ -255,6 +255,22 @@ class Client
     }
 
     /**
+     * @return Api\Deployments
+     */
+    public function deployments()
+    {
+        return new Api\Deployments($this);
+    }
+
+    /**
+     * @return Api\Environments
+     */
+    public function environments()
+    {
+        return new Api\Environments($this);
+    }
+
+    /**
      * @param string $name
      *
      * @return AbstractApi|mixed
@@ -316,6 +332,12 @@ class Client
 
             case 'version':
                 return $this->version();
+
+            case 'environments':
+                return $this->environments();
+
+            case 'deployments':
+                return $this->deployments();
 
             default:
                 throw new InvalidArgumentException('Invalid endpoint: "'.$name.'"');

--- a/test/Gitlab/Tests/Api/EnvironmentsTest.php
+++ b/test/Gitlab/Tests/Api/EnvironmentsTest.php
@@ -73,6 +73,21 @@ class EnvironmentsTest extends TestCase
         $this->assertEquals($expectedBool, $api->remove(1, 3));
     }
 
+    /**
+     * @test
+     */
+    public function shouldStopEnvironment()
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/environments/3/stop')
+            ->will($this->returnValue($expectedBool));
+        $this->assertEquals($expectedBool, $api->stop(1, 3));
+    }
+
     protected function getApiClass()
     {
         return 'Gitlab\Api\Environments';


### PR DESCRIPTION
the delete function only deletes the environment from the gitlab-database.
the stop function executes the stop action, defined in the gitlab ci yml for the environment.