### PR TITLE
Added show() method for Environments

### DIFF
--- a/lib/Gitlab/Api/Environments.php
+++ b/lib/Gitlab/Api/Environments.php
@@ -17,6 +17,16 @@ class Environments extends AbstractApi
 
     /**
      * @param int $project_id
+     * @param int $environment_id
+     * @return mixed
+     */
+    public function show($project_id, $environment_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'environments/'.$this->encodePath($environment_id)));
+    }
+
+    /**
+     * @param int $project_id
      * @param array $parameters (
      *
      *     @var string $name         The name of the environment


### PR DESCRIPTION
The method seems missing. It is needed to get detailed information on Environment and exists according to docs:
https://docs.gitlab.com/ee/api/environments.html#get-a-specific-environment