### PR TITLE
Upgrade the BuilderTest to use getMockBuilder and not the deprecated getMock function

### DIFF
--- a/test/Gitlab/Tests/HttpClient/BuilderTest.php
+++ b/test/Gitlab/Tests/HttpClient/BuilderTest.php
@@ -22,9 +22,9 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->subject = new Builder(
-            $this->createMock(HttpClient::class),
-            $this->createMock(RequestFactory::class),
-            $this->createMock(StreamFactory::class)
+            $this->getMockBuilder(HttpClient::class)->getMock(),
+            $this->getMockBuilder(RequestFactory::class)->getMock(),
+            $this->getMockBuilder(StreamFactory::class)->getMock()
         );
     }
 
@@ -32,14 +32,14 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
     {
         $client = $this->subject->getHttpClient();
 
-        $this->subject->addPlugin($this->createMock(Plugin::class));
+        $this->subject->addPlugin($this->getMockBuilder(Plugin::class)->getMock());
 
         $this->assertNotSame($client, $this->subject->getHttpClient());
     }
 
     public function testRemovePluginShouldInvalidateHttpClient()
     {
-        $this->subject->addPlugin($this->createMock(Plugin::class));
+        $this->subject->addPlugin($this->getMockBuilder(Plugin::class)->getMock());
 
         $client = $this->subject->getHttpClient();
 

--- a/test/Gitlab/Tests/HttpClient/BuilderTest.php
+++ b/test/Gitlab/Tests/HttpClient/BuilderTest.php
@@ -22,9 +22,9 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->subject = new Builder(
-            $this->getMock(HttpClient::class),
-            $this->getMock(RequestFactory::class),
-            $this->getMock(StreamFactory::class)
+            $this->createMock(HttpClient::class),
+            $this->createMock(RequestFactory::class),
+            $this->createMock(StreamFactory::class)
         );
     }
 
@@ -32,14 +32,14 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
     {
         $client = $this->subject->getHttpClient();
 
-        $this->subject->addPlugin($this->getMock(Plugin::class));
+        $this->subject->addPlugin($this->createMock(Plugin::class));
 
         $this->assertNotSame($client, $this->subject->getHttpClient());
     }
 
     public function testRemovePluginShouldInvalidateHttpClient()
     {
-        $this->subject->addPlugin($this->getMock(Plugin::class));
+        $this->subject->addPlugin($this->createMock(Plugin::class));
 
         $client = $this->subject->getHttpClient();
 


### PR DESCRIPTION
I found this while working on #351 

Before this change I got this while running phpunit:

```
There were 3 warnings:

1) Gitlab\Tests\HttpClient\BuilderTest::testAddPluginShouldInvalidateHttpClient
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

2) Gitlab\Tests\HttpClient\BuilderTest::testRemovePluginShouldInvalidateHttpClient
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

3) Gitlab\Tests\HttpClient\BuilderTest::testHttpClientShouldBeAnHttpMethodsClient
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead
```