### PR TITLE
[9.19] Add with_merge_status_recheck option for fetching merge requests

### DIFF
--- a/lib/Gitlab/Api/MergeRequests.php
+++ b/lib/Gitlab/Api/MergeRequests.php
@@ -110,6 +110,9 @@ class MergeRequests extends AbstractApi
         $resolver->setDefined('search');
         $resolver->setDefined('source_branch');
         $resolver->setDefined('target_branch');
+        $resolver->setDefined('with_merge_status_recheck')
+            ->setAllowedTypes('with_merge_status_recheck', 'bool')
+        ;
 
         $path = null === $project_id ? 'merge_requests' : $this->getProjectPath($project_id, 'merge_requests');
 

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -143,7 +143,7 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_requests/2', ['include_diverged_commits_count' => true,  'include_rebase_in_progress' => true])
+            ->with('projects/1/merge_requests/2', ['include_diverged_commits_count' => true, 'include_rebase_in_progress' => true, 'with_merge_status_recheck' => true])
             ->will($this->returnValue($expectedArray))
         ;
 

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -63,6 +63,7 @@ class MergeRequestsTest extends TestCase
                 'assignee_id' => 1,
                 'source_branch' => 'develop',
                 'target_branch' => 'master',
+                'with_merge_status_recheck' => true,
             ])
             ->will($this->returnValue($expectedArray))
         ;
@@ -80,6 +81,7 @@ class MergeRequestsTest extends TestCase
             'assignee_id' => 1,
             'source_branch' => 'develop',
             'target_branch' => 'master',
+            'with_merge_status_recheck' => true,
         ]));
     }
 
@@ -143,14 +145,13 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_requests/2', ['include_diverged_commits_count' => true, 'include_rebase_in_progress' => true, 'with_merge_status_recheck' => true])
+            ->with('projects/1/merge_requests/2', ['include_diverged_commits_count' => true,  'include_rebase_in_progress' => true])
             ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->show(1, 2, [
             'include_diverged_commits_count' => true,
             'include_rebase_in_progress' => true,
-            'with_merge_status_recheck' => true,
         ]));
     }
 

--- a/test/Gitlab/Tests/Api/MergeRequestsTest.php
+++ b/test/Gitlab/Tests/Api/MergeRequestsTest.php
@@ -150,6 +150,7 @@ class MergeRequestsTest extends TestCase
         $this->assertEquals($expectedArray, $api->show(1, 2, [
             'include_diverged_commits_count' => true,
             'include_rebase_in_progress' => true,
+            'with_merge_status_recheck' => true,
         ]));
     }
 


### PR DESCRIPTION
GitLab added `with_merge_status_recheck` in 13.0: https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-requests