### PR TITLE
[9.18] Adding 'stats' property to Commit model

### DIFF
--- a/lib/Gitlab/Model/Commit.php
+++ b/lib/Gitlab/Model/Commit.php
@@ -39,7 +39,8 @@ class Commit extends AbstractModel
         'authored_date',
         'committed_date',
         'created_at',
-        'project'
+        'project',
+        'stats'
     );
 
     /**


### PR DESCRIPTION
So, when I'm trying to get list of commits with 'with_stats' property - the array 'stats' which Gitlab returns dissapears because no such property added.