### PR TITLE
Extend create groups api

### DIFF
--- a/lib/Gitlab/Api/Groups.php
+++ b/lib/Gitlab/Api/Groups.php
@@ -67,16 +67,26 @@ class Groups extends AbstractApi
      * @param string $path
      * @param string $description
      * @param string $visibility
+     * @param bool   $lfs_enabled
+     * @param bool   $request_access_enabled
+     * @param int    $parent_id
+     * @param int    $shared_runners_minutes_limit
      * @return mixed
      */
-    public function create($name, $path, $description = null, $visibility = 'private')
+    public function create($name, $path, $description = null, $visibility = 'private', $lfs_enabled = null, $request_access_enabled = null, $parent_id = null, $shared_runners_minutes_limit = null)
     {
-        return $this->post('groups', array(
+        $params = array(
             'name' => $name,
             'path' => $path,
             'description' => $description,
             'visibility' => $visibility,
-        ));
+            'lfs_enabled' => $lfs_enabled,
+            'request_access_enabled' => $request_access_enabled,
+            'parent_id' => $parent_id,
+            'shared_runners_minutes_limit' => $shared_runners_minutes_limit,
+        );
+
+        return $this->post('groups', array_filter($params, 'strlen'));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/GroupsTest.php
+++ b/test/Gitlab/Tests/Api/GroupsTest.php
@@ -127,9 +127,9 @@ class GroupsTest extends TestCase
 
         $api = $this->getApiMock();
         $api->expects($this->once())
-        ->method('post')
-        ->with('groups', array('name' => 'A new group', 'path' => 'a-new-group', 'description' => 'Description', 'visibility' => 'public'))
-        ->will($this->returnValue($expectedArray))
+            ->method('post')
+            ->with('groups', array('name' => 'A new group', 'path' => 'a-new-group', 'description' => 'Description', 'visibility' => 'public'))
+            ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->create('A new group', 'a-new-group', 'Description', 'public'));
@@ -144,9 +144,9 @@ class GroupsTest extends TestCase
 
         $api = $this->getApiMock();
         $api->expects($this->once())
-        ->method('post')
-        ->with('groups', array('name' => 'A new group', 'path' => 'a-new-group', 'description' => 'Description', 'visibility' => 'public', 'parent_id' => 666))
-        ->will($this->returnValue($expectedArray))
+            ->method('post')
+            ->with('groups', array('name' => 'A new group', 'path' => 'a-new-group', 'description' => 'Description', 'visibility' => 'public', 'parent_id' => 666))
+            ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->create('A new group', 'a-new-group', 'Description', 'public', null, null, 666));

--- a/test/Gitlab/Tests/Api/GroupsTest.php
+++ b/test/Gitlab/Tests/Api/GroupsTest.php
@@ -111,11 +111,28 @@ class GroupsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('groups', array('name' => 'A new group', 'path' => 'a-new-group', 'description' => null, 'visibility' => 'private'))
+            ->with('groups', array('name' => 'A new group', 'path' => 'a-new-group', 'visibility' => 'private'))
             ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->create('A new group', 'a-new-group'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateGroupWithDescriptionVisibilityAndParentId()
+    {
+        $expectedArray = array('id' => 1, 'name' => 'A new group', 'visibility_level' => 2, 'parent_id' => 666);
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('groups', array('name' => 'A new group', 'path' => 'a-new-group', 'description' => 'Description', 'visibility' => 'public', 'parent_id' => 666))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->create('A new group', 'a-new-group', 'Description', 'public', null, null, 666));
     }
 
     /**
@@ -127,9 +144,9 @@ class GroupsTest extends TestCase
 
         $api = $this->getApiMock();
         $api->expects($this->once())
-            ->method('post')
-            ->with('groups', array('name' => 'A new group', 'path' => 'a-new-group', 'description' => 'Description', 'visibility' => 'public'))
-            ->will($this->returnValue($expectedArray))
+        ->method('post')
+        ->with('groups', array('name' => 'A new group', 'path' => 'a-new-group', 'description' => 'Description', 'visibility' => 'public'))
+        ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->create('A new group', 'a-new-group', 'Description', 'public'));

--- a/test/Gitlab/Tests/Api/GroupsTest.php
+++ b/test/Gitlab/Tests/Api/GroupsTest.php
@@ -121,23 +121,6 @@ class GroupsTest extends TestCase
     /**
      * @test
      */
-    public function shouldCreateGroupWithDescriptionVisibilityAndParentId()
-    {
-        $expectedArray = array('id' => 1, 'name' => 'A new group', 'visibility_level' => 2, 'parent_id' => 666);
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('post')
-            ->with('groups', array('name' => 'A new group', 'path' => 'a-new-group', 'description' => 'Description', 'visibility' => 'public', 'parent_id' => 666))
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->create('A new group', 'a-new-group', 'Description', 'public', null, null, 666));
-    }
-
-    /**
-     * @test
-     */
     public function shouldCreateGroupWithDescriptionAndVisibility()
     {
         $expectedArray = array('id' => 1, 'name' => 'A new group', 'visibility_level' => 2);
@@ -150,6 +133,23 @@ class GroupsTest extends TestCase
         ;
 
         $this->assertEquals($expectedArray, $api->create('A new group', 'a-new-group', 'Description', 'public'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateGroupWithDescriptionVisibilityAndParentId()
+    {
+        $expectedArray = array('id' => 1, 'name' => 'A new group', 'visibility_level' => 2, 'parent_id' => 666);
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+        ->method('post')
+        ->with('groups', array('name' => 'A new group', 'path' => 'a-new-group', 'description' => 'Description', 'visibility' => 'public', 'parent_id' => 666))
+        ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->create('A new group', 'a-new-group', 'Description', 'public', null, null, 666));
     }
 
     /**


### PR DESCRIPTION
This PR will add additional fields (optionally) as described here: https://docs.gitlab.com/ce/api/groups.html#new-group

I had to "filter" out `null` values as it would else return a 500 from gitlab.com. `description` is optional anyways, so it can be removed if `null`.