### PR TITLE
Added assignee_id to defined options

### DIFF
--- a/lib/Gitlab/Api/Issues.php
+++ b/lib/Gitlab/Api/Issues.php
@@ -44,6 +44,9 @@ class Issues extends AbstractApi
             ->setAllowedValues('sort', ['asc', 'desc'])
         ;
         $resolver->setDefined('search');
+        $resolver->setDefined('assignee_id')
+            ->setAllowedTypes('assignee_id', 'integer')
+        ;
 
         $path = $project_id === null ? 'issues' : $this->getProjectPath($project_id, 'issues');
 

--- a/test/Gitlab/Tests/Api/IssuesTest.php
+++ b/test/Gitlab/Tests/Api/IssuesTest.php
@@ -434,6 +434,26 @@ class IssuesTest extends TestCase
         $this->assertEquals($expectedArray, $api->closedByMergeRequests(1, 2));
     }
 
+    /**
+     * @test
+     */
+    public function shouldGetProjectIssuesByAssignee()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'title' => 'An issue'),
+            array('id' => 2, 'title' => 'Another issue'),
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/issues', array('assignee_id' => 1))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->all(1, array('assignee_id' => 1)));
+    }
+
     protected function getApiClass()
     {
         return 'Gitlab\Api\Issues';


### PR DESCRIPTION
This added option allows only issues assigned to a specific person to be returned.