### PR TITLE
Add repository merge base API support

### DIFF
--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -460,4 +460,14 @@ class Repositories extends AbstractApi
     {
         return $this->get($this->getProjectPath($project_id, 'repository/archive.'.$format), $params);
     }
+
+    /**
+     * @param int $project_id
+     * @param array $refs
+     * @return mixed
+     */
+    public function mergeBase($project_id, $refs)
+    {
+        return $this->get($this->getProjectPath($project_id, 'repository/merge_base'), array('refs' => $refs));
+    }
 }

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -222,7 +222,7 @@ class ProjectsTest extends TestCase
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->archive(1, array('efgh5678efgh5678efgh5678efgh5678efgh5678', '1234567812345678123456781234567812345678')));
+        $this->assertEquals($expectedArray, $api->mergeBase(1, array('efgh5678efgh5678efgh5678efgh5678efgh5678', '1234567812345678123456781234567812345678')));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -196,6 +196,38 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetMergeBase()
+    {
+        $expectedArray = array(
+            'id' => 'abcd1234abcd1234abcd1234abcd1234abcd1234',
+            'short_id' => 'abcd1234',
+            'title' => 'A commit',
+            'created_at' => '2018-01-01T00:00:00.000Z',
+            'parent_ids' => array(
+               'efgh5678efgh5678efgh5678efgh5678efgh5678',
+            ),
+            'message' => 'A commit',
+            'author_name' => 'Jane Doe',
+            'author_email' => 'jane@example.org',
+            'authored_date' => '2018-01-01T00:00:00.000Z',
+            'committer_name' => 'Jane Doe',
+            'committer_email' => 'jane@example.org',
+            'committed_date' => '2018-01-01T00:00:00.000Z',
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/repository/merge_base', array('refs' => array('efgh5678efgh5678efgh5678efgh5678efgh5678', '1234567812345678123456781234567812345678')))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->archive(1, array('efgh5678efgh5678efgh5678efgh5678efgh5678', '1234567812345678123456781234567812345678')));
+    }
+
+    /**
+     * @test
+     */
     public function shouldUnarchiveProject()
     {
         $expectedArray = array('id' => 1, 'archived' => false);

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -196,38 +196,6 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
-    public function shouldGetMergeBase()
-    {
-        $expectedArray = array(
-            'id' => 'abcd1234abcd1234abcd1234abcd1234abcd1234',
-            'short_id' => 'abcd1234',
-            'title' => 'A commit',
-            'created_at' => '2018-01-01T00:00:00.000Z',
-            'parent_ids' => array(
-               'efgh5678efgh5678efgh5678efgh5678efgh5678',
-            ),
-            'message' => 'A commit',
-            'author_name' => 'Jane Doe',
-            'author_email' => 'jane@example.org',
-            'authored_date' => '2018-01-01T00:00:00.000Z',
-            'committer_name' => 'Jane Doe',
-            'committer_email' => 'jane@example.org',
-            'committed_date' => '2018-01-01T00:00:00.000Z',
-        );
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('projects/1/repository/merge_base', array('refs' => array('efgh5678efgh5678efgh5678efgh5678efgh5678', '1234567812345678123456781234567812345678')))
-            ->will($this->returnValue($expectedArray))
-        ;
-
-        $this->assertEquals($expectedArray, $api->mergeBase(1, array('efgh5678efgh5678efgh5678efgh5678efgh5678', '1234567812345678123456781234567812345678')));
-    }
-
-    /**
-     * @test
-     */
     public function shouldUnarchiveProject()
     {
         $expectedArray = array('id' => 1, 'archived' => false);

--- a/test/Gitlab/Tests/Api/RepositoriesTest.php
+++ b/test/Gitlab/Tests/Api/RepositoriesTest.php
@@ -515,6 +515,38 @@ class RepositoriesTest extends TestCase
         $this->assertEquals($expectedArray, $api->contributors(1));
     }
 
+    /**
+     * @test
+     */
+    public function shouldGetMergeBase()
+    {
+        $expectedArray = array(
+            'id' => 'abcd1234abcd1234abcd1234abcd1234abcd1234',
+            'short_id' => 'abcd1234',
+            'title' => 'A commit',
+            'created_at' => '2018-01-01T00:00:00.000Z',
+            'parent_ids' => array(
+               'efgh5678efgh5678efgh5678efgh5678efgh5678',
+            ),
+            'message' => 'A commit',
+            'author_name' => 'Jane Doe',
+            'author_email' => 'jane@example.org',
+            'authored_date' => '2018-01-01T00:00:00.000Z',
+            'committer_name' => 'Jane Doe',
+            'committer_email' => 'jane@example.org',
+            'committed_date' => '2018-01-01T00:00:00.000Z',
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/repository/merge_base', array('refs' => array('efgh5678efgh5678efgh5678efgh5678efgh5678', '1234567812345678123456781234567812345678')))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->mergeBase(1, array('efgh5678efgh5678efgh5678efgh5678efgh5678', '1234567812345678123456781234567812345678')));
+    }
+
     protected function getApiClass()
     {
         return 'Gitlab\Api\Repositories';


### PR DESCRIPTION
Adds support for an API endpoint GitLab added recently—https://docs.gitlab.com/ce/api/repositories.html#merge-base