### PR TITLE
Add method impersonate() to Client to act on a users behalf

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -338,8 +338,43 @@ class Client
      */
     public function authenticate(string $token, string $authMethod, string $sudo = null)
     {
-        $this->getHttpClientBuilder()->removePlugin(Authentication::class);
-        $this->getHttpClientBuilder()->addPlugin(new Authentication($authMethod, $token, $sudo));
+        $httpClientBuilder = $this->getHttpClientBuilder();
+        $httpClientBuilder->removePlugin(Authentication::class);
+        $httpClientBuilder->addPlugin(new Authentication($authMethod, $token, $sudo));
+
+        return $this;
+    }
+
+    /**
+     * Impersonate a user and act on their behalf.
+     *
+     * - temporarily fetches an impersonation token
+     * - authenticates with it
+     * - allows the user to act within the scope of the callback
+     * - purges the token
+     *
+     * @param int      $userId Id of the user to act as
+     * @param callable $act    Will be called with $this, authenticated as the user
+     *
+     * @return $this
+     */
+    public function impersonate(int $userId, callable $act)
+    {
+        $usersApi = $this->users();
+
+        $tokenResponse = $usersApi->createImpersonationToken($userId, 'gitlab-php-client', ['api']);
+
+        $httpClientBuilder = $this->getHttpClientBuilder();
+        $previousAuthentication = $httpClientBuilder->removePlugin(Authentication::class);
+
+        try {
+            $httpClientBuilder->addPlugin(new Authentication(self::AUTH_HTTP_TOKEN, $tokenResponse['token']));
+            $act($this);
+        } finally {
+            $httpClientBuilder->removePlugin(Authentication::class);
+            $httpClientBuilder->addPlugin($previousAuthentication);
+            $usersApi->removeImpersonationToken($userId, $tokenResponse['id']);
+        }
 
         return $this;
     }

--- a/src/HttpClient/Builder.php
+++ b/src/HttpClient/Builder.php
@@ -170,16 +170,20 @@ class Builder
      *
      * @param string $fqcn
      *
-     * @return void
+     * @return Plugin|null
      */
     public function removePlugin(string $fqcn)
     {
+        $plugin = null;
+
         foreach ($this->plugins as $idx => $plugin) {
             if ($plugin instanceof $fqcn) {
                 unset($this->plugins[$idx]);
                 $this->pluginClient = null;
             }
         }
+
+        return $plugin;
     }
 
     /**


### PR DESCRIPTION
This function conveniently takes care of both creating and revoking the impersonation token and allows making API calls while authenticated as the user.

If this idea is something you want to pursue further, I am happy to add tests and documentation.