### PR TITLE
Fixed redirects for downloading artifacts

### DIFF
--- a/lib/Gitlab/Client.php
+++ b/lib/Gitlab/Client.php
@@ -82,11 +82,11 @@ class Client
 
         $this->httpClientBuilder->addPlugin(new GitlabExceptionThrower());
         $this->httpClientBuilder->addPlugin(new HistoryPlugin($this->responseHistory));
-        $this->httpClientBuilder->addPlugin(new ApiVersion());
         $this->httpClientBuilder->addPlugin(new HeaderDefaultsPlugin([
             'User-Agent' => 'php-gitlab-api (http://github.com/m4tthumphrey/php-gitlab-api)',
         ]));
         $this->httpClientBuilder->addPlugin(new RedirectPlugin());
+        $this->httpClientBuilder->addPlugin(new ApiVersion());
 
         $this->setUrl('https://gitlab.com');
     }

--- a/test/Gitlab/Tests/HttpClient/Plugin/ApiVersionTest.php
+++ b/test/Gitlab/Tests/HttpClient/Plugin/ApiVersionTest.php
@@ -36,6 +36,7 @@ class ApiVersionTest extends TestCase
         $request = new Request('GET', 'projects');
         $expected = new Request('GET', '/api/v4/projects');
         $plugin = new ApiVersion();
+        $promise = new HttpFulfilledPromise(new Response());
 
         $callback = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['next'])
@@ -44,6 +45,7 @@ class ApiVersionTest extends TestCase
         $callback->expects($this->once())
             ->method('next')
             ->with($expected)
+            ->willReturn($promise)
         ;
 
         $plugin->handleRequest($request, [$callback, 'next'], function () {
@@ -54,6 +56,7 @@ class ApiVersionTest extends TestCase
     {
         $request = new Request('GET', '/api/v4/projects');
         $plugin = new ApiVersion();
+        $promise = new HttpFulfilledPromise(new Response());
 
         $callback = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['next'])
@@ -62,6 +65,7 @@ class ApiVersionTest extends TestCase
         $callback->expects($this->once())
             ->method('next')
             ->with($request)
+            ->willReturn($promise)
         ;
 
         $plugin->handleRequest($request, [$callback, 'next'], function () {


### PR DESCRIPTION
When downloading artifacts, I'm being redirected to an object store at Google. At this point the ApiVersion plugin currently adds the API version to Google's URL, which causes errors.

By keeping track of the last request, we know if it is being redirected. The following request will overwrite the last stored state. To be able to keep track of redirects, we need to be after the RedirectPlugin.