### PR TITLE
Add a SHA property/filter for pipelines

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -182,6 +182,7 @@ class Projects extends AbstractApi
      *     @var string $scope       The scope of pipelines, one of: running, pending, finished, branches, tags.
      *     @var string $status      The status of pipelines, one of: running, pending, success, failed, canceled, skipped.
      *     @var string $ref         The ref of pipelines.
+     *     @var string $sha         The sha of pipelines.
      *     @var bool   $yaml_errors Returns pipelines with invalid configurations.
      *     @var string $name        The name of the user who triggered pipelines.
      *     @var string $username    The username of the user who triggered pipelines.
@@ -204,6 +205,7 @@ class Projects extends AbstractApi
             ->setAllowedValues('status', ['running', 'pending', 'success', 'failed', 'canceled', 'skipped'])
         ;
         $resolver->setDefined('ref');
+        $resolver->setDefined('sha');
         $resolver->setDefined('yaml_errors')
             ->setAllowedTypes('yaml_errors', 'bool')
             ->setNormalizer('yaml_errors', $booleanNormalizer)

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -500,7 +500,7 @@ class ProjectsTest extends TestCase
             ->will($this->returnValue($expectedArray))
         ;
 
-	    $this->assertEquals($expectedArray, $api->pipelines(1, ['sha' => '123']));
+        $this->assertEquals($expectedArray, $api->pipelines(1, ['sha' => '123']));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -482,26 +482,26 @@ class ProjectsTest extends TestCase
         $this->assertEquals($expectedArray, $api->pipelines(1, ['yaml_errors' => false]));
     }
 
-	/**
-	 * @test
-	 */
-	public function shouldGetPipelinesWithSHA()
-	{
-		$expectedArray = array(
-			array('id' => 1, 'status' => 'success','ref' => 'new-pipeline'),
-			array('id' => 2, 'status' => 'failed', 'ref' => 'new-pipeline'),
-			array('id' => 3, 'status' => 'pending', 'ref' => 'test-pipeline')
-		);
+    /**
+     * @test
+     */
+    public function shouldGetPipelinesWithSHA()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'status' => 'success','ref' => 'new-pipeline'),
+            array('id' => 2, 'status' => 'failed', 'ref' => 'new-pipeline'),
+            array('id' => 3, 'status' => 'pending', 'ref' => 'test-pipeline')
+        );
 
-		$api = $this->getApiMock();
-		$api->expects($this->once())
-			->method('get')
-			->with('projects/1/pipelines', ['sha' => '123'])
-			->will($this->returnValue($expectedArray))
-		;
+	    $api = $this->getApiMock();
+	    $api->expects($this->once())
+	        ->method('get')
+	        ->with('projects/1/pipelines', ['sha' => '123'])
+	        ->will($this->returnValue($expectedArray))
+	    ;
 
-		$this->assertEquals($expectedArray, $api->pipelines(1, ['sha' => '123']));
-	}
+	    $this->assertEquals($expectedArray, $api->pipelines(1, ['sha' => '123']));
+    }
 
     /**
      * @test

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -482,6 +482,27 @@ class ProjectsTest extends TestCase
         $this->assertEquals($expectedArray, $api->pipelines(1, ['yaml_errors' => false]));
     }
 
+	/**
+	 * @test
+	 */
+	public function shouldGetPipelinesWithSHA()
+	{
+		$expectedArray = array(
+			array('id' => 1, 'status' => 'success','ref' => 'new-pipeline'),
+			array('id' => 2, 'status' => 'failed', 'ref' => 'new-pipeline'),
+			array('id' => 3, 'status' => 'pending', 'ref' => 'test-pipeline')
+		);
+
+		$api = $this->getApiMock();
+		$api->expects($this->once())
+			->method('get')
+			->with('projects/1/pipelines', ['sha' => '123'])
+			->will($this->returnValue($expectedArray))
+		;
+
+		$this->assertEquals($expectedArray, $api->pipelines(1, ['sha' => '123']));
+	}
+
     /**
      * @test
      */

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -493,12 +493,12 @@ class ProjectsTest extends TestCase
             array('id' => 3, 'status' => 'pending', 'ref' => 'test-pipeline')
         );
 
-	    $api = $this->getApiMock();
-	    $api->expects($this->once())
-	        ->method('get')
-	        ->with('projects/1/pipelines', ['sha' => '123'])
-	        ->will($this->returnValue($expectedArray))
-	    ;
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/pipelines', ['sha' => '123'])
+            ->will($this->returnValue($expectedArray))
+        ;
 
 	    $this->assertEquals($expectedArray, $api->pipelines(1, ['sha' => '123']));
     }


### PR DESCRIPTION
I need to search the pipelines for a sha of a specific commit. This change adds a parameter to filter the pipelines for a sha of a commit.

If you have questions or require changes, please let me know.