### PR TITLE
encode $job_name

### DIFF
--- a/lib/Gitlab/Api/Jobs.php
+++ b/lib/Gitlab/Api/Jobs.php
@@ -81,7 +81,7 @@ class Jobs extends AbstractApi
     public function artifactsByRefName($project_id, $ref_name, $job_name)
     {
         return $this->getAsResponse("projects/".$this->encodePath($project_id)."/jobs/artifacts/".$this->encodePath($ref_name)."/download", array(
-            'job' => $job_name
+            'job' => $this->encodePath($job_name)
         ))->getBody();
     }
 


### PR DESCRIPTION
In the method `artifactsByRefName()` the $job_name is not encoded.
I guess that should be done to avoid errors