### PR TITLE
[Jobs] do not encode query parameters at this stage, they are encoded in AbstractApi::preparePath()

### DIFF
--- a/lib/Gitlab/Api/Jobs.php
+++ b/lib/Gitlab/Api/Jobs.php
@@ -81,7 +81,7 @@ class Jobs extends AbstractApi
     public function artifactsByRefName($project_id, $ref_name, $job_name)
     {
         return $this->getAsResponse("projects/".$this->encodePath($project_id)."/jobs/artifacts/".$this->encodePath($ref_name)."/download", array(
-            'job' => $this->encodePath($job_name)
+            'job' => $job_name
         ))->getBody();
     }
 

--- a/lib/Gitlab/Api/Jobs.php
+++ b/lib/Gitlab/Api/Jobs.php
@@ -95,7 +95,7 @@ class Jobs extends AbstractApi
     public function artifactByRefName($project_id, $ref_name, $job_name, $artifact_path)
     {
         return $this->getAsResponse("projects/".$this->encodePath($project_id)."/jobs/artifacts/".$this->encodePath($ref_name)."/raw/".$this->encodePath($artifact_path), array(
-            'job' => $this->encodePath($job_name)
+            'job' => $job_name
         ))->getBody();
     }
 


### PR DESCRIPTION
Hello,

I think there is a mistake here.

@lowtower In the commit 91e47d42e0ce2ae09cb140ad3c2a3b550f67858b, you encoded the query parameter at this stage, do you remember what the reason is?

Thank you.