### PR TITLE
Group + Project model properties

### DIFF
--- a/lib/Gitlab/Model/Group.php
+++ b/lib/Gitlab/Model/Group.php
@@ -9,7 +9,17 @@ use Gitlab\Client;
  * @property-read string $name
  * @property-read string $path
  * @property-read string $description
+ * @property-read string $visibility
+ * @property-read bool $lfs_enabled
+ * @property-read string $avatar_url
+ * @property-read string $web_url
+ * @property-read bool $request_access_enabled
+ * @property-read string $full_name
+ * @property-read string $full_path
+ * @property-read int $file_template_project_id
+ * @property-read int|null $parent_id
  * @property-read Project[] $projects
+ * @property-read Project[] $shared_projects
  */
 class Group extends AbstractModel
 {
@@ -21,7 +31,17 @@ class Group extends AbstractModel
         'name',
         'path',
         'description',
-        'projects'
+        'visibility',
+        'lfs_enabled',
+        'avatar_url',
+        'web_url',
+        'request_access_enabled',
+        'full_name',
+        'full_path',
+        'file_template_project_id',
+        'parent_id',
+        'projects',
+        'shared_projects',
     );
 
     /**
@@ -39,6 +59,14 @@ class Group extends AbstractModel
                 $projects[] = Project::fromArray($client, $project);
             }
             $data['projects'] = $projects;
+        }
+
+        if (isset($data['shared_projects'])) {
+            $projects = array();
+            foreach ($data['shared_projects'] as $project) {
+                $projects[] = Project::fromArray($client, $project);
+            }
+            $data['shared_projects'] = $projects;
         }
 
         return $group->hydrate($data);
@@ -132,12 +160,12 @@ class Group extends AbstractModel
     public function projects()
     {
         $data = $this->client->groups()->projects($this->id);
-        
+
         $projects = array();
         foreach ($data as $project) {
             $projects[] = Project::fromArray($this->getClient(), $project);
         }
-        
+
         return $projects;
     }
 

--- a/lib/Gitlab/Model/Project.php
+++ b/lib/Gitlab/Model/Project.php
@@ -8,30 +8,45 @@ use Gitlab\Client;
  * Class Project
  *
  * @property-read int $id
- * @property-read string $code
- * @property-read string $name
- * @property-read string $name_with_namespace
  * @property-read string $description
- * @property-read string $path
- * @property-read string $path_with_namespace
+ * @property-read string $default_branch
+ * @property-read string $visibility
  * @property-read string $ssh_url_to_repo
  * @property-read string $http_url_to_repo
  * @property-read string $web_url
- * @property-read string $default_branch
- * @property-read bool $private
- * @property-read bool $public
+ * @property-read string $readme_url
+ * @property-read string[] $tag_list
+ * @property-read User $owner
+ * @property-read string $name
+ * @property-read string $name_with_namespace
+ * @property-read string $path
+ * @property-read string $path_with_namespace
  * @property-read bool $issues_enabled
+ * @property-read int $open_issues_count
  * @property-read bool $merge_requests_enabled
- * @property-read bool $wall_enabled
+ * @property-read bool $jobs_enabled
  * @property-read bool $wiki_enabled
  * @property-read bool $snippets_enabled
+ * @property-read bool $resolve_outdated_diff_discussions
+ * @property-read bool $container_registry_enabled
  * @property-read string $created_at
- * @property-read int $greatest_access_level
  * @property-read string $last_activity_at
- * @property-read string $tag_list
- * @property-read string $avatar_url
- * @property-read User $owner
+ * @property-read int $creator_id
  * @property-read ProjectNamespace $namespace
+ * @property-read string $import_status
+ * @property-read bool $archived
+ * @property-read string $avatar_url
+ * @property-read bool $shared_runners_enabled
+ * @property-read int $forks_count
+ * @property-read int $star_count
+ * @property-read string $runners_token
+ * @property-read bool $public_jobs
+ * @property-read Group[] $shared_with_groups
+ * @property-read bool $only_allow_merge_if_pipeline_succeeds
+ * @property-read bool $only_allow_merge_if_all_discussions_are_resolved
+ * @property-read bool $request_access_enabled
+ * @property-read string $merge_method
+ * @property-read bool $approvals_before_merge
  */
 class Project extends AbstractModel
 {
@@ -40,30 +55,45 @@ class Project extends AbstractModel
      */
     protected static $properties = array(
         'id',
-        'code',
-        'name',
-        'name_with_namespace',
-        'namespace',
         'description',
-        'path',
-        'path_with_namespace',
+        'default_branch',
+        'visibility',
         'ssh_url_to_repo',
         'http_url_to_repo',
         'web_url',
-        'default_branch',
-        'owner',
-        'private',
-        'public',
-        'issues_enabled',
-        'merge_requests_enabled',
-        'wall_enabled',
-        'wiki_enabled',
-        'created_at',
-        'greatest_access_level',
-        'last_activity_at',
-        'snippets_enabled',
+        'readme_url',
         'tag_list',
-        'avatar_url'
+        'owner',
+        'name',
+        'name_with_namespace',
+        'path',
+        'path_with_namespace',
+        'issues_enabled',
+        'open_issues_count',
+        'merge_requests_enabled',
+        'jobs_enabled',
+        'wiki_enabled',
+        'snippets_enabled',
+        'resolve_outdated_diff_discussions',
+        'container_registry_enabled',
+        'created_at',
+        'last_activity_at',
+        'creator_id',
+        'namespace',
+        'import_status',
+        'archived',
+        'avatar_url',
+        'shared_runners_enabled',
+        'forks_count',
+        'star_count',
+        'runners_token',
+        'public_jobs',
+        'shared_with_groups',
+        'only_allow_merge_if_pipeline_succeeds',
+        'only_allow_merge_if_all_discussions_are_resolved',
+        'request_access_enabled',
+        'merge_method',
+        'approvals_before_merge',
     );
 
     /**
@@ -82,6 +112,14 @@ class Project extends AbstractModel
 
         if (isset($data['namespace']) && is_array($data['namespace'])) {
             $data['namespace'] = ProjectNamespace::fromArray($client, $data['namespace']);
+        }
+
+        if (isset($data['shared_with_groups'])) {
+            $groups = [];
+            foreach ($data['shared_with_groups'] as $group) {
+                $groups[] = Group::fromArray($client, $group);
+            }
+            $data['shared_with_groups'] = $groups;
         }
 
         return $project->hydrate($data);

--- a/test/Gitlab/Tests/Model/GroupTest.php
+++ b/test/Gitlab/Tests/Model/GroupTest.php
@@ -7,17 +7,59 @@ use Gitlab\Model\Group;
 use Gitlab\Model\Project;
 use PHPUnit\Framework\TestCase;
 use Gitlab\Api\Groups;
-use Gitlab\Api\Projects;
 
 class GroupTest extends TestCase
 {
-    private function getGroupMock(array $data = [])
+    public function testFromArray()
     {
         $client = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        return Group::fromArray($client, $data);
+        $data = [
+            'id' => 1,
+            'name' => 'Foobar Group',
+            'path' => 'foo-bar',
+            'description' => 'An interesting group',
+            'visibility' => 'public',
+            'lfs_enabled' => true,
+            'avatar_url' => 'http://localhost:3000/uploads/group/avatar/1/foo.jpg',
+            'web_url' => 'http://localhost:3000/groups/foo-bar',
+            'request_access_enabled' => false,
+            'full_name' => 'Foobar Group',
+            'full_path' => 'foo-bar',
+            'file_template_project_id' => 1,
+            'parent_id' => null,
+            'projects' => [
+                ['id' => 1],
+            ],
+            'shared_projects' => [
+                ['id' => 2],
+            ],
+        ];
+
+        $group = Group::fromArray($client, $data);
+
+        $this->assertInstanceOf(Group::class, $group);
+        $this->assertSame($data['id'], $group->id);
+        $this->assertSame($data['name'], $group->name);
+        $this->assertSame($data['path'], $group->path);
+        $this->assertSame($data['description'], $group->description);
+        $this->assertSame($data['visibility'], $group->visibility);
+        $this->assertSame($data['lfs_enabled'], $group->lfs_enabled);
+        $this->assertSame($data['avatar_url'], $group->avatar_url);
+        $this->assertSame($data['web_url'], $group->web_url);
+        $this->assertSame($data['request_access_enabled'], $group->request_access_enabled);
+        $this->assertSame($data['full_name'], $group->full_name);
+        $this->assertSame($data['full_path'], $group->full_path);
+        $this->assertSame($data['file_template_project_id'], $group->file_template_project_id);
+        $this->assertSame($data['parent_id'], $group->parent_id);
+
+        $this->assertCount(1, $group->projects);
+        $this->assertInstanceOf(Project::class, $group->projects[0]);
+
+        $this->assertCount(1, $group->shared_projects);
+        $this->assertInstanceOf(Project::class, $group->shared_projects[0]);
     }
 
     public function testProjects()

--- a/test/Gitlab/Tests/Model/ProjectTest.php
+++ b/test/Gitlab/Tests/Model/ProjectTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Gitlab\Tests\Model;
+
+use Gitlab\Client;
+use Gitlab\Model\Group;
+use Gitlab\Model\Project;
+use Gitlab\Model\ProjectNamespace;
+use Gitlab\Model\User;
+use PHPUnit\Framework\TestCase;
+
+class ProjectTest extends TestCase
+{
+    public function testFromArray()
+    {
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $data = [
+            'id' => 4,
+            'description' => null,
+            'default_branch' => 'master',
+            'visibility' => 'private',
+            'ssh_url_to_repo' => 'git@example.com:diaspora/diaspora-client.git',
+            'http_url_to_repo' => 'http://example.com/diaspora/diaspora-client.git',
+            'web_url' => 'http://example.com/diaspora/diaspora-client',
+            'readme_url' => 'http://example.com/diaspora/diaspora-client/blob/master/README.md',
+            'tag_list' => [
+                'example',
+                'disapora client'
+            ],
+            'owner' => [
+                'id' => 3,
+            ],
+            'name' => 'Diaspora Client',
+            'name_with_namespace' => 'Diaspora / Diaspora Client',
+            'path' => 'diaspora-client',
+            'path_with_namespace' => 'diaspora/diaspora-client',
+            'issues_enabled' => true,
+            'open_issues_count' => 1,
+            'merge_requests_enabled' => true,
+            'jobs_enabled' => true,
+            'wiki_enabled' => true,
+            'snippets_enabled' => false,
+            'resolve_outdated_diff_discussions' => false,
+            'container_registry_enabled' => false,
+            'created_at' => '2013-09-30T13:46:02Z',
+            'last_activity_at' => '2013-09-30T13:46:02Z',
+            'creator_id' => 3,
+            'namespace' => [
+                'id' => 3,
+            ],
+            'import_status' => 'none',
+            'archived' => false,
+            'avatar_url' => 'http://example.com/uploads/project/avatar/4/uploads/avatar.png',
+            'shared_runners_enabled' => true,
+            'forks_count' => 0,
+            'star_count' => 0,
+            'runners_token' => 'b8547b1dc37721d05889db52fa2f02',
+            'public_jobs' => true,
+            'shared_with_groups' => [
+                ['id' => 12]
+            ],
+            'only_allow_merge_if_pipeline_succeeds' => false,
+            'only_allow_merge_if_all_discussions_are_resolved' => false,
+            'request_access_enabled' => false,
+            'merge_method' => 'merge',
+            'approvals_before_merge' => 0,
+        ];
+
+        $project = Project::fromArray($client, $data);
+
+        $this->assertInstanceOf(Project::class, $project);
+        $this->assertSame($data['id'], $project->id);
+        $this->assertSame($data['description'], $project->description);
+        $this->assertSame($data['default_branch'], $project->default_branch);
+        $this->assertSame($data['visibility'], $project->visibility);
+        $this->assertSame($data['ssh_url_to_repo'], $project->ssh_url_to_repo);
+        $this->assertSame($data['http_url_to_repo'], $project->http_url_to_repo);
+        $this->assertSame($data['web_url'], $project->web_url);
+        $this->assertSame($data['readme_url'], $project->readme_url);
+        $this->assertSame($data['tag_list'], $project->tag_list);
+        $this->assertInstanceOf(User::class, $project->owner);
+        $this->assertSame($data['name'], $project->name);
+        $this->assertSame($data['name_with_namespace'], $project->name_with_namespace);
+        $this->assertSame($data['path'], $project->path);
+        $this->assertSame($data['path_with_namespace'], $project->path_with_namespace);
+        $this->assertSame($data['issues_enabled'], $project->issues_enabled);
+        $this->assertSame($data['open_issues_count'], $project->open_issues_count);
+        $this->assertSame($data['merge_requests_enabled'], $project->merge_requests_enabled);
+        $this->assertSame($data['jobs_enabled'], $project->jobs_enabled);
+        $this->assertSame($data['wiki_enabled'], $project->wiki_enabled);
+        $this->assertSame($data['snippets_enabled'], $project->snippets_enabled);
+        $this->assertSame($data['resolve_outdated_diff_discussions'], $project->resolve_outdated_diff_discussions);
+        $this->assertSame($data['container_registry_enabled'], $project->container_registry_enabled);
+        $this->assertSame($data['created_at'], $project->created_at);
+        $this->assertSame($data['last_activity_at'], $project->last_activity_at);
+        $this->assertSame($data['creator_id'], $project->creator_id);
+        $this->assertInstanceOf(ProjectNamespace::class, $project->namespace);
+        $this->assertSame($data['import_status'], $project->import_status);
+        $this->assertSame($data['archived'], $project->archived);
+        $this->assertSame($data['avatar_url'], $project->avatar_url);
+        $this->assertSame($data['shared_runners_enabled'], $project->shared_runners_enabled);
+        $this->assertSame($data['forks_count'], $project->forks_count);
+        $this->assertSame($data['star_count'], $project->star_count);
+        $this->assertSame($data['runners_token'], $project->runners_token);
+        $this->assertSame($data['public_jobs'], $project->public_jobs);
+        $this->assertCount(1, $project->shared_with_groups);
+        $this->assertInstanceOf(Group::class, $project->shared_with_groups[0]);
+        $this->assertSame($data['only_allow_merge_if_pipeline_succeeds'], $project->only_allow_merge_if_pipeline_succeeds);
+        $this->assertSame($data['only_allow_merge_if_all_discussions_are_resolved'], $project->only_allow_merge_if_all_discussions_are_resolved);
+        $this->assertSame($data['request_access_enabled'], $project->request_access_enabled);
+        $this->assertSame($data['merge_method'], $project->merge_method);
+        $this->assertSame($data['approvals_before_merge'], $project->approvals_before_merge);
+    }
+}


### PR DESCRIPTION
Hello,

this PR updates the model properties for Group and Project to match the current GitLab API v4 implementation according to (it does not add all additional properties which can be fetched by accessing a single project or group):
* https://docs.gitlab.com/11.11/ee/api/groups.html#list-groups
* https://docs.gitlab.com/11.11/ee/api/projects.html#list-all-projects

For projects this removes the properties `code`, `public`, `private` and `greatest_access_level` which are not returned by the current API version.

Note: I also reordered the project properties to match the GitLab documentation to easier be able to see whether new properties were added.