### PR TITLE
Use the plugin client factory in the http client builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require": {
 		"php": "^5.6 || ^7.0",
 		"ext-xml": "*",
-		"php-http/client-common": "^1.5",
+		"php-http/client-common": "^1.6",
 		"php-http/client-implementation": "^1.0",
 		"php-http/discovery": "^1.2",
 		"php-http/httplug": "^1.1",

--- a/lib/Gitlab/HttpClient/Builder.php
+++ b/lib/Gitlab/HttpClient/Builder.php
@@ -5,6 +5,7 @@ namespace Gitlab\HttpClient;
 use Http\Client\Common\HttpMethodsClient;
 use Http\Client\Common\Plugin;
 use Http\Client\Common\PluginClient;
+use Http\Client\Common\PluginClientFactory;
 use Http\Client\HttpClient;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\MessageFactoryDiscovery;
@@ -81,7 +82,7 @@ class Builder
             $this->httpClientModified = false;
 
             $this->pluginClient = new HttpMethodsClient(
-                new PluginClient($this->httpClient, $this->plugins),
+                (new PluginClientFactory())->createClient($this->httpClient, $this->plugins),
                 $this->requestFactory
             );
         }


### PR DESCRIPTION
This is a minor change that we need to do in increase the developer experience for Symfony users. This will make our custom plugins visible in the Symfony debug toolbar.

---

Related to https://github.com/KnpLabs/php-github-api/pull/687.