### PR TITLE
Added support for the path parameter to the commits endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "m4tthumphrey/php-gitlab-api",
+	"name": "thomx12/php-gitlab-api",
 	"type": "library",
 	"description": "GitLab API client",
 	"homepage": "https://github.com/m4tthumphrey/php-gitlab-api",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "thomx12/php-gitlab-api",
+	"name": "m4tthumphrey/php-gitlab-api",
 	"type": "library",
 	"description": "GitLab API client",
 	"homepage": "https://github.com/m4tthumphrey/php-gitlab-api",

--- a/lib/Gitlab/Api/Groups.php
+++ b/lib/Gitlab/Api/Groups.php
@@ -1,5 +1,7 @@
 <?php namespace Gitlab\Api;
 
+use Symfony\Component\OptionsResolver\Options;
+
 class Groups extends AbstractApi
 {
     /**
@@ -18,7 +20,7 @@ class Groups extends AbstractApi
     public function all(array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
-        $booleanNormalizer = function ($value) {
+        $booleanNormalizer = function (Options $resolver, $value) {
             return $value ? 'true' : 'false';
         };
 
@@ -180,7 +182,7 @@ class Groups extends AbstractApi
     public function projects($id, array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
-        $booleanNormalizer = function ($value) {
+        $booleanNormalizer = function (Options $resolver, $value) {
             return $value ? 'true' : 'false';
         };
 

--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -1,5 +1,6 @@
 <?php namespace Gitlab\Api;
 
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 
@@ -36,7 +37,7 @@ class MergeRequests extends AbstractApi
     public function all($project_id, array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
-        $datetimeNormalizer = function (\DateTimeInterface $value) {
+        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value) {
             return $value->format('c');
         };
         $resolver->setDefined('iids')

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -1,5 +1,6 @@
 <?php namespace Gitlab\Api;
 
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -33,7 +34,7 @@ class Projects extends AbstractApi
     public function all(array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
-        $booleanNormalizer = function ($value) {
+        $booleanNormalizer = function (Options $resolver, $value) {
             return $value ? 'true' : 'false';
         };
         $resolver->setDefined('archived')
@@ -171,7 +172,7 @@ class Projects extends AbstractApi
     public function pipelines($project_id, array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
-        $booleanNormalizer = function ($value) {
+        $booleanNormalizer = function (Options $resolver, $value) {
             return $value ? 'true' : 'false';
         };
 
@@ -430,7 +431,7 @@ class Projects extends AbstractApi
     public function events($project_id, array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
-        $datetimeNormalizer = function (\DateTimeInterface $value) {
+        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value) {
             return $value->format('Y-m-d');
         };
 

--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -152,6 +152,7 @@ class Repositories extends AbstractApi
             return $value->format('c');
         };
 
+        $resolver->setDefined('path');
         $resolver->setDefined('ref_name');
         $resolver->setDefined('since')
             ->setAllowedTypes('since', \DateTimeInterface::class)

--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -1,5 +1,6 @@
 <?php namespace Gitlab\Api;
 
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class Repositories extends AbstractApi
@@ -148,7 +149,7 @@ class Repositories extends AbstractApi
     public function commits($project_id, array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
-        $datetimeNormalizer = function (\DateTimeInterface $value) {
+        $datetimeNormalizer = function (Options $options, \DateTimeInterface $value) {
             return $value->format('c');
         };
 
@@ -213,7 +214,7 @@ class Repositories extends AbstractApi
             ->setAllowedValues('actions', function (array $actions) {
                 return !empty($actions);
             })
-            ->setNormalizer('actions', function (OptionsResolver $resolver, array $actions) {
+            ->setNormalizer('actions', function (Options $resolver, array $actions) {
                 $actionsOptionsResolver = new OptionsResolver();
                 $actionsOptionsResolver->setDefined('action')
                     ->setRequired('action')

--- a/lib/Gitlab/Api/Users.php
+++ b/lib/Gitlab/Api/Users.php
@@ -1,5 +1,7 @@
 <?php namespace Gitlab\Api;
 
+use Symfony\Component\OptionsResolver\Options;
+
 class Users extends AbstractApi
 {
     /**
@@ -21,7 +23,7 @@ class Users extends AbstractApi
     public function all(array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
-        $datetimeNormalizer = function (\DateTimeInterface $value) {
+        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value) {
             return $value->format('c');
         };
 

--- a/test/Gitlab/Tests/Api/GroupsTest.php
+++ b/test/Gitlab/Tests/Api/GroupsTest.php
@@ -27,6 +27,46 @@ class GroupsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetAllGroupsWithBooleanParam()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'name' => 'A group'),
+            array('id' => 2, 'name' => 'Another group'),
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups', ['all_available' => 'false'])
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->all(['all_available' => false]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetAllGroupProjectsWithBooleanParam()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'name' => 'A group'),
+            array('id' => 2, 'name' => 'Another group'),
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/projects', ['archived' => 'false'])
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->projects(1, ['archived' => false]));
+    }
+
+    /**
+     * @test
+     */
     public function shouldNotNeedPaginationWhenGettingGroups()
     {
         $expectedArray = array(

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -42,6 +42,34 @@ class MergeRequestsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetAllWithDateTimeParams()
+    {
+        $expectedArray = $this->getMultipleMergeRequestsData();
+
+        $createdAfter = new \DateTime('2018-01-01 00:00:00');
+        $createdBefore = new \DateTime('2018-01-31 00:00:00');
+
+        $expectedWithArray = [
+            'created_after' => $createdAfter->format(DATE_ATOM),
+            'created_before' => $createdBefore->format(DATE_ATOM),
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/merge_requests', $expectedWithArray)
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals(
+            $expectedArray,
+            $api->all(1, ['created_after' => $createdAfter, 'created_before' => $createdBefore])
+        );
+    }
+
+    /**
+     * @test
+     */
     public function shouldShowMergeRequest()
     {
         $expectedArray = array('id' => 2, 'name' => 'A merge request');

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -73,6 +73,18 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetNotArchivedProjects()
+    {
+        $expectedArray = $this->getMultipleProjectsData();
+
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['archived' => 'false']);
+
+        $this->assertEquals($expectedArray, $api->all(['archived' => false]));
+    }
+
+    /**
+     * @test
+     */
     public function shouldSearchProjects()
     {
         $expectedArray = $this->getMultipleProjectsData();
@@ -226,6 +238,27 @@ class ProjectsTest extends TestCase
         ;
 
         $this->assertEquals($expectedArray, $api->pipelines(1));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetPipelinesWithBooleanParam()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'status' => 'success','ref' => 'new-pipeline'),
+            array('id' => 2, 'status' => 'failed', 'ref' => 'new-pipeline'),
+            array('id' => 3, 'status' => 'pending', 'ref'=> 'test-pipeline')
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/pipelines', ['yaml_errors' => 'false'])
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->pipelines(1, ['yaml_errors' => false]));
     }
 
     /**
@@ -658,6 +691,34 @@ class ProjectsTest extends TestCase
         ;
 
         $this->assertEquals($expectedArray, $api->events(1));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetEventsWithDateTimeParams()
+    {
+        $expectedArray = [
+            ['id' => 1, 'title' => 'An event'],
+            ['id' => 2, 'title' => 'Another event']
+        ];
+
+        $after = new \DateTime('2018-01-01 00:00:00');
+        $before = new \DateTime('2018-01-31 00:00:00');
+
+        $expectedWithArray = [
+            'after' => $after->format('Y-m-d'),
+            'before' => $before->format('Y-m-d'),
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/events', $expectedWithArray)
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->events(1, ['after' => $after, 'before' => $before]));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/RepositoriesTest.php
+++ b/test/Gitlab/Tests/Api/RepositoriesTest.php
@@ -260,6 +260,34 @@ class RepositoriesTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetCommitsWithTimeParams()
+    {
+        $expectedArray = [
+            ['id' => 'abcd1234', 'title' => 'A commit'],
+            ['id' => 'efgh5678', 'title' => 'Another commit']
+        ];
+
+        $since = new \DateTime('2018-01-01 00:00:00');
+        $until = new \DateTime('2018-01-31 00:00:00');
+
+        $expectedWithArray = [
+            'since' => $since->format(DATE_ATOM),
+            'until' => $until->format(DATE_ATOM),
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/repository/commits', $expectedWithArray)
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->commits(1, ['since' => $since, 'until' => $until]));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetCommit()
     {
         $expectedArray = array('id' => 'abcd1234', 'title' => 'A commit');

--- a/test/Gitlab/Tests/Api/RepositoriesTest.php
+++ b/test/Gitlab/Tests/Api/RepositoriesTest.php
@@ -250,11 +250,11 @@ class RepositoriesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/repository/commits', array('page' => 2, 'per_page' => 25, 'ref_name' => 'master'))
+            ->with('projects/1/repository/commits', array('page' => 2, 'per_page' => 25, 'ref_name' => 'master', 'path' => 'file_path/file_name'))
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->commits(1, ['page' => 2, 'per_page' => 25, 'ref_name' => 'master']));
+        $this->assertEquals($expectedArray, $api->commits(1, ['page' => 2, 'per_page' => 25, 'ref_name' => 'master', 'path' => 'file_path/file_name']));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/UsersTest.php
+++ b/test/Gitlab/Tests/Api/UsersTest.php
@@ -47,6 +47,37 @@ class UsersTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetUsersWithDateTimeParams()
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'Matt'],
+            ['id' => 2, 'name' => 'John'],
+        ];
+
+        $createdAfter = new \DateTime('2018-01-01 00:00:00');
+        $createdBefore = new \DateTime('2018-01-31 00:00:00');
+
+        $expectedWithArray = [
+            'created_after' => $createdAfter->format(DATE_ATOM),
+            'created_before' => $createdBefore->format(DATE_ATOM),
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('users', $expectedWithArray)
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals(
+            $expectedArray,
+            $api->all(['created_after' => $createdAfter, 'created_before' => $createdBefore])
+        );
+    }
+
+    /**
+     * @test
+     */
     public function shouldShowUser()
     {
         $expectedArray = array('id' => 1, 'name' => 'Matt');


### PR DESCRIPTION
Though not documented, [there is support for the path parameter in the gitlab commits API](https://gitlab.com/gitlab-org/gitlab-ce/commit/146d4348ca6812e26729de40a831f4ae8c27fde6). So I thought it should be implemented here as well.
