### PR TITLE
[10.1] Add with_merge_status_recheck option for fetching merge requests

### DIFF
--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -112,6 +112,9 @@ class MergeRequests extends AbstractApi
         $resolver->setDefined('search');
         $resolver->setDefined('source_branch');
         $resolver->setDefined('target_branch');
+        $resolver->setDefined('with_merge_status_recheck')
+            ->setAllowedTypes('with_merge_status_recheck', 'bool')
+        ;
 
         $path = null === $project_id ? 'merge_requests' : $this->getProjectPath($project_id, 'merge_requests');
 

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -145,7 +145,7 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_requests/2', ['include_diverged_commits_count' => true,  'include_rebase_in_progress' => true])
+            ->with('projects/1/merge_requests/2', ['include_diverged_commits_count' => true, 'include_rebase_in_progress' => true, 'with_merge_status_recheck' => true])
             ->will($this->returnValue($expectedArray))
         ;
 

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -65,6 +65,7 @@ class MergeRequestsTest extends TestCase
                 'assignee_id' => 1,
                 'source_branch' => 'develop',
                 'target_branch' => 'master',
+                'with_merge_status_recheck' => true,
             ])
             ->will($this->returnValue($expectedArray))
         ;
@@ -82,6 +83,7 @@ class MergeRequestsTest extends TestCase
             'assignee_id' => 1,
             'source_branch' => 'develop',
             'target_branch' => 'master',
+            'with_merge_status_recheck' => true,
         ]));
     }
 
@@ -145,14 +147,13 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_requests/2', ['include_diverged_commits_count' => true, 'include_rebase_in_progress' => true, 'with_merge_status_recheck' => true])
+            ->with('projects/1/merge_requests/2', ['include_diverged_commits_count' => true,  'include_rebase_in_progress' => true])
             ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->show(1, 2, [
             'include_diverged_commits_count' => true,
             'include_rebase_in_progress' => true,
-            'with_merge_status_recheck' => true,
         ]));
     }
 

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -152,6 +152,7 @@ class MergeRequestsTest extends TestCase
         $this->assertEquals($expectedArray, $api->show(1, 2, [
             'include_diverged_commits_count' => true,
             'include_rebase_in_progress' => true,
+            'with_merge_status_recheck' => true,
         ]));
     }
 


### PR DESCRIPTION
GitLab added `with_merge_status_recheck` in 13.0: https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-requests