### PR TITLE
removed pagination parameters default values and validation for project members

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -245,8 +245,6 @@ class Projects extends AbstractApi
      * @param array $parameters (
      *
      *     @var string $query           The query you want to search members for.
-     *     @var string $page            The page you want to take members from. (default: 1)
-     *     @var string $per_page        The count of members per page. (default: 20)
      * )
      *
      * @throws MissingOptionsException  If a required option is not provided
@@ -266,19 +264,8 @@ class Projects extends AbstractApi
 
         $resolver = $this->createOptionsResolver();
 
-        $resolver->setDefaults(array(
-            'page' => 1,
-            'per_page' => 20,
-        ));
-
         $resolver->setDefined('query')
             ->setAllowedTypes('query', 'string')
-        ;
-        $resolver->setDefined('page')
-            ->setAllowedTypes('page', 'int')
-        ;
-        $resolver->setDefined('per_page')
-            ->setAllowedTypes('per_page', 'int')
         ;
 
         return $this->get($this->getProjectPath($project_id, 'members'), $resolver->resolve($parameters));

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -371,7 +371,7 @@ class ProjectsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/members', array('query' => 'at', 'page' => 1, 'per_page' => 20))
+            ->with('projects/1/members', array('query' => 'at'))
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -391,11 +391,34 @@ class ProjectsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/members', array('page' => 1, 'per_page' => 20))
+            ->with('projects/1/members')
             ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->members(1, null));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetMembersWithPagination()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'name' => 'Matt'),
+            array('id' => 2, 'name' => 'Bob')
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/members', array(
+                'page' => 2,
+                'per_page' => 15
+            ))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->members(1, array('page' => 2, 'per_page' => 15)));
     }
 
     /**


### PR DESCRIPTION
After the merge of #281 I realized that we don't need the validation of the parameters "page" and "per_page" since it will be validated by the gitlab api itself.

Therefore I removed the validation and default values for these parameters but also added a test for getting the project members with pagination.

@m1guelpf  Sorry that I've noticed only now.