### PR TITLE
[9.18] Add some methods related to merge requests approvals

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -416,4 +416,17 @@ class MergeRequests extends AbstractApi
     {
         return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_iid).'/approval_rules'));
     }
+
+    public function createLevelRule($project_id, $mr_iid, $name, $approvals_required, array $optionalParameters = [])
+    {
+        $baseParam = [
+            'name' => $name,
+            'approvals_required' => $approvals_required,
+        ];
+
+        return $this->post(
+            $this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_iid).'/approval_rules'),
+            array_merge($baseParam, $optionalParameters)
+        );
+    }
 }

--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -429,4 +429,17 @@ class MergeRequests extends AbstractApi
             array_merge($baseParam, $optionalParameters)
         );
     }
+
+    public function updateLevelRule($project_id, $mr_iid, $approval_rule_id, $name, $approvals_required, array $optionalParameters = [])
+    {
+        $baseParam = [
+            'name' => $name,
+            'approvals_required' => $approvals_required,
+        ];
+
+        return $this->put(
+            $this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_iid).'/approval_rules/'.$this->encodePath($approval_rule_id)),
+            array_merge($baseParam, $optionalParameters)
+        );
+    }
 }

--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -442,4 +442,9 @@ class MergeRequests extends AbstractApi
             array_merge($baseParam, $optionalParameters)
         );
     }
+
+    public function deleteLevelRule($project_id, $mr_iid, $approval_rule_id)
+    {
+        return $this->delete($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_iid).'/approval_rules/'.$this->encodePath($approval_rule_id)));
+    }
 }

--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -406,4 +406,9 @@ class MergeRequests extends AbstractApi
 
         return $this->put($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_id)).'/rebase', $resolver->resolve($params));
     }
+
+    public function approvalState($project_id, $mr_iid)
+    {
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_iid).'/approval_state'));
+    }
 }

--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -411,4 +411,9 @@ class MergeRequests extends AbstractApi
     {
         return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_iid).'/approval_state'));
     }
+
+    public function levelRules($project_id, $mr_iid)
+    {
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.$this->encodePath($mr_iid).'/approval_rules'));
+    }
 }

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -952,4 +952,9 @@ class Projects extends AbstractApi
     {
         return $this->get('projects/'.$this->encodePath($project_id).'/approvals');
     }
+
+    public function approvalsRules($project_id)
+    {
+        return $this->get('projects/'.$this->encodePath($project_id).'/approval_rules');
+    }
 }

--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -947,4 +947,9 @@ class Projects extends AbstractApi
     {
         return $this->post($this->getProjectPath($project_id, 'protected_branches'), $params);
     }
+
+    public function approvalsConfiguration($project_id)
+    {
+        return $this->get('projects/'.$this->encodePath($project_id).'/approvals');
+    }
 }

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -531,6 +531,25 @@ class MergeRequestsTest extends TestCase
         $this->assertEquals($expectedArray, $api->awardEmoji(1, 2));
     }
 
+    /**
+     * @test
+     */
+    public function shoudGetApprovalState()
+    {
+        $expectedArray = [
+            'approval_rules_overwritten' => 1,
+            'rules' => [],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/merge_requests/2/approval_state')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->approvalState(1, 2));
+    }
+
     protected function getMultipleMergeRequestsData()
     {
         return array(

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -654,6 +654,79 @@ class MergeRequestsTest extends TestCase
         ]));
     }
 
