### PR TITLE
Implement project transfer API

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -398,6 +398,15 @@ class Projects extends AbstractApi
 
     /**
      * @param int $project_id
+     * @param mixed $namespace
+     * @return mixed
+     */
+    public function transfer($project_id, $namespace) {
+        return $this->put($this->getProjectPath($project_id, 'transfer'), ['namespace' => $namespace]);
+    }
+
+    /**
+     * @param int $project_id
      * @return mixed
      */
     public function deployKeys($project_id)

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -401,7 +401,8 @@ class Projects extends AbstractApi
      * @param mixed $namespace
      * @return mixed
      */
-    public function transfer($project_id, $namespace) {
+    public function transfer($project_id, $namespace)
+    {
         return $this->put($this->getProjectPath($project_id, 'transfer'), ['namespace' => $namespace]);
     }
 

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -641,6 +641,27 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldTransfer()
+    {
+        $expectedArray = array(
+            'id' => 1,
+            'name' => 'Project Name',
+            'namespace' => array('name' => 'a_namespace'),
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('projects/1/transfer', ['namespace' => 'a_namespace'])
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->transfer(1, 'a_namespace'));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetDeployKeys()
     {
         $expectedArray = array(


### PR DESCRIPTION
This implements another project transfer API: https://docs.gitlab.com/ce/api/projects.html#transfer-a-project-to-a-new-namespace

This was added by https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/20122, seems like permissions might be different from the other ways to transfer a project.

(For our instance of GitLab, this API returns normally. While `…->api('groups')->transfer(…)` does transfer the project, but the HTTP request times out.)