### PR TITLE
Allow passing arbitrary additional options to MergeRequests#create()

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -109,21 +109,27 @@ class MergeRequests extends AbstractApi
      * @param string $source
      * @param string $target
      * @param string $title
-     * @param int $assignee
-     * @param int $target_project_id
-     * @param string $description
+     * @param int $assignee @deprecated will be moved into $optionalParams
+     * @param int $target_project_id @deprecated will be moved into $optionalParams
+     * @param string $description @deprecated will be moved into $optionalParams
+     * @param array $optionalParams
      * @return mixed
      */
-    public function create($project_id, $source, $target, $title, $assignee = null, $target_project_id = null, $description = null)
+    public function create($project_id, $source, $target, $title, $assignee = null, $target_project_id = null, $description = null, array $optionalParams = [])
     {
-        return $this->post($this->getProjectPath($project_id, 'merge_requests'), array(
+        $baseParams = [
             'source_branch' => $source,
             'target_branch' => $target,
             'title' => $title,
             'assignee_id' => $assignee,
+            'description' => $description,
             'target_project_id' => $target_project_id,
-            'description' => $description
-        ));
+        ];
+
+        return $this->post(
+            $this->getProjectPath($project_id, 'merge_requests'),
+            array_merge($baseParams, $optionalParams)
+        );
     }
 
     /**

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -147,14 +147,27 @@ class MergeRequestsTest extends TestCase
                 'title' => 'Merge Request',
                 'target_branch' => 'master',
                 'source_branch' => 'develop',
-                'description' => 'Some changes',
                 'assignee_id' => 6,
-                'target_project_id' => 20
+                'target_project_id' => 20,
+                'description' => 'Some changes',
+                'remove_source_branch' => true,
             ))
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->create(1, 'develop', 'master', 'Merge Request', 6, 20, 'Some changes'));
+        $this->assertEquals(
+            $expectedArray,
+            $api->create(
+                1,
+                'develop',
+                'master',
+                'Merge Request',
+                6,
+                20,
+                'Some changes',
+                ['remove_source_branch' => true]
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
I added the additional parameters in a non-breaking way for now.

For the next major release, the API should be cleaned up and move all optional parameters into the array parameter.