### PR TITLE
Update Projects.php

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -84,7 +84,7 @@ class Projects extends AbstractApi
     }
 
     /**
-     * @param int $project_id
+     * @param int|string $project_id
      * @param array $parameters {
      *
      *     @var bool   $statistics                    Include project statistics.


### PR DESCRIPTION
PHPStan complains about $project_id type in show method. 
I have added string type to @param for better compatibility with api.
Gitlab Api docs states, that id can be integer or string url encoded path of the project.
(https://docs.gitlab.com/ee/api/projects.html)
