### PR TITLE
iid instead of id in issue contruct

### DIFF
--- a/lib/Gitlab/Model/Issue.php
+++ b/lib/Gitlab/Model/Issue.php
@@ -50,7 +50,7 @@ class Issue extends AbstractModel implements Noteable
      */
     public static function fromArray(Client $client, Project $project, array $data)
     {
-        $issue = new static($project, $data['id'], $client);
+        $issue = new static($project, $data['iid'], $client);
 
         if (isset($data['author'])) {
             $data['author'] = User::fromArray($client, $data['author']);
@@ -65,14 +65,14 @@ class Issue extends AbstractModel implements Noteable
 
     /**
      * @param Project $project
-     * @param int $id
+     * @param int $iid
      * @param Client $client
      */
-    public function __construct(Project $project, $id = null, Client $client = null)
+    public function __construct(Project $project, $iid = null, Client $client = null)
     {
         $this->setClient($client);
         $this->setData('project', $project);
-        $this->setData('id', $id);
+        $this->setData('iid', $iid);
     }
 
     /**

--- a/lib/Gitlab/Model/Project.php
+++ b/lib/Gitlab/Model/Project.php
@@ -807,47 +807,47 @@ class Project extends AbstractModel
     }
 
     /**
-     * @param int $id
+     * @param int $iid
      * @return Issue
      */
-    public function issue($id)
+    public function issue($iid)
     {
-        $issue = new Issue($this, $id, $this->getClient());
+        $issue = new Issue($this, $iid, $this->getClient());
 
         return $issue->show();
     }
 
     /**
-     * @param int $id
+     * @param int $iid
      * @param array $params
      * @return Issue
      */
-    public function updateIssue($id, array $params)
+    public function updateIssue($iid, array $params)
     {
-        $issue = new Issue($this, $id, $this->getClient());
+        $issue = new Issue($this, $iid, $this->getClient());
 
         return $issue->update($params);
     }
 
     /**
-     * @param int $id
+     * @param int $iid
      * @param string $comment
      * @return Issue
      */
-    public function closeIssue($id, $comment = null)
+    public function closeIssue($iid, $comment = null)
     {
-        $issue = new Issue($this, $id, $this->getClient());
+        $issue = new Issue($this, $iid, $this->getClient());
 
         return $issue->close($comment);
     }
 
     /**
-     * @param int $id
+     * @param int $iid
      * @return Issue
      */
-    public function openIssue($id)
+    public function openIssue($iid)
     {
-        $issue = new Issue($this, $id, $this->getClient());
+        $issue = new Issue($this, $iid, $this->getClient());
 
         return $issue->open();
     }

--- a/test/Gitlab/Tests/Model/IssueTest.php
+++ b/test/Gitlab/Tests/Model/IssueTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Gitlab\Tests\Model;
+
+use Gitlab\Client;
+use Gitlab\Model\Issue;
+use Gitlab\Model\Project;
+
+class IssueTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCorrectConstructWithoutIidAndClient()
+    {
+        $project = new Project();
+
+        $sUT = new Issue($project);
+
+        $this->assertSame($project, $sUT->project);
+        $this->assertSame(null, $sUT->iid);
+        $this->assertSame(null, $sUT->getClient());
+    }
+
+    public function testCorrectConstructWithoutClient()
+    {
+        $project = new Project();
+
+        $sUT = new Issue($project, 10);
+
+        $this->assertSame($project, $sUT->project);
+        $this->assertSame(10, $sUT->iid);
+        $this->assertSame(null, $sUT->getClient());
+    }
+
+    public function testCorrectConstruct()
+    {
+        $project = new Project();
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $sUT = new Issue($project, 10, $client);
+
+        $this->assertSame($project, $sUT->project);
+        $this->assertSame(10, $sUT->iid);
+        $this->assertSame($client, $sUT->getClient());
+    }
+
+    public function testFromArray()
+    {
+        $project = new Project();
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $sUT = Issue::fromArray($client, $project, ['iid' => 10]);
+
+        $this->assertSame($project, $sUT->project);
+        $this->assertSame(10, $sUT->iid);
+        $this->assertSame($client, $sUT->getClient());
+    }
+}


### PR DESCRIPTION
Hello,

This MR is related to #229 and fix the following use case : 

```php
<?php
$client = \Gitlab\Client::create('http://mygitlab.com')->authenticate('myToken',\Gitlab\Client::AUTH_URL_TOKEN);
$project = new Project(31,$client);

$project->closeIssue(1,"this is the end"); // iid is use as identifier in https://github.com/cube43/php-gitlab-api/blob/067b183b07f86caadd3662a681f61406ffa3d3a5/lib/Gitlab/Model/Issue.php#L94
$project->openIssue(1); // iid is use as identifier in https://github.com/cube43/php-gitlab-api/blob/067b183b07f86caadd3662a681f61406ffa3d3a5/lib/Gitlab/Model/Issue.php#L94
$project->updateIssue(2,array('assignee_id'=>1)); // iid is use as identifier in https://github.com/cube43/php-gitlab-api/blob/067b183b07f86caadd3662a681f61406ffa3d3a5/lib/Gitlab/Model/Issue.php#L94
$project->issue(2); // iid is use as identifier in https://github.com/cube43/php-gitlab-api/blob/067b183b07f86caadd3662a681f61406ffa3d3a5/lib/Gitlab/Model/Issue.php#L83

```

Thanks for your work