### PR TITLE
Add method impersonate() to Client to act on a users behalf

### DIFF
--- a/lib/Gitlab/Client.php
+++ b/lib/Gitlab/Client.php
@@ -497,6 +497,12 @@ class Client
         $tokenResponse = $usersApi->createImpersonationToken($userId, 'gitlab-php-client', ['api']);
 
         $httpClientBuilder = $this->getHttpClientBuilder();
+
+        /**
+         * Can not be null, since we were able to authenticate to get the impersonation token.
+         *
+         * @var Authentication $previousAuthentication
+         */
         $previousAuthentication = $httpClientBuilder->removePlugin(Authentication::class);
 
         try {

--- a/lib/Gitlab/Client.php
+++ b/lib/Gitlab/Client.php
@@ -490,7 +490,7 @@ class Client
      *
      * @return $this
      */
-    public function impersonate(int $userId, callable $act)
+    public function impersonate($userId, callable $act)
     {
         $usersApi = $this->users();
 

--- a/lib/Gitlab/HttpClient/Builder.php
+++ b/lib/Gitlab/HttpClient/Builder.php
@@ -168,16 +168,20 @@ class Builder
      *
      * @param string $fqcn
      *
-     * @return void
+     * @return Plugin|null
      */
     public function removePlugin($fqcn)
     {
+        $plugin = null;
+
         foreach ($this->plugins as $idx => $plugin) {
             if ($plugin instanceof $fqcn) {
                 unset($this->plugins[$idx]);
                 $this->pluginClient = null;
             }
         }
+
+        return $plugin;
     }
 
     /**


### PR DESCRIPTION
This method conveniently takes care of both creating and revoking the impersonation token and allows making API calls while authenticated as the user.

If this idea is something you want to pursue further, I am happy to add tests and documentation.