### PR TITLE
Add methods for managing emails for users

### DIFF
--- a/lib/Gitlab/Api/Users.php
+++ b/lib/Gitlab/Api/Users.php
@@ -265,6 +265,36 @@ class Users extends AbstractApi
 
     /**
      * @param int $user_id
+     * @return mixed
+     */
+    public function userEmails($user_id)
+    {
+        return $this->get('users/'.$this->encodePath($user_id).'/emails');
+    }
+
+    /**
+     * @param int $user_id
+     * @param string $email
+     * @return mixed
+     */
+    public function createEmailForUser($user_id, $email)
+    {
+        return $this->post('users/'.$this->encodePath($user_id).'/emails', array(
+            'email' => $email,
+        ));
+    }
+
+    /**
+     * @param int $user_id
+     * @param int $email_id
+     * @return mixed
+     */
+    public function removeUserEmail($user_id, $email_id) {
+        return $this->delete('users/'.$this->encodePath($user_id).'/emails/'.$this->encodePath($email_id));
+    }
+
+    /**
+     * @param int $user_id
      * @param array $params
      * @return mixed
      */

--- a/lib/Gitlab/Api/Users.php
+++ b/lib/Gitlab/Api/Users.php
@@ -289,7 +289,8 @@ class Users extends AbstractApi
      * @param int $email_id
      * @return mixed
      */
-    public function removeUserEmail($user_id, $email_id) {
+    public function removeUserEmail($user_id, $email_id)
+    {
         return $this->delete('users/'.$this->encodePath($user_id).'/emails/'.$this->encodePath($email_id));
     }
 

--- a/test/Gitlab/Tests/Api/UsersTest.php
+++ b/test/Gitlab/Tests/Api/UsersTest.php
@@ -429,6 +429,60 @@ class UsersTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetEmailsForUser()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'email' => 'foo@bar.baz'),
+            array('id' => 2, 'email' => 'foo@bar.qux'),
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('users/1/emails')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->userEmails(1));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateEmailForUser()
+    {
+        $expectedArray = array('id' => 3, 'email' => 'foo@bar.example');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('users/1/emails', array('email' => 'foo@bar.example'))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->createEmailForUser(1, 'foo@bar.example'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldDeleteEmailForUser()
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('users/1/emails/3')
+            ->will($this->returnValue($expectedBool))
+        ;
+
+        $this->assertEquals($expectedBool, $api->removeUserEmail(1, 3));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetCurrentUserImpersonationTokens()
     {
         $expectedArray = array(


### PR DESCRIPTION
This adds integrations for:
- https://docs.gitlab.com/ce/api/users.html#list-emails-for-user
- https://docs.gitlab.com/ce/api/users.html#add-email-for-user
- https://docs.gitlab.com/ce/api/users.html#delete-email-for-given-user