### PR TITLE
[10.0] Add test to ensure iids does not become iids[0] in query string

### DIFF
--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -519,7 +519,7 @@ class MergeRequestsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/merge_requests', ['iids' => [2]])
+            ->with('projects/1/merge_requests', ['iids[]' => 2])
             ->will($this->returnValue($expectedArray))
         ;
 


### PR DESCRIPTION
This is a test for #573 

I observed the same behavior when working around #587 / #588. With our GitLab 13.4.4 instance, I didn’t get an “iids is invalid” error; instead, the parameter was ignored and I got all merge requests.