### PR TITLE
Update parameters according to https://docs.gitlab.com/ee/api/commits…

### DIFF
--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -162,6 +162,8 @@ class Repositories extends AbstractApi
             ->setAllowedTypes('until', \DateTimeInterface::class)
             ->setNormalizer('until', $datetimeNormalizer)
         ;
+        $resolver->setDefined('all');
+        $resolver->setDefined('with_stats');
 
         return $this->get($this->getProjectPath($project_id, 'repository/commits'), $resolver->resolve($parameters));
     }

--- a/test/Gitlab/Tests/Api/RepositoriesTest.php
+++ b/test/Gitlab/Tests/Api/RepositoriesTest.php
@@ -250,11 +250,11 @@ class RepositoriesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/repository/commits', array('page' => 2, 'per_page' => 25, 'ref_name' => 'master'))
+            ->with('projects/1/repository/commits', array('page' => 2, 'per_page' => 25, 'ref_name' => 'master', 'all' => true, 'with_stats' => true))
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->commits(1, ['page' => 2, 'per_page' => 25, 'ref_name' => 'master']));
+        $this->assertEquals($expectedArray, $api->commits(1, ['page' => 2, 'per_page' => 25, 'ref_name' => 'master', 'all' => true, 'with_stats' => true]));
     }
 
     /**


### PR DESCRIPTION
Allow the "all" and "with_stats" parameters for the commits API endpoint.
As documented here: https://docs.gitlab.com/ee/api/commits.html