### PR TITLE
Support user avatar file upload

### DIFF
--- a/lib/Gitlab/Api/Users.php
+++ b/lib/Gitlab/Api/Users.php
@@ -98,11 +98,12 @@ class Users extends AbstractApi
     /**
      * @param int $id
      * @param array $params
+     * @param array $files
      * @return mixed
      */
-    public function update($id, array $params)
+    public function update($id, array $params, array $files = array())
     {
-        return $this->put('users/'.$this->encodePath($id), $params);
+        return $this->put('users/'.$this->encodePath($id), $params, array(), $files);
     }
 
     /**

--- a/test/Gitlab/Tests/Api/UsersTest.php
+++ b/test/Gitlab/Tests/Api/UsersTest.php
@@ -161,6 +161,17 @@ class UsersTest extends TestCase
         ;
 
         $this->assertEquals($expectedArray, $api->update(3, array('name' => 'Billy Bob')));
+
+        $expectedArray = array('id' => 4, 'avatar_url' => 'http://localhost:3000/uploads/user/avatar/4/image.jpg');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('users/4', array(), array(), array('avatar' => '/some/image.jpg'))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->update(4, array(), array('avatar' => '/some/image.jpg')));
     }
 
     /**


### PR DESCRIPTION
This adds support for uploading a user's avatar via a new files argument. It works like `…->update(…, array('avatar' => 'path/to/avatar'))`

The code in `AbstractApi::put()` is copied from `AbstractApi::post()`.

I wasn’t able to find any existing testing of file uploads. Please let me know if there is a good way to add tests.