### PR TITLE
Use QueryStringBuilder in AbstractAPI::put

### DIFF
--- a/lib/Gitlab/Api/AbstractApi.php
+++ b/lib/Gitlab/Api/AbstractApi.php
@@ -8,6 +8,7 @@ use Http\Discovery\StreamFactoryDiscovery;
 use Http\Message\MultipartStream\MultipartStreamBuilder;
 use Http\Message\StreamFactory;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -89,7 +90,7 @@ abstract class AbstractApi implements ApiInterface
 
         $body = null;
         if (empty($files) && !empty($parameters)) {
-            $body = $this->streamFactory->createStream(QueryStringBuilder::build($parameters));
+            $body = $this->prepareBody($parameters);
             $requestHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
         } elseif (!empty($files)) {
             $builder = new MultipartStreamBuilder($this->streamFactory);
@@ -128,7 +129,7 @@ abstract class AbstractApi implements ApiInterface
 
         $body = null;
         if (!empty($parameters)) {
-            $body = $this->streamFactory->createStream(http_build_query($parameters));
+            $body = $this->prepareBody($parameters);
             $requestHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
         }
 
@@ -195,6 +196,18 @@ abstract class AbstractApi implements ApiInterface
         ;
 
         return $resolver;
+    }
+
+    /**
+     * @param array $parameters
+     * @return StreamInterface
+     */
+    private function prepareBody(array $parameters = [])
+    {
+        $raw = QueryStringBuilder::build($parameters);
+        $stream = $this->streamFactory->createStream($raw);
+
+        return $stream;
     }
 
     private function preparePath($path, array $parameters = [])

--- a/test/Gitlab/Tests/Api/AbstractApiTest.php
+++ b/test/Gitlab/Tests/Api/AbstractApiTest.php
@@ -1,0 +1,59 @@
+<?php namespace Gitlab\Tests\Api;
+
+use Gitlab\Client;
+use Http\Client\HttpClient;
+use ReflectionClass;
+
+class AbstractApiTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldPrepareBodyWithCleanArrays()
+    {
+        $parameters = [
+            'array_param' => [
+                'value1',
+                'value2'
+            ]
+        ];
+        $expectedBody = 'array_param[]=value1&array_param[]=value2';
+
+        $abstractApiMock = $this->getAbstractApiMock();
+        $reflection = new ReflectionClass(get_class($abstractApiMock));
+        $method = $reflection->getMethod('prepareBody');
+        $method->setAccessible(true);
+        $stream = $method->invokeArgs(
+            $abstractApiMock,
+            [
+                $parameters
+            ]
+        );
+
+        $this->assertEquals($expectedBody, urldecode((string)$stream));
+    }
+
+    protected function getAbstractApiMock(array $methods = [])
+    {
+        $httpClient = $this->getMockBuilder(HttpClient::class)
+            ->setMethods(array('sendRequest'))
+            ->getMock()
+        ;
+        $httpClient
+            ->expects($this->any())
+            ->method('sendRequest')
+        ;
+        $client = Client::createWithHttpClient($httpClient);
+
+        $abstractApiMock = $this->getMockBuilder('Gitlab\Api\AbstractApi')
+            ->setConstructorArgs([
+                $client,
+                null
+            ])
+            ->setMethods($methods)
+            ->getMockForAbstractClass()
+        ;
+
+        return $abstractApiMock;
+    }
+}


### PR DESCRIPTION
Replace http_build_query to avoid issues with array parameters.

For example : 
```
$merge_request = new GitlabMergeRequest(
    [...]
);
$merge_request = $merge_request->show();
$merge_request->update([
    'labels' => ['Needs review']
]);
```

will currently return an "invalid labels" error.