### PR TITLE
Implement merge request API rebase endpoint

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -379,4 +379,19 @@ class MergeRequests extends AbstractApi
     {
         return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_iid).'/award_emoji'));
     }
+
+    /**
+     * @param int $project_id
+     * @param int $mr_id
+     * @param array $params
+     * @return mixed
+     */
+    public function rebase($project_id, $mr_id, array $params = [])
+    {
+        $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('skip_ci')
+            ->setAllowedTypes('skip_ci', 'bool');
+
+        return $this->put($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id)).'/rebase', $resolver->resolve($params));
+    }
 }

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -518,4 +518,23 @@ class MergeRequestsTest extends TestCase
     {
         return 'Gitlab\Api\MergeRequests';
     }
+
+    /**
+     * @test
+     */
+    public function shouldRebaseMergeRequest()
+    {
+        $expectedArray = array('rebase_in_progress' => true);
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('projects/1/merge_requests/2/rebase', array('skip_ci' => true))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->rebase(1, 2, array(
+            'skip_ci' => true,
+        )));
+    }
 }


### PR DESCRIPTION
The Gitlab merge request API added support for automatically rebasing the source_branch of the merge request against its target_branch (see: https://docs.gitlab.com/ee/api/merge_requests.html#rebase-a-merge-request). The code contained in this commit implements this feature.

* Add Rebase MR API call
* Add test for rebase MR