### PR TITLE
Implements move issue API endpoint.

### DIFF
--- a/lib/Gitlab/Api/Issues.php
+++ b/lib/Gitlab/Api/Issues.php
@@ -84,6 +84,19 @@ class Issues extends AbstractApi
     /**
      * @param int $project_id
      * @param int $issue_iid
+     * @param int $to_project_id
+     * @return mixed
+     */
+    public function move($project_id, $issue_iid, $to_project_id)
+    {
+        return $this->post($this->getProjectPath($project_id, 'issues/'.$this->encodePath($issue_iid)).'/move', array(
+            'to_project_id' => $to_project_id
+        ));
+    }
+
+    /**
+     * @param int $project_id
+     * @param int $issue_iid
      * @return mixed
      */
     public function remove($project_id, $issue_iid)

--- a/lib/Gitlab/Model/Issue.php
+++ b/lib/Gitlab/Model/Issue.php
@@ -97,6 +97,17 @@ class Issue extends AbstractModel implements Noteable
     }
 
     /**
+     * @param Project $toProject
+     * @return Issue
+     */
+    public function move(Project $toProject)
+    {
+        $data = $this->client->issues()->move($this->project->id, $this->iid, $toProject->id);
+
+        return static::fromArray($this->getClient(), $toProject, $data);
+    }
+
+    /**
      * @param string $comment
      * @return Issue
      */

--- a/test/Gitlab/Tests/Api/IssuesTest.php
+++ b/test/Gitlab/Tests/Api/IssuesTest.php
@@ -116,6 +116,23 @@ class IssuesTest extends TestCase
     /**
      * @test
      */
+    public function shouldMoveIssue()
+    {
+        $expectedArray = array('id' => 2, 'title' => 'A moved issue');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/issues/2/move', array('to_project_id' => 3))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->move(1, 2, 3));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetIssueComments()
     {
         $expectedArray = array(

--- a/test/Gitlab/Tests/Model/IssueTest.php
+++ b/test/Gitlab/Tests/Model/IssueTest.php
@@ -2,6 +2,7 @@
 
 namespace Gitlab\Tests\Model;
 
+use Gitlab\Api\Issues;
 use Gitlab\Client;
 use Gitlab\Model\Issue;
 use Gitlab\Model\Project;
@@ -101,5 +102,30 @@ class IssueTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($issue->hasLabel('foo'));
         $this->assertTrue($issue->hasLabel('bar'));
         $this->assertFalse($issue->hasLabel(''));
+    }
+
+    public function testMove()
+    {
+        $project = new Project(1);
+        $toProject = new Project(2);
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $issues = $this->getMockBuilder(Issues::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $client->expects($this->once())
+            ->method('issues')
+            ->willReturn($issues);
+        $issues->expects($this->once())
+            ->method('move')
+            ->willReturn(['iid' => 11]);
+
+        $issue = Issue::fromArray($client, $project, ['iid' => 10])->move($toProject);
+
+        $this->assertInstanceOf(Issue::class, $issue);
+        $this->assertSame($client, $issue->getClient());
+        $this->assertSame($toProject, $issue->project);
+        $this->assertSame(11, $issue->iid);
     }
 }


### PR DESCRIPTION
Adds the ability to move an issue from a project to another one, referring to this part of the [GitLab API documentation](https://docs.gitlab.com/ee/api/issues.html#move-an-issue).