### PR TITLE
Properly escape $tag_name in Tags API

### DIFF
--- a/lib/Gitlab/Api/Tags.php
+++ b/lib/Gitlab/Api/Tags.php
@@ -18,7 +18,7 @@ class Tags extends AbstractApi
      */
     public function show($project_id, $tag_name)
     {
-        return $this->get($this->getProjectPath($project_id, 'repository/tags/'.$tag_name));
+        return $this->get($this->getProjectPath($project_id, 'repository/tags/'.$this->encodePath($tag_name)));
     }
 
     /**
@@ -28,7 +28,7 @@ class Tags extends AbstractApi
      */
     public function create($project_id, array $params = array())
     {
-        return $this->post($this->getProjectPath($project_id, "repository/tags"), $params);
+        return $this->post($this->getProjectPath($project_id, 'repository/tags'), $params);
     }
 
     /**
@@ -38,7 +38,7 @@ class Tags extends AbstractApi
      */
     public function remove($project_id, $tag_name)
     {
-        return $this->delete($this->getProjectPath($project_id, 'repository/tags/'.$tag_name));
+        return $this->delete($this->getProjectPath($project_id, 'repository/tags/'.$this->encodePath($tag_name)));
     }
 
     /**
@@ -49,7 +49,7 @@ class Tags extends AbstractApi
      */
     public function createRelease($project_id, $tag_name, array $params = array())
     {
-        return $this->post($this->getProjectPath($project_id, 'repository/tags/'.$tag_name.'/release'), $params);
+        return $this->post($this->getProjectPath($project_id, 'repository/tags/'.$this->encodePath($tag_name).'/release'), $params);
     }
 
     /**
@@ -60,6 +60,6 @@ class Tags extends AbstractApi
      */
     public function updateRelease($project_id, $tag_name, array $params = array())
     {
-        return $this->put($this->getProjectPath($project_id, 'repository/tags/'.$tag_name.'/release'), $params);
+        return $this->put($this->getProjectPath($project_id, 'repository/tags/'.$this->encodePath($tag_name).'/release'), $params);
     }
 }


### PR DESCRIPTION
Tag names might contain slashes, for example.