### PR TITLE
Add $skip_confirmation parameter to Users::createEmailForUser()

### DIFF
--- a/lib/Gitlab/Api/Users.php
+++ b/lib/Gitlab/Api/Users.php
@@ -275,12 +275,14 @@ class Users extends AbstractApi
     /**
      * @param int $user_id
      * @param string $email
+     * @param bool $skip_confirmation
      * @return mixed
      */
-    public function createEmailForUser($user_id, $email)
+    public function createEmailForUser($user_id, $email, $skip_confirmation = false)
     {
         return $this->post('users/'.$this->encodePath($user_id).'/emails', array(
             'email' => $email,
+            'skip_confirmation' => $skip_confirmation,
         ));
     }
 

--- a/test/Gitlab/Tests/Api/UsersTest.php
+++ b/test/Gitlab/Tests/Api/UsersTest.php
@@ -456,11 +456,28 @@ class UsersTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('users/1/emails', array('email' => 'foo@bar.example'))
+            ->with('users/1/emails', array('email' => 'foo@bar.example', 'skip_confirmation' => false))
             ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->createEmailForUser(1, 'foo@bar.example'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateConfirmedEmailForUser()
+    {
+        $expectedArray = array('id' => 4, 'email' => 'foo@baz.example');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('users/1/emails', array('email' => 'foo@baz.example', 'skip_confirmation' => true))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->createEmailForUser(1, 'foo@baz.example', true));
     }
 
     /**


### PR DESCRIPTION
GitLab 11.4 added a new parameter to the Add email for user API: https://docs.gitlab.com/ce/api/users.html#add-email-for-user