+    /**
+     * @test
+     */
+    public function shoudUpdateLevelRuleWithoutOptionalParameters()
+    {
+        $expectedArray = [
+            'id' => 20892835,
+            'name' => 'Foo',
+            'rule_type' => 'regular',
+            'eligible_approvers' => [],
+            'approvals_required' => 3,
+            'users' => [],
+            'groups' => [],
+            'contains_hidden_groups' => null,
+            'section' => null,
+            'source_rule' => null,
+            'overridden' => null,
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with(
+                'projects/1/merge_requests/2/approval_rules/20892835',
+                [
+                    'name' => 'Foo',
+                    'approvals_required' => 3,
+                ]
+            )
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->updateLevelRule(1, 2, 20892835, 'Foo', 3));
+    }
+
+    /**
+     * @test
+     */
+    public function shoudUpdateLevelRuleWithOptionalParameters()
+    {
+        $expectedArray = [
+            'id' => 20892835,
+            'name' => 'Foo',
+            'rule_type' => 'regular',
+            'eligible_approvers' => [],
+            'approvals_required' => 3,
+            'users' => [1951878],
+            'groups' => [104121],
+            'contains_hidden_groups' => null,
+            'section' => null,
+            'source_rule' => null,
+            'overridden' => null,
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with(
+                'projects/1/merge_requests/2/approval_rules/20892835',
+                [
+                    'name' => 'Foo',
+                    'approvals_required' => 3,
+                    'user_ids' => [1951878],
+                    'group_ids' => [104121],
+                ]
+            )
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->updateLevelRule(1, 2, 20892835, 'Foo', 3, [
+            'user_ids' => [1951878],
+            'group_ids' => [104121],
+        ]));
+    }
+
     protected function getMultipleMergeRequestsData()
     {
         return array(

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -550,6 +550,37 @@ class MergeRequestsTest extends TestCase
         $this->assertEquals($expectedArray, $api->approvalState(1, 2));
     }
 
+
+    /**
+     * @test
+     */
+    public function shoudGetLevelRules()
+    {
+        $expectedArray = [
+            [
+                'id' => 1,
+                'name' => 'Foo',
+                'rule_type' => 'regular',
+                'eligible_approvers' => [],
+                'approvals_required' => 1,
+                'users' => [],
+                'groups' => [],
+                'contains_hidden_groups' => null,
+                'section' => null,
+                'source_rule' => null,
+                'overridden' => null,
+            ],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/merge_requests/2/approval_rules')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->levelRules(1, 2));
+    }
+
     protected function getMultipleMergeRequestsData()
     {
         return array(

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -581,6 +581,79 @@ class MergeRequestsTest extends TestCase
         $this->assertEquals($expectedArray, $api->levelRules(1, 2));
     }
 
+    /**
+     * @test
+     */
+    public function shoudCreateLevelRuleWithoutOptionalParameters()
+    {
+        $expectedArray = [
+            'id' => 20892835,
+            'name' => 'Foo',
+            'rule_type' => 'regular',
+            'eligible_approvers' => [],
+            'approvals_required' => 3,
+            'users' => [],
+            'groups' => [],
+            'contains_hidden_groups' => null,
+            'section' => null,
+            'source_rule' => null,
+            'overridden' => null,
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with(
+                'projects/1/merge_requests/2/approval_rules',
+                [
+                    'name' => 'Foo',
+                    'approvals_required' => 3,
+                ]
+            )
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->createLevelRule(1, 2, 'Foo', 3));
+    }
+
+    /**
+     * @test
+     */
+    public function shoudCreateLevelRuleWithOptionalParameters()
+    {
+        $expectedArray = [
+            'id' => 20892835,
+            'name' => 'Foo',
+            'rule_type' => 'regular',
+            'eligible_approvers' => [],
+            'approvals_required' => 3,
+            'users' => [1951878],
+            'groups' => [104121],
+            'contains_hidden_groups' => null,
+            'section' => null,
+            'source_rule' => null,
+            'overridden' => null,
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with(
+                'projects/1/merge_requests/2/approval_rules',
+                [
+                    'name' => 'Foo',
+                    'approvals_required' => 3,
+                    'user_ids' => [1951878],
+                    'group_ids' => [104121],
+                ]
+            )
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->createLevelRule(1, 2, 'Foo', 3, [
+            'user_ids' => [1951878],
+            'group_ids' => [104121],
+        ]));
+    }
+
     protected function getMultipleMergeRequestsData()
     {
         return array(

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -727,6 +727,22 @@ class MergeRequestsTest extends TestCase
         ]));
     }
 
+    /**
+     * @test
+     */
+    public function shoudDeleteLevelRule()
+    {
+        $expectedValue = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/merge_requests/2/approval_rules/3')
+            ->will($this->returnValue($expectedValue));
+
+        $this->assertEquals($expectedValue, $api->deleteLevelRule(1, 2, 3));
+    }
+
     protected function getMultipleMergeRequestsData()
     {
         return array(

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -1839,6 +1839,28 @@ class ProjectsTest extends TestCase
         $this->assertEquals($expectedArray, $api->addProtectedBranch(1, array('name' => 'master', 'push_access_level' => 0, 'merge_access_level' => 30)));
     }
 
+    public function shoudGetApprovalsConfiguration()
+    {
+        $expectedArray = [
+            'approvers' => [],
+            'approver_groups' => [],
+            'approvals_before_merge' => 1,
+            'reset_approvals_on_push' => true,
+            'disable_overriding_approvers_per_merge_request' => null,
+            'merge_requests_author_approval' => null,
+            'merge_requests_disable_committers_approval' => null,
+            'require_password_to_approve' => null,
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/approvals')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->approvalsConfiguration(1));
+    }
+
     protected function getApiClass()
     {
         return 'Gitlab\Api\Projects';

--- a/test/Gitlab/Tests/Api/ProjectsTest.php
+++ b/test/Gitlab/Tests/Api/ProjectsTest.php
@@ -1861,6 +1861,31 @@ class ProjectsTest extends TestCase
         $this->assertEquals($expectedArray, $api->approvalsConfiguration(1));
     }
 
+    public function shoudGetApprovalRules()
+    {
+        $expectedArray = [
+            [
+                'id' => 1,
+                'name' => 'All Members',
+                'rule_type' => 'any_approver',
+                'eligible_approvers' => [],
+                'approvals_required' => 1,
+                'users' => [],
+                'groups' => [],
+                'contains_hidden_groups' => false,
+                'protected_branches' => [],
+            ],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/approval_rules')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->approvalRules(1));
+    }
+
     protected function getApiClass()
     {
         return 'Gitlab\Api\Projects';


### PR DESCRIPTION
This PR add methods for these API endpoints:
* https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-configuration
* https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-project-level-rules
* https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-the-approval-state-of-merge-requests
* https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-merge-request-level-rules
* https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-merge-request-level-rule
* https://docs.gitlab.com/ee/api/merge_request_approvals.html#update-merge-request-level-rule
* https://docs.gitlab.com/ee/api/merge_request_approvals.html#delete-merge-request-level-rule
