### PR TITLE
Implement optional parameters for show single MR API endpoint

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -97,11 +97,23 @@ class MergeRequests extends AbstractApi
     /**
      * @param int $project_id
      * @param int $mr_id
+     * @param array $parameters {
+     *     @var bool               $include_diverged_commits_count      Return the commits behind the target branch
+     *     @var bool               $include_rebase_in_progress          Return whether a rebase operation is in progress
+     * }
      * @return mixed
      */
-    public function show($project_id, $mr_id)
+    public function show($project_id, $mr_id, $parameters = [])
     {
-        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id)));
+        $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('include_diverged_commits_count')
+            ->setAllowedTypes('include_diverged_commits_count', 'bool')
+        ;
+        $resolver->setDefined('include_rebase_in_progress')
+            ->setAllowedTypes('include_rebase_in_progress', 'bool')
+        ;
+
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id)), $resolver->resolve($parameters));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -108,6 +108,31 @@ class MergeRequestsTest extends TestCase
 
         $this->assertEquals($expectedArray, $api->show(1, 2));
     }
+    
+    /**
+     * @test
+     */
+    public function shouldShowMergeRequestWithOptionalParameters()
+    {
+        $expectedArray = array(
+            'id' => 2,
+            'name' => 'A merge request',
+            'diverged_commits_count' => 0,
+            'rebase_in_progress' => false
+        );
+        
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/merge_requests/2', array('include_diverged_commits_count' => true,  'include_rebase_in_progress' => true))
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->show(1, 2, array(
+            'include_diverged_commits_count' => true,
+            'include_rebase_in_progress' => true
+        )));
+    }
 
     /**
      * @test


### PR DESCRIPTION
The Gitlab merge request API has several optional parameters for the show single merge request API endpoint (see: https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr). The code contained in this commit implements those optional parameters EXCEPT `render_html`.

* Add optional parameters for show single MR
* Extend test for show single MR