### PR TITLE
Add the more paremeters to the MergeRequests api call

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -68,8 +68,29 @@ class MergeRequests extends AbstractApi
             ->setAllowedTypes('created_before', \DateTimeInterface::class)
             ->setNormalizer('created_before', $datetimeNormalizer)
         ;
+
+        $resolver->setDefined('updated_after')
+            ->setAllowedTypes('updated_after', \DateTimeInterface::class)
+            ->setNormalizer('updated_after', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('updated_before')
+            ->setAllowedTypes('updated_before', \DateTimeInterface::class)
+            ->setNormalizer('updated_before', $datetimeNormalizer)
+        ;
+
+        $resolver->setDefined('scope')
+            ->setAllowedValues('scope', ['created_by_me', 'assigned_to_me', 'all'])
+        ;
+        $resolver->setDefined('author_id')
+            ->setAllowedTypes('author_id', 'integer');
+
+        $resolver->setDefined('assignee_id')
+            ->setAllowedTypes('assignee_id', 'integer');
+
         $resolver->setDefined('search');
-        
+        $resolver->setDefined('source_branch');
+        $resolver->setDefined('target_branch');
+
         return $this->get($this->getProjectPath($project_id, 'merge_requests'), $resolver->resolve($parameters));
     }
 

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -1,6 +1,5 @@
 <?php namespace Gitlab\Tests\Api;
 
-use Gitlab\Api\AbstractApi;
 use Gitlab\Api\MergeRequests;
 
 class MergeRequestsTest extends TestCase
@@ -32,11 +31,37 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_requests', ['page' => 2, 'per_page' => 5, 'order_by' => 'updated_at', 'sort' => 'desc'])
+            ->with('projects/1/merge_requests', [
+                'page' => 2,
+                'per_page' => 5,
+                'labels' => 'label1,label2,label3',
+                'milestone' => 'milestone1',
+                'order_by' => 'updated_at',
+                'state' => 'all',
+                'sort' => 'desc',
+                'scope' => 'all',
+                'author_id' => 1,
+                'assignee_id' => 1,
+                'source_branch' => 'develop',
+                'target_branch' => 'master',
+            ])
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->all(1, ['page' => 2, 'per_page' => 5, 'order_by' => 'updated_at', 'sort' => 'desc']));
+        $this->assertEquals($expectedArray, $api->all(1, [
+            'page' => 2,
+            'per_page' => 5,
+            'labels' => 'label1,label2,label3',
+            'milestone' => 'milestone1',
+            'order_by' => 'updated_at',
+            'state' => 'all',
+            'sort' => 'desc',
+            'scope' => 'all',
+            'author_id' => 1,
+            'assignee_id' => 1,
+            'source_branch' => 'develop',
+            'target_branch' => 'master',
+        ]));
     }
 
     /**


### PR DESCRIPTION
The new fields are:
updated_after
updated_before
scope
author_id
assignee_id
sourche_branch
target_branch

(I added more fields in the test because they where in the class but not in the test)

See https://docs.gitlab.com/ce/api/merge_requests.html#list-project-merge-requests for more details