### PR TITLE
[10.2] Add support for approved_by_ids in MergeRequests API

### DIFF
--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -115,6 +115,12 @@ class MergeRequests extends AbstractApi
         $resolver->setDefined('with_merge_status_recheck')
             ->setAllowedTypes('with_merge_status_recheck', 'bool')
         ;
+        $resolver->setDefined('approved_by_ids')
+            ->setAllowedTypes('approved_by_ids', 'array')
+            ->setAllowedValues('approved_by_ids', function (array $value) {
+                return \count($value) === \count(\array_filter($value, 'is_int'));
+            })
+        ;
 
         $path = null === $project_id ? 'merge_requests' : $this->getProjectPath($project_id, 'merge_requests');
 

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -66,6 +66,7 @@ class MergeRequestsTest extends TestCase
                 'source_branch' => 'develop',
                 'target_branch' => 'master',
                 'with_merge_status_recheck' => true,
+                'approved_by_ids' => [1],
             ])
             ->will($this->returnValue($expectedArray))
         ;
@@ -84,6 +85,7 @@ class MergeRequestsTest extends TestCase
             'source_branch' => 'develop',
             'target_branch' => 'master',
             'with_merge_status_recheck' => true,
+            'approved_by_ids' => [1],
         ]));
     }
 


### PR DESCRIPTION
This PR should fix the problem, described in https://github.com/GitLabPHP/Client/issues/599