### PR TITLE
[9.18] Add scope and allow all projects to merge request api

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -12,12 +12,14 @@ class MergeRequests extends AbstractApi
     const STATE_CLOSED = 'closed';
 
     /**
-     * @param int   $project_id
+     * @param int|null   $project_id               Return the merge requests for all projects or a specific project
      * @param array $parameters {
      *
      *     @var int[]              $iids           Return the request having the given iid.
      *     @var string             $state          Return all merge requests or just those that are opened, closed, or
      *                                             merged.
+     *     @var string             $scope          Return merge requests for the given scope: created-by-me,
+     *                                             assigned-to-me or all. Defaults to created-by-me.
      *     @var string             $order_by       Return requests ordered by created_at or updated_at fields. Default
      *                                             is created_at.
      *     @var string             $sort           Return requests sorted in asc or desc order. Default is desc.
@@ -34,7 +36,7 @@ class MergeRequests extends AbstractApi
      *
      * @return mixed
      */
-    public function all($project_id, array $parameters = [])
+    public function all($project_id = null, array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value) {
@@ -48,6 +50,9 @@ class MergeRequests extends AbstractApi
         ;
         $resolver->setDefined('state')
             ->setAllowedValues('state', ['all', 'opened', 'merged', 'closed'])
+        ;
+        $resolver->setDefined('scope')
+            ->setAllowedValues('scope', ['created-by-me', 'assigned-to-me', 'all'])
         ;
         $resolver->setDefined('order_by')
             ->setAllowedValues('order_by', ['created_at', 'updated_at'])
@@ -91,7 +96,9 @@ class MergeRequests extends AbstractApi
         $resolver->setDefined('source_branch');
         $resolver->setDefined('target_branch');
 
-        return $this->get($this->getProjectPath($project_id, 'merge_requests'), $resolver->resolve($parameters));
+        $path = $project_id === null ? 'merge_requests' : $this->getProjectPath($project_id, 'merge_requests');
+
+        return $this->get($path, $resolver->resolve($parameters));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -24,6 +24,23 @@ class MergeRequestsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetAllWithNoProject()
+    {
+        $expectedArray = $this->getMultipleMergeRequestsData();
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('merge_requests', array())
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->all());
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetAllWithParams()
     {
         $expectedArray = $this->getMultipleMergeRequestsData();
@@ -108,7 +125,7 @@ class MergeRequestsTest extends TestCase
 
         $this->assertEquals($expectedArray, $api->show(1, 2));
     }
-    
+
     /**
      * @test
      */
@@ -120,7 +137,7 @@ class MergeRequestsTest extends TestCase
             'diverged_commits_count' => 0,
             'rebase_in_progress' => false
         );
-        
+
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')


### PR DESCRIPTION
Adds scope to merge request API and have made project_id optional on the merge request which was added in Gitlab 9.5:
- https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-requests

Carry https://github.com/m4tthumphrey/php-gitlab-api/pull/287 by @biggins

Rebased against 3050e6d
