### PR TITLE
Add routes to manage group boards

### DIFF
--- a/lib/Gitlab/Api/GroupsBoards.php
+++ b/lib/Gitlab/Api/GroupsBoards.php
@@ -1,0 +1,123 @@
+<?php namespace Gitlab\Api;
+
+class GroupsBoards extends AbstractApi
+{
+    /**
+     * @param int $group_id
+     * @param array $parameters
+     *
+     * @return mixed
+     */
+    public function all($group_id = null, array $parameters = [])
+    {
+        $resolver = $this->createOptionsResolver();
+
+        $path = $group_id === null ? 'boards' : $this->getGroupPath($group_id, 'boards');
+
+        return $this->get($path, $resolver->resolve($parameters));
+    }
+
+    /**
+     * @param int $group_id
+     * @param int $board_id
+     * @return mixed
+     */
+    public function show($group_id, $board_id)
+    {
+        return $this->get($this->getGroupPath($group_id, 'boards/'.$this->encodePath($board_id)));
+    }
+
+    /**
+     * @param int $group_id
+     * @param array $params
+     * @return mixed
+     */
+    public function create($group_id, array $params)
+    {
+        return $this->post($this->getGroupPath($group_id, 'boards'), $params);
+    }
+
+    /**
+     * @param int $group_id
+     * @param int $board_id
+     * @param array $params
+     * @return mixed
+     */
+    public function update($group_id, $board_id, array $params)
+    {
+        return $this->put($this->getGroupPath($group_id, 'boards/'.$this->encodePath($board_id)), $params);
+    }
+
+    /**
+     * @param int $group_id
+     * @param int $board_id
+     * @return mixed
+     */
+    public function remove($group_id, $board_id)
+    {
+        return $this->delete($this->getGroupPath($group_id, 'boards/'.$this->encodePath($board_id)));
+    }
+
+    /**
+     * @param int $group_id
+     * @param int $board_id
+     * @return mixed
+     */
+    public function allLists($group_id, $board_id)
+    {
+        return $this->get($this->getGroupPath($group_id, 'boards/'.$this->encodePath($board_id).'/lists'));
+    }
+
+    /**
+     * @param int $group_id
+     * @param int $board_id
+     * @param int $list_id
+     * @return mixed
+     */
+    public function showList($group_id, $board_id, $list_id)
+    {
+        return $this->get($this->getGroupPath($group_id, 'boards/'.$this->encodePath($board_id).'/lists/'.$this->encodePath($list_id)));
+    }
+
+    /**
+     * @param int $group_id
+     * @param int $board_id
+     * @param int $label_id
+     * @return mixed
+     */
+    public function createList($group_id, $board_id, $label_id)
+    {
+        $params = array(
+            'label_id' => $label_id
+        );
+
+        return $this->post($this->getGroupPath($group_id, 'boards/'.$this->encodePath($board_id).'/lists'), $params);
+    }
+
+    /**
+     * @param int $group_id
+     * @param int $board_id
+     * @param int $list_id
+     * @param int $position
+     * @return mixed
+     */
+    public function updateList($group_id, $board_id, $list_id, $position)
+    {
+        $params = array(
+            'position' => $position
+        );
+
+        return $this->put($this->getGroupPath($group_id, 'boards/'.$this->encodePath($board_id).'/lists/'.$this->encodePath($list_id)), $params);
+    }
+
+    /**
+     * @param int $group_id
+     * @param int $board_id
+     * @param int $list_id
+     * @return mixed
+     */
+    public function deleteList($group_id, $board_id, $list_id)
+    {
+        return $this->delete($this->getGroupPath($group_id, 'boards/'.$this->encodePath($board_id).'/lists/'.$this->encodePath($list_id)));
+    }
+}

--- a/lib/Gitlab/Client.php
+++ b/lib/Gitlab/Client.php
@@ -159,6 +159,15 @@ class Client
     }
 
     /**
+     * @return Api\GroupsBoards
+     */
+    public function groupsBoards()
+    {
+        return new Api\GroupsBoards($this);
+    }
+
+
+    /**
      * @return Api\IssueLinks
      */
     public function issueLinks()
