### PR TITLE
[9.19] Added user events

### DIFF
--- a/lib/Gitlab/Api/Users.php
+++ b/lib/Gitlab/Api/Users.php
@@ -486,5 +486,6 @@ class Users extends AbstractApi
             ->setAllowedValues('sort', ['asc', 'desc'])
         ;
 
-        return $this->get('users/'.$this->encodePath($user_id).'/events', $resolver->resolve($parameters));    }
+        return $this->get('users/'.$this->encodePath($user_id).'/events', $resolver->resolve($parameters));
+    }
 }

--- a/lib/Gitlab/Api/Users.php
+++ b/lib/Gitlab/Api/Users.php
@@ -450,8 +450,8 @@ class Users extends AbstractApi
     }
 
     /**
-     * @param int $user_id
-     * @param array      $parameters {
+     * @param int   $user_id
+     * @param array $parameters {
      *
      *     @var string             $action      include only events of a particular action type
      *     @var string             $target_type include only events of a particular target type

--- a/lib/Gitlab/Api/Users.php
+++ b/lib/Gitlab/Api/Users.php
@@ -448,4 +448,44 @@ class Users extends AbstractApi
     {
         return $this->delete('users/'.$this->encodePath($user_id).'/impersonation_tokens/'.$this->encodePath($impersonation_token_id));
     }
+
+    /**
+     * @param int|string $user_id
+     * @param array      $parameters {
+     *
+     *     @var string             $action      include only events of a particular action type
+     *     @var string             $target_type include only events of a particular target type
+     *     @var \DateTimeInterface $before      include only events created before a particular date
+     *     @var \DateTimeInterface $after       include only events created after a particular date
+     *     @var string             $sort        Sort events in asc or desc order by created_at (default is desc)
+     * }
+     *
+     * @return mixed
+     */
+    public function events($user_id, array $parameters = [])
+    {
+        $resolver = $this->createOptionsResolver();
+        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value) {
+            return $value->format('Y-m-d');
+        };
+
+        $resolver->setDefined('action')
+            ->setAllowedValues('action', ['created', 'updated', 'closed', 'reopened', 'pushed', 'commented', 'merged', 'joined', 'left', 'destroyed', 'expired'])
+        ;
+        $resolver->setDefined('target_type')
+            ->setAllowedValues('target_type', ['issue', 'milestone', 'merge_request', 'note', 'project', 'snippet', 'user'])
+        ;
+        $resolver->setDefined('before')
+            ->setAllowedTypes('before', \DateTimeInterface::class)
+            ->setNormalizer('before', $datetimeNormalizer);
+        $resolver->setDefined('after')
+            ->setAllowedTypes('after', \DateTimeInterface::class)
+            ->setNormalizer('after', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['asc', 'desc'])
+        ;
+
+        return $this->get('users/' . $this->encodePath($user_id) . '/events', $resolver->resolve($parameters));
+    }
 }

--- a/lib/Gitlab/Api/Users.php
+++ b/lib/Gitlab/Api/Users.php
@@ -450,7 +450,7 @@ class Users extends AbstractApi
     }
 
     /**
-     * @param int|string $user_id
+     * @param int $user_id
      * @param array      $parameters {
      *
      *     @var string             $action      include only events of a particular action type

--- a/lib/Gitlab/Api/Users.php
+++ b/lib/Gitlab/Api/Users.php
@@ -486,6 +486,5 @@ class Users extends AbstractApi
             ->setAllowedValues('sort', ['asc', 'desc'])
         ;
 
-        return $this->get('users/' . $this->encodePath($user_id) . '/events', $resolver->resolve($parameters));
-    }
+        return $this->get('users/'.$this->encodePath($user_id).'/events', $resolver->resolve($parameters));    }
 }

--- a/test/Gitlab/Tests/Api/UsersTest.php
+++ b/test/Gitlab/Tests/Api/UsersTest.php
@@ -757,8 +757,8 @@ class UsersTest extends TestCase
         $before = new \DateTime('2018-01-31 00:00:00');
 
         $expectedWithArray = [
-        'after' => $after->format('Y-m-d'),
-        'before' => $before->format('Y-m-d'),
+            'after' => $after->format('Y-m-d'),
+            'before' => $before->format('Y-m-d'),
         ];
 
         $api = $this->getApiMock();

--- a/test/Gitlab/Tests/Api/UsersTest.php
+++ b/test/Gitlab/Tests/Api/UsersTest.php
@@ -723,4 +723,72 @@ class UsersTest extends TestCase
     {
         return 'Gitlab\Api\Users';
     }
+
+    /**
+     * @test
+     */
+    public function shouldGetEvents()
+    {
+        $expectedArray = [
+            ['id' => 1, 'title' => 'An event'],
+            ['id' => 2, 'title' => 'Another event'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('users/1/events', [])
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->events(1));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetEventsWithDateTimeParams()
+    {
+        $expectedArray = [
+            ['id' => 1, 'title' => 'An event'],
+            ['id' => 2, 'title' => 'Another event'],
+        ];
+
+        $after = new \DateTime('2018-01-01 00:00:00');
+        $before = new \DateTime('2018-01-31 00:00:00');
+
+        $expectedWithArray = [
+        'after' => $after->format('Y-m-d'),
+        'before' => $before->format('Y-m-d'),
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('users/1/events', $expectedWithArray)
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->events(1, ['after' => $after, 'before' => $before]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetEventsWithPagination()
+    {
+        $expectedArray = [
+            ['id' => 1, 'title' => 'An event'],
+            ['id' => 2, 'title' => 'Another event'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('users/1/events', [
+                'page' => 2,
+                'per_page' => 15,
+            ])
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->events(1, ['page' => 2, 'per_page' => 15]));
+    }
 }


### PR DESCRIPTION
I've added a missing API call to /users/:id/events to retrieve events for a specified user
See https://docs.gitlab.com/ee/api/events.html#get-user-contribution-events