### PR TITLE
Branches API: add search attribute

### DIFF
--- a/lib/Gitlab/Api/Repositories.php
+++ b/lib/Gitlab/Api/Repositories.php
@@ -10,12 +10,18 @@ class Repositories extends AbstractApi
 
     /**
      * @param int $project_id
-     * @param array $parameters
+     * @param array $parameters (
+     *
+     *     @var string $search
+     * )
      * @return mixed
      */
     public function branches($project_id, array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('search')
+            ->setAllowedTypes('search', 'string');
+
         return $this->get($this->getProjectPath($project_id, 'repository/branches'), $resolver->resolve($parameters));
     }
 

--- a/test/Gitlab/Tests/Api/RepositoriesTest.php
+++ b/test/Gitlab/Tests/Api/RepositoriesTest.php
@@ -18,11 +18,11 @@ class RepositoriesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/repository/branches')
+            ->with('projects/1/repository/branches', ['search' => '^term'])
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->branches(1));
+        $this->assertEquals($expectedArray, $api->branches(1, ['search' => '^term']));
     }
 
     /**
@@ -217,7 +217,7 @@ class RepositoriesTest extends TestCase
 
         $this->assertEquals($expectedArray, $api->updateRelease($project_id, $tagName, $description));
     }
-    
+
     /**
      * @test
      */


### PR DESCRIPTION
The branches api can have an optional "search" parameter to filter for branch names

https://docs.gitlab.com/ee/api/branches.html#list-repository-branches