### PR TITLE
Facilitate creating pipelines with variables

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -235,12 +235,26 @@ class Projects extends AbstractApi
     /**
      * @param int $project_id
      * @param string $commit_ref
+     * @param array $variables (
+     *     @var array (
+     *         @var string $key             The name of the variable
+     *         @var mixed $value            The value of the variable
+     *         @var string $variable_type   env_var (default) or file
+     *     )
+     * )
      * @return mixed
      */
-    public function createPipeline($project_id, $commit_ref)
+    public function createPipeline($project_id, $commit_ref, $variables = null)
     {
-        return $this->post($this->getProjectPath($project_id, 'pipeline'), array(
-            'ref' => $commit_ref));
+        $parameters = array(
+            'ref' => $commit_ref,
+        );
+
+        if ($variables !== null) {
+            $parameters['variables'] = $variables;
+        }
+
+        return $this->post($this->getProjectPath($project_id, 'pipeline'), $parameters);
     }
 
     /**

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -570,6 +570,35 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldCreatePipelineWithVariables()
+    {
+        $expectedArray = array(
+            array('id' => 4, 'status' => 'created', 'ref' => 'test-pipeline')
+        );
+        $variables = array(
+            array(
+                'key' => 'test_var_1',
+                'value' => 'test_value_1'
+            ),
+            array(
+                'key' => 'test_var_2',
+                'variable_type' => 'file',
+                'value' => 'test_value_2'
+            )
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/pipeline', array('ref' => 'test-pipeline', 'variables' => $variables))
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->createPipeline(1, 'test-pipeline', $variables));
+    }
+
+    /**
+     * @test
+     */
     public function shouldRetryPipeline()
     {
         $expectedArray = array(


### PR DESCRIPTION
Resolves #461 

I started adding an OptionsResolver to validate the variables, but it doesn't appear to be possible to validate non-associative arrays of arrays. See https://github.com/symfony/symfony/issues/34207

The lack of validation does mean that it's compatible with GitLab versions pre and post 11.11.