### PR TITLE
Correct Guzzle6 client example

### DIFF
--- a/doc/customize.md
+++ b/doc/customize.md
@@ -21,7 +21,7 @@ As timeout configuration is not compatible with HTTP client abstraction, you hav
 an explicit HTTP client implementation.
 
 ```php
-$httpClient = Http\Adapter\Guzzle6::createWithConfig([
+$httpClient = Http\Adapter\Guzzle6\Client::createWithConfig([
     'timeout' => 1.0
 ]);
 $client = Gitlab\Client::createWithHttpClient($httpClient);


### PR DESCRIPTION
Fixes class name in example code.