### PR TITLE
Adding redirect plugin for Artifact downloads

### DIFF
--- a/lib/Gitlab/Client.php
+++ b/lib/Gitlab/Client.php
@@ -11,6 +11,7 @@ use Http\Client\Common\HttpMethodsClient;
 use Http\Client\Common\Plugin\AddHostPlugin;
 use Http\Client\Common\Plugin\HeaderDefaultsPlugin;
 use Http\Client\Common\Plugin\HistoryPlugin;
+use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Client\HttpClient;
 use Http\Discovery\UriFactoryDiscovery;
 
@@ -85,6 +86,7 @@ class Client
         $this->httpClientBuilder->addPlugin(new HeaderDefaultsPlugin([
             'User-Agent' => 'php-gitlab-api (http://github.com/m4tthumphrey/php-gitlab-api)',
         ]));
+        $this->httpClientBuilder->addPlugin(new RedirectPlugin());
 
         $this->setUrl('https://gitlab.com');
     }


### PR DESCRIPTION
On gitlab.com, the artifacts can be sometimes moved to Amazon S3. In this event, the call to the API will not return the artifact but will return an HTTP 302 code.

See 

- https://gitlab.com/gitlab-org/gitlab-ee/merge_requests/5168
- https://github.com/thecodingmachine/washingmachine/issues/23#issuecomment-411488680

We need to follow this redirect to download the artifact.
The current HTTP client does not follow redirects automatically.

This PR simply adds the "RedirectPlugin" to the list of plugins of the HTTP client. Therefore, the HTTP client will follow the redirects and return the artifact as expected.