### PR TITLE
[9.19] Add issue reorder method

### DIFF
--- a/lib/Gitlab/Api/Issues.php
+++ b/lib/Gitlab/Api/Issues.php
@@ -85,17 +85,13 @@ class Issues extends AbstractApi
     /**
      * @param int|string $project_id
      * @param int        $issue_iid
-     * @param null|int   $move_after_id
-     * @param null|int   $move_before_id
+     * @param array      $params
      *
      * @return mixed
      */
-    public function reorder($project_id, $issue_iid, $move_after_id = null, $move_before_id = null)
+    public function reorder($project_id, $issue_iid, array $params = [])
     {
-        return $this->put($this->getProjectPath($project_id, 'issues/'.$this->encodePath($issue_iid)).'/reorder', [
-            'move_after_id' => $move_after_id,
-            'move_before_id' => $move_before_id,
-        ]);
+        return $this->put($this->getProjectPath($project_id, 'issues/'.$this->encodePath($issue_iid)).'/reorder', $params);
     }
 
     /**

--- a/lib/Gitlab/Api/Issues.php
+++ b/lib/Gitlab/Api/Issues.php
@@ -85,6 +85,22 @@ class Issues extends AbstractApi
     /**
      * @param int|string $project_id
      * @param int        $issue_iid
+     * @param null|int   $move_after_id
+     * @param null|int   $move_before_id
+     *
+     * @return mixed
+     */
+    public function reorder($project_id, $issue_iid, $move_after_id = null, $move_before_id = null)
+    {
+        return $this->put($this->getProjectPath($project_id, 'issues/'.$this->encodePath($issue_iid)).'/reorder', [
+            'move_after_id' => $move_after_id,
+            'move_before_id' => $move_before_id,
+        ]);
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $issue_iid
      * @param int|string $to_project_id
      *
      * @return mixed

--- a/lib/Gitlab/Api/Issues.php
+++ b/lib/Gitlab/Api/Issues.php
@@ -89,7 +89,7 @@ class Issues extends AbstractApi
      *
      * @return mixed
      */
-    public function reorder($project_id, $issue_iid, array $params = [])
+    public function reorder($project_id, $issue_iid, array $params)
     {
         return $this->put($this->getProjectPath($project_id, 'issues/'.$this->encodePath($issue_iid)).'/reorder', $params);
     }

--- a/test/Gitlab/Tests/Api/IssuesTest.php
+++ b/test/Gitlab/Tests/Api/IssuesTest.php
@@ -187,7 +187,7 @@ class IssuesTest extends TestCase
             ->with('projects/1/issues/2/reorder', ['move_after_id' => 3, 'move_before_id' => 4])
             ->will($this->returnValue($expectedArray))
         ;
-        $this->assertEquals($expectedArray, $api->reorder(1, 2, 3, 4));
+        $this->assertEquals($expectedArray, $api->reorder(1, 2, ['move_after_id' => 3, 'move_before_id' => 4]));
     }
 
     /**

--- a/test/Gitlab/Tests/Api/IssuesTest.php
+++ b/test/Gitlab/Tests/Api/IssuesTest.php
@@ -178,6 +178,21 @@ class IssuesTest extends TestCase
     /**
      * @test
      */
+    public function shouldReorderIssue()
+    {
+        $expectedArray = ['id' => 2, 'title' => 'A reordered issue'];
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('projects/1/issues/2/reorder', ['move_after_id' => 3, 'move_before_id' => 4])
+            ->will($this->returnValue($expectedArray))
+        ;
+        $this->assertEquals($expectedArray, $api->reorder(1, 2, 3, 4));
+    }
+
+    /**
+     * @test
+     */
     public function shouldMoveIssue()
     {
         $expectedArray = ['id' => 2, 'title' => 'A moved issue'];


### PR DESCRIPTION
In v13.2 GitLab introduced issue reordering: https://docs.gitlab.com/ee/api/issues.html#reorder-an-issue