### PR TITLE
Add missing Release support

### DIFF
--- a/lib/Gitlab/Api/Tags.php
+++ b/lib/Gitlab/Api/Tags.php
@@ -40,4 +40,26 @@ class Tags extends AbstractApi
     {
         return $this->delete($this->getProjectPath($project_id, 'repository/tags/'.$tag_name));
     }
+
+    /**
+     * @param int $project_id
+     * @param string $tag_name
+     * @param array $params
+     * @return mixed
+     */
+    public function createRelease($project_id, $tag_name, array $params = array())
+    {
+        return $this->post($this->getProjectPath($project_id, 'repository/tags/'.$tag_name.'/release'), $params);
+    }
+
+    /**
+     * @param int $project_id
+     * @param string $tag_name
+     * @param array $params
+     * @return mixed
+     */
+    public function updateRelease($project_id, $tag_name, array $params = array())
+    {
+        return $this->put($this->getProjectPath($project_id, 'repository/tags/'.$tag_name.'/release'), $params);
+    }
 }

--- a/test/Gitlab/Tests/Api/TagsTest.php
+++ b/test/Gitlab/Tests/Api/TagsTest.php
@@ -144,6 +144,7 @@ class TagsTest extends TestCase
         );
     }
 
+
     protected function getApiClass()
     {
         return 'Gitlab\Api\Tags';

--- a/test/Gitlab/Tests/Api/TagsTest.php
+++ b/test/Gitlab/Tests/Api/TagsTest.php
@@ -78,6 +78,72 @@ class TagsTest extends TestCase
         $this->assertEquals($expectedArray, $api->remove(1, 'v1.1.0'));
     }
 
+    /**
+     * @test
+     * @dataProvider releaseDataProvider
+     * @param string $releaseName
+     * @param string $description
+     * @param array $expectedResult
+     */
+    public function shouldCreateRelease($releaseName, $description, $expectedResult)
+    {
+        $params = array(
+            'description' => $description,
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/repository/tags/' . $releaseName . '/release', $params)
+            ->will($this->returnValue($expectedResult));
+
+        $this->assertEquals($expectedResult, $api->create(1, $params));
+    }
+
+    /**
+     * @test
+     * @dataProvider releaseDataProvider
+     * @param string $releaseName
+     * @param string $description
+     * @param array $expectedResult
+     */
+    public function shouldUpdateRelease($releaseName, $description, $expectedResult)
+    {
+        $params = array(
+            'description' => $description,
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('projects/1/repository/tags/' . $releaseName . '/release', $params)
+            ->will($this->returnValue($expectedResult));
+
+        $this->assertEquals($expectedResult, $api->create(1, $params));
+    }
+
+    public function releaseDataProvider()
+    {
+        return array(
+            array(
+                'tagName' => 'v1.1.0',
+                'description' => 'Amazing release. Wow',
+                'expectedResult' => array(
+                    'tag_name' => '1.0.0',
+                    'description' => 'Amazing release. Wow',
+                ),
+            ),
+            array(
+                'tagName' => urlencode('version/1.1.0'),
+                'description' => 'Amazing release. Wow',
+                'expectedResult' => array(
+                    'tag_name' => 'version/1.1.0',
+                    'description' => 'Amazing release. Wow',
+                ),
+            ),
+        );
+    }
+
     protected function getApiClass()
     {
         return 'Gitlab\Api\Tags';


### PR DESCRIPTION
Add missing Release support
https://docs.gitlab.com/ee/api/tags.html#create-a-new-release

example of usage:
`$client->tags()->createRelease($projectId, urlencode($tagName), [
     'description' => $description,
])`

`$client->tags()->updateRelease($projectId, urlencode($tagName), [
      'description' => $description,
]);`