@@ -311,6 +320,9 @@ class Client
             case 'board':
             case 'issue_boards':
                 return $this->issueBoards();
+
+            case 'group_boards':
+                return $this->groupsBoards();
 
             case 'issue_links':
                 return $this->issueLinks();

--- a/test/Gitlab/Tests/Api/GroupBoardsTest.php
+++ b/test/Gitlab/Tests/Api/GroupBoardsTest.php
@@ -1,0 +1,230 @@
+<?php namespace Gitlab\Tests\Api;
+
+class GroupBoardsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllBoards()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'title' => 'A board'),
+            array('id' => 2, 'title' => 'Another board'),
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('boards', array())
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->all());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldShowIssueBoard()
+    {
+        $expectedArray = array('id' => 2, 'name' => 'Another issue board');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/boards/2')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->show(1, 2));
+    }
+    
+    /**
+     * @test
+     */
+    public function shouldCreateIssueBoard()
+    {
+        $expectedArray = array('id' => 3, 'name' => 'A new issue board');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('groups/1/boards', array('name' => 'A new issue board'))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->create(1, array('name' => 'A new issue board')));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUpdateIssueBoard()
+    {
+        $expectedArray = array('id' => 2, 'name' => 'A renamed issue board');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('groups/1/boards/2', array('name' => 'A renamed issue board', 'labels' => 'foo'))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->update(1, 2, array('name' => 'A renamed issue board', 'labels' => 'foo')));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRemoveIssueBoard()
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('groups/1/boards/2')
+            ->will($this->returnValue($expectedBool))
+        ;
+
+        $this->assertEquals($expectedBool, $api->remove(1, 2));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetAllLists()
+    {
+        $expectedArray = array(
+            array(
+                'id' => 1,
+                'label' => array(
+                    'name' => 'First label',
+                    'color' => '#F0AD4E',
+                    'description' => null
+                ),
+                'position' => 1
+            ), array(
+                'id' => 2,
+                'label' => array(
+                    'name' => 'Second label',
+                    'color' => '#F0AD4E',
+                    'description' => null
+                ),
+                'position' => 2
+            )
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/boards/2/lists')
+            ->will($this->returnValue($expectedArray))
+        ;
+    
+        $this->assertEquals($expectedArray, $api->allLists(1, 2));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetList()
+    {
+        $expectedArray = array(
+            array(
+                'id' => 3,
+                'label' => array(
+                    'name' => 'Some label',
+                    'color' => '#F0AD4E',
+                    'description' => null
+                ),
+                'position' => 3
+            )
+        );
+    
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/boards/2/lists/3')
+            ->will($this->returnValue($expectedArray))
+        ;
+    
+        $this->assertEquals($expectedArray, $api->showList(1, 2, 3));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateList()
+    {
+        $expectedArray = array(
+            array(
+                'id' => 3,
+                'label' => array(
+                    'name' => 'Some label',
+                    'color' => '#F0AD4E',
+                    'description' => null
+                ),
+                'position' => 3
+            )
+        );
+    
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('groups/1/boards/2/lists', array('label_id' => 4))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->createList(1, 2, 4));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldUpdateList()
+    {
+        $expectedArray = array(
+            array(
+                'id' => 3,
+                'label' => array(
+                    'name' => 'Some label',
+                    'color' => '#F0AD4E',
+                    'description' => null
+                ),
+                'position' => 1
+            )
+        );
+    
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('groups/5/boards/2/lists/3', array('position' => 1))
+            ->will($this->returnValue($expectedArray))
+        ;
+    
+        $this->assertEquals($expectedArray, $api->updateList(5, 2, 3, 1));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldDeleteList()
+    {
+        $expectedBool = true;
+    
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('groups/1/boards/2/lists/3')
+            ->will($this->returnValue($expectedBool))
+        ;
+    
+        $this->assertEquals($expectedBool, $api->deleteList(1, 2, 3));
+    }
+
+    protected function getApiClass()
+    {
+        return 'Gitlab\Api\GroupsBoards';
+    }
+}


### PR DESCRIPTION
FYI this is more or less the same code as `IssueBoards`.