### PR TITLE
Create merge request 500 error fix

### DIFF
--- a/lib/Gitlab/Model/Project.php
+++ b/lib/Gitlab/Model/Project.php
@@ -724,7 +724,7 @@ class Project extends AbstractModel
      */
     public function createMergeRequest($source, $target, $title, $assignee = null, $description = null)
     {
-        $data = $this->client->mergeRequests()->create($this->id, $source, $target, $title, $assignee, null, $description);
+        $data = $this->client->mergeRequests()->create($this->id, $source, $target, $title, $assignee, $this->id, $description);
 
         return MergeRequest::fromArray($this->getClient(), $this, $data);
     }


### PR DESCRIPTION
Parameter target_project_id must be filled otherwise if it is null gitlab returns 500 internal server error