### PR TITLE
Add parameters to get project labels

### DIFF
--- a/lib/Gitlab/Api/IssueBoards.php
+++ b/lib/Gitlab/Api/IssueBoards.php
@@ -22,6 +22,47 @@ class IssueBoards extends AbstractApi
      * @param int $board_id
      * @return mixed
      */
+    public function show($project_id, $board_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'boards/'.$this->encodePath($board_id)));
+    }
+
+    /**
+     * @param int $project_id
+     * @param array $params
+     * @return mixed
+     */
+    public function create($project_id, array $params)
+    {
+        return $this->post($this->getProjectPath($project_id, 'boards'), $params);
+    }
+
+    /**
+     * @param int $project_id
+     * @param int $board_id
+     * @param array $params
+     * @return mixed
+     */
+    public function update($project_id, $board_id, array $params)
+    {
+        return $this->put($this->getProjectPath($project_id, 'boards/'.$this->encodePath($board_id)), $params);
+    }
+
+    /**
+     * @param int $project_id
+     * @param int $board_id
+     * @return mixed
+     */
+    public function remove($project_id, $board_id)
+    {
+        return $this->delete($this->getProjectPath($project_id, 'boards/'.$this->encodePath($board_id)));
+    }
+
+    /**
+     * @param int $project_id
+     * @param int $board_id
+     * @return mixed
+     */
     public function allLists($project_id, $board_id)
     {
         return $this->get($this->getProjectPath($project_id, 'boards/'.$this->encodePath($board_id).'/lists'));

--- a/lib/Gitlab/Api/IssueBoards.php
+++ b/lib/Gitlab/Api/IssueBoards.php
@@ -48,12 +48,10 @@ class IssueBoards extends AbstractApi
     public function createList($project_id, $board_id, $label_id)
     {
         $params = array(
-            'id' => $project_id,
-            'board_id' => $board_id,
             'label_id' => $label_id
         );
 
-        return $this->get($this->getProjectPath($project_id, 'boards/'.$this->encodePath($board_id).'/lists'), $params);
+        return $this->post($this->getProjectPath($project_id, 'boards/'.$this->encodePath($board_id).'/lists'), $params);
     }
 
     /**

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -493,11 +493,14 @@ class Projects extends AbstractApi
 
     /**
      * @param int $project_id
+     * @param array $parameters
      * @return mixed
      */
-    public function labels($project_id)
+    public function labels($project_id, array $parameters = [])
     {
-        return $this->get($this->getProjectPath($project_id, 'labels'));
+        $resolver = $this->createOptionsResolver();
+
+        return $this->get($this->getProjectPath($project_id, 'labels'), $resolver->resolve($parameters));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/IssueBoardsTest.php
+++ b/test/Gitlab/Tests/Api/IssueBoardsTest.php
@@ -61,58 +61,75 @@ class IssueBoardsTest extends TestCase
     //
     //     $this->assertEquals($expectedArray, $api->all(1, 2, 5, array('order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'open')));
     // }
-    //
-    // /**
-    //  * @test
-    //  */
-    // public function shouldShowIssue()
-    // {
-    //     $expectedArray = array('id' => 2, 'title' => 'Another issue');
-    //
-    //     $api = $this->getApiMock();
-    //     $api->expects($this->once())
-    //         ->method('get')
-    //         ->with('projects/1/issues?iid=2')
-    //         ->will($this->returnValue($expectedArray))
-    //     ;
-    //
-    //     $this->assertEquals($expectedArray, $api->show(1, 2));
-    // }
-    //
-    // /**
-    //  * @test
-    //  */
-    // public function shouldCreateIssue()
-    // {
-    //     $expectedArray = array('id' => 3, 'title' => 'A new issue');
-    //
-    //     $api = $this->getApiMock();
-    //     $api->expects($this->once())
-    //         ->method('post')
-    //         ->with('projects/1/issues', array('title' => 'A new issue', 'labels' => 'foo,bar'))
-    //         ->will($this->returnValue($expectedArray))
-    //     ;
-    //
-    //     $this->assertEquals($expectedArray, $api->create(1, array('title' => 'A new issue', 'labels' => 'foo,bar')));
-    // }
-    //
-    // /**
-    //  * @test
-    //  */
-    // public function shouldUpdateIssue()
-    // {
-    //     $expectedArray = array('id' => 2, 'title' => 'A renamed issue');
-    //
-    //     $api = $this->getApiMock();
-    //     $api->expects($this->once())
-    //         ->method('put')
-    //         ->with('projects/1/issues/2', array('title' => 'A renamed issue', 'labels' => 'foo'))
-    //         ->will($this->returnValue($expectedArray))
-    //     ;
-    //
-    //     $this->assertEquals($expectedArray, $api->update(1, 2, array('title' => 'A renamed issue', 'labels' => 'foo')));
-    // }
-    //
+    
+    /**
+     * @test
+     */
+    public function shouldShowIssueBoard()
+    {
+        $expectedArray = array('id' => 2, 'name' => 'Another issue board');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/boards/2')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->show(1, 2));
+    }
+    
+    /**
+     * @test
+     */
+    public function shouldCreateIssueBoard()
+    {
+        $expectedArray = array('id' => 3, 'name' => 'A new issue board');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/boards', array('name' => 'A new issue board'))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->create(1, array('name' => 'A new issue board')));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUpdateIssueBoard()
+    {
+        $expectedArray = array('id' => 2, 'name' => 'A renamed issue board');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('projects/1/boards/2', array('name' => 'A renamed issue board', 'labels' => 'foo'))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->update(1, 2, array('name' => 'A renamed issue board', 'labels' => 'foo')));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRemoveIssueBoard()
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/boards/2')
+            ->will($this->returnValue($expectedBool))
+        ;
+
+        $this->assertEquals($expectedBool, $api->remove(1, 2));
+    }
+
     // /**
     //  * @test
     //  */


### PR DESCRIPTION
Couldn't get all the labels of a project due to the default limit of 20 per page.
Now we can pass optional paramaters to get project labels
ex: $parameters = ['page'=>1, 'per_page'=>100];