### PR TITLE
Add method to retrieve all members from projects (including inherited)

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -294,6 +294,37 @@ class Projects extends AbstractApi
 
     /**
      * @param int $project_id
+     * @param array $parameters (
+     *
+     *     @var string $query           The query you want to search members for.
+     * )
+     *
+     * @throws MissingOptionsException  If a required option is not provided
+     *
+     * @return mixed
+     */
+    public function membersAll($project_id, $parameters = [])
+    {
+        if (!is_array($parameters)) {
+            @trigger_error("Deprecated: String parameter of the members() function is deprecated.", E_USER_NOTICE);
+            $username_query = $parameters;
+            $parameters = array();
+            if (!empty($username_query)) {
+                $parameters['query'] = $username_query;
+            }
+        }
+
+        $resolver = $this->createOptionsResolver();
+
+        $resolver->setDefined('query')
+            ->setAllowedTypes('query', 'string')
+        ;
+
+        return $this->get($this->getProjectPath($project_id, 'members/all'), $resolver->resolve($parameters));
+    }
+
+    /**
+     * @param int $project_id
      * @param int $user_id
      * @return mixed
      */
@@ -768,7 +799,7 @@ class Projects extends AbstractApi
     {
         return $this->get($this->getProjectPath($project_id, 'deployments/'.$this->encodePath($deployment_id)));
     }
-    
+
     /**
      * @param mixed $project_id
      * @param array $parameters
@@ -796,7 +827,7 @@ class Projects extends AbstractApi
 
         return $this->post($this->getProjectPath($project_id, 'share'), $resolver->resolve($parameters));
     }
-    
+
     /**
      * @param mixed $project_id
      * @param int $group_id

--- a/lib/Gitlab/Model/Project.php
+++ b/lib/Gitlab/Model/Project.php
@@ -191,6 +191,22 @@ class Project extends AbstractModel
     }
 
     /**
+     * @param string $username_query
+     * @return User[]
+     */
+    public function membersAll($username_query = null)
+    {
+        $data = $this->client->projects()->membersAll($this->id, $username_query);
+
+        $members = array();
+        foreach ($data as $member) {
+            $members[] = User::fromArray($this->getClient(), $member);
+        }
+
+        return $members;
+    }
+
+    /**
      * @param int $user_id
      * @return User
      */

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -643,6 +643,122 @@ class ProjectsTest extends TestCase
     }
 
     /**
+     * Get expected array for tests which check project members all
+     *
+     * @return array
+     *   Project issues list.
+     */
+    public function getMembersAllExpectedArray()
+    {
+        return [
+            [
+                "id" => 1,
+                "username" => "raymond_smith",
+                "name" => "Raymond Smith",
+                "state" => "active",
+                "avatar_url" => "https://www.gravatar.com/avatar/c2525a7f58ae3776070e44c106c48e15?s=80&d=identicon",
+                "web_url" => "http://192.168.1.8:3000/root",
+                "expires_at" => "2012-10-22T14:13:35Z",
+                "access_level" => 30
+            ],
+            [
+                "id" => 2,
+                "username" => "john_doe",
+                "name" => "John Doe",
+                "state" => "active",
+                "avatar_url" => "https://www.gravatar.com/avatar/c2525a7f58ae3776070e44c106c48e15?s=80&d=identicon",
+                "web_url" => "http://192.168.1.8:3000/root",
+                "expires_at" => "2012-10-22T14:13:35Z",
+                "access_level" => 40
+            ],
+            [
+                "id" => 3,
+                "username" => "mr_admin",
+                "name" => "Mr Admin",
+                "state" => "active",
+                "avatar_url" => "https://www.gravatar.com/avatar/c2525a7f58ae3776070e44c106c48e15?s=80&d=identicon",
+                "web_url" => "http://192.168.1.8:3000/root",
+                "expires_at" => "2012-11-22T14:13:35Z",
+                "access_level" => 50
+            ]
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetMembersAll()
+    {
+        $expectedArray = $this->getMembersAllExpectedArray();
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/members/all')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->membersAll(1));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetMembersAllWithQuery()
+    {
+        $expectedmMembersAllArray = $this->getMembersAllExpectedArray();
+        $expectedArray = array(
+            $expectedmMembersAllArray[0]
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/members/all', array('query' => 'at'))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->membersAll(1, 'at'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetMembersAllWithNullQuery()
+    {
+        $expectedArray = $this->getMembersAllExpectedArray();
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/members/all')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->membersAll(1, null));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetMembersAllWithPagination()
+    {
+        $expectedArray = $this->getMembersAllExpectedArray();
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/members/all', array(
+                'page' => 2,
+                'per_page' => 15
+            ))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->membersAll(1, array('page' => 2, 'per_page' => 15)));
+    }
+
+    /**
      * @test
      */
     public function shouldGetMember()


### PR DESCRIPTION
Implements this API method: https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members