### PR TITLE
Allow setting path and name when forking a Project

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -629,13 +629,15 @@ class Projects extends AbstractApi
      * @param array $params (
      *
      *     @var string $namespace      The ID or path of the namespace that the project will be forked to
+     *     @var string $path           The path of the forked project (optional)
+     *     @var string $name           The name of the forked project (optional)
      * )
      * @return mixed
      */
     public function fork($project_id, array $parameters = [])
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefined('namespace');
+        $resolver->setDefined(['namespace', 'path', 'name']);
 
         $resolved = $resolver->resolve($parameters);
 

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -1234,6 +1234,72 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldForkWithNamespace()
+    {
+        $expectedArray = [
+            'namespace' => 'new_namespace',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/fork', $expectedArray)
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->fork(1, [
+            'namespace' => 'new_namespace',
+        ]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldForkWithNamespaceAndPath()
+    {
+        $expectedArray = [
+            'namespace' => 'new_namespace',
+            'path' => 'new_path',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/fork', $expectedArray)
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->fork(1, [
+            'namespace' => 'new_namespace',
+            'path' => 'new_path',
+        ]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldForkWithNamespaceAndPathAndName()
+    {
+        $expectedArray = [
+            'namespace' => 'new_namespace',
+            'path' => 'new_path',
+            'name' => 'new_name'
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/fork', $expectedArray)
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->fork(1, [
+            'namespace' => 'new_namespace',
+            'path' => 'new_path',
+            'name' => 'new_name'
+        ]));
+    }
+
+    /**
+     * @test
+     */
     public function shouldCreateForkRelation()
     {
         $expectedArray = array('project_id' => 1, 'forked_id' => 2);


### PR DESCRIPTION
GitLab API allows two optional params when forking, path and name: https://docs.gitlab.com/ee/api/projects.html#fork-project

Added them to the validator so, when forking a repo, it can be renamed and placed in a different path.
