### PR TITLE
Add method to get issues for a group.

### DIFF
--- a/lib/Gitlab/Api/Issues.php
+++ b/lib/Gitlab/Api/Issues.php
@@ -21,36 +21,17 @@ class Issues extends AbstractApi
      */
     public function all($project_id = null, array $parameters = [])
     {
-        $resolver = $this->createOptionsResolver();
-
-        $resolver->setDefined('state')
-            ->setAllowedValues('state', ['opened', 'closed'])
-        ;
-        $resolver->setDefined('labels');
-        $resolver->setDefined('milestone');
-        $resolver->setDefined('iids')
-            ->setAllowedTypes('iids', 'array')
-            ->setAllowedValues('iids', function (array $value) {
-                return count($value) == count(array_filter($value, 'is_int'));
-            })
-        ;
-        $resolver->setDefined('scope')
-            ->setAllowedValues('scope', ['created-by-me', 'assigned-to-me', 'all'])
-        ;
-        $resolver->setDefined('order_by')
-            ->setAllowedValues('order_by', ['created_at', 'updated_at'])
-        ;
-        $resolver->setDefined('sort')
-            ->setAllowedValues('sort', ['asc', 'desc'])
-        ;
-        $resolver->setDefined('search');
-        $resolver->setDefined('assignee_id')
-            ->setAllowedTypes('assignee_id', 'integer')
-        ;
-
         $path = $project_id === null ? 'issues' : $this->getProjectPath($project_id, 'issues');
 
-        return $this->get($path, $resolver->resolve($parameters));
+        return $this->get($path, $this->createOptionsResolver()->resolve($parameters));
+    }
+
+    public function group($group_id, array $parameters = [])
+    {
+        return $this->get(
+            $this->getGroupPath($group_id, 'issues'),
+            $this->createOptionsResolver()->resolve($parameters)
+        );
     }
 
     /**
@@ -327,5 +308,40 @@ class Issues extends AbstractApi
     public function closedByMergeRequests($project_id, $issue_iid)
     {
         return $this->get($this->getProjectPath($project_id, 'issues/'.$this->encodePath($issue_iid)).'/closed_by');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function createOptionsResolver()
+    {
+        $resolver = parent::createOptionsResolver();
+
+        $resolver->setDefined('state')
+            ->setAllowedValues('state', ['opened', 'closed'])
+        ;
+        $resolver->setDefined('labels');
+        $resolver->setDefined('milestone');
+        $resolver->setDefined('iids')
+            ->setAllowedTypes('iids', 'array')
+            ->setAllowedValues('iids', function (array $value) {
+                return count($value) == count(array_filter($value, 'is_int'));
+            })
+        ;
+        $resolver->setDefined('scope')
+            ->setAllowedValues('scope', ['created-by-me', 'assigned-to-me', 'all'])
+        ;
+        $resolver->setDefined('order_by')
+            ->setAllowedValues('order_by', ['created_at', 'updated_at'])
+        ;
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['asc', 'desc'])
+        ;
+        $resolver->setDefined('search');
+        $resolver->setDefined('assignee_id')
+            ->setAllowedTypes('assignee_id', 'integer')
+        ;
+
+        return $resolver;
     }
 }

--- a/test/Gitlab/Tests/Api/IssuesTest.php
+++ b/test/Gitlab/Tests/Api/IssuesTest.php
@@ -25,6 +25,66 @@ class IssuesTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetAllGroupIssues()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'title' => 'An issue'),
+            array('id' => 2, 'title' => 'Another issue'),
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/issues', array())
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->group(1));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetGroupIssuesWithPagination()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'title' => 'An issue'),
+            array('id' => 2, 'title' => 'Another issue'),
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/issues', array('page' => 2, 'per_page' => 5))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->group(1, ['page' => 2, 'per_page' => 5]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetGroupIssuesWithParams()
+    {
+        $expectedArray = array(
+            array('id' => 1, 'title' => 'An issue'),
+            array('id' => 2, 'title' => 'Another issue'),
+        );
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/issues', array('order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'opened'))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->group(1, array('order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'opened')));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetProjectIssuesWithPagination()
     {
         $expectedArray = array(


### PR DESCRIPTION
Distinct method group() was added to Issues api route to enable getting issues for a group.

In fact, there should be 3 methods: all(), group() and project() (like in IssuesStatistics), but removing $project_id parameter from all() method now will result in a breaking change.