### PR TITLE
Compare branches,tags,commits: add straight option

### DIFF
--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -320,13 +320,14 @@ class Repositories extends AbstractApi
      * @param int $project_id
      * @param string $fromShaOrMaster
      * @param string $toShaOrMaster
+     * @param bool $straight
      * @return mixed
      */
-    public function compare($project_id, $fromShaOrMaster, $toShaOrMaster)
+    public function compare($project_id, $fromShaOrMaster, $toShaOrMaster, $straight = false)
     {
         return $this->get($this->getProjectPath(
             $project_id,
-            'repository/compare?from='.$this->encodePath($fromShaOrMaster).'&to='.$this->encodePath($toShaOrMaster)
+            'repository/compare?from='.$this->encodePath($fromShaOrMaster).'&to='.$this->encodePath($toShaOrMaster).'&straight='.$this->encodePath($straight ? 'true' : 'false')
         ));
     }
 

--- a/test/Gitlab/Tests/Api/RepositoriesTest.php
+++ b/test/Gitlab/Tests/Api/RepositoriesTest.php
@@ -455,14 +455,31 @@ class RepositoriesTest extends TestCase
     /**
      * @test
      */
-    public function shouldCompare()
+    public function shouldCompareStraight()
     {
         $expectedArray = array('commit' => 'object');
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/repository/compare?from=master&to=feature')
+            ->with('projects/1/repository/compare?from=master&to=feature&straight=true')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->compare(1, 'master', 'feature', true));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotCompareStraight()
+    {
+        $expectedArray = array('commit' => 'object');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/repository/compare?from=master&to=feature&straight=false')
             ->will($this->returnValue($expectedArray))
         ;
 


### PR DESCRIPTION
Add the [straight option](https://docs.gitlab.com/ee/api/repositories.html#compare-branches-tags-or-commits) for the compare api.

To keep BC, the default value is set to `false`.

