### PR TITLE
[11.1] Add 'search_namespaces' for list-all-projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added CI schedule variables endpoints
 * Added support for triggering a pipeline
+* Add 'search_namespaces' parameter for list-all-projects
 
 [11.1.0]: https://github.com/GitLabPHP/Client/compare/11.0.0...11.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added CI schedule variables endpoints
 * Added support for triggering a pipeline
-* Add 'search_namespaces' parameter for list-all-projects
+* Added support for the search_namespaces projects parameter
 
 [11.1.0]: https://github.com/GitLabPHP/Client/compare/11.0.0...11.1.0
 

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -30,6 +30,7 @@ class Projects extends AbstractApi
      *                                              or last_activity_at fields (default is created_at)
      *     @var string $sort                        Return projects sorted in asc or desc order (default is desc)
      *     @var string $search                      return list of projects matching the search criteria
+     *     @var bool   $search_namespaces           Include ancestor namespaces when matching search criteria. 
      *     @var bool   $simple                      return only the ID, URL, name, and path of each project
      *     @var bool   $owned                       limit by projects owned by the current user
      *     @var bool   $membership                  limit by projects that the current user is a member of
@@ -66,6 +67,10 @@ class Projects extends AbstractApi
             ->setAllowedValues('sort', ['asc', 'desc'])
         ;
         $resolver->setDefined('search');
+        $resolver->setDefined('search_namespaces')
+            ->setAllowedTypes('search_namespaces', 'bool')
+            ->setNormalizer('search_namespaces', $booleanNormalizer)
+        ;
         $resolver->setDefined('simple')
             ->setAllowedTypes('simple', 'bool')
             ->setNormalizer('simple', $booleanNormalizer)

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -30,7 +30,7 @@ class Projects extends AbstractApi
      *                                              or last_activity_at fields (default is created_at)
      *     @var string $sort                        Return projects sorted in asc or desc order (default is desc)
      *     @var string $search                      return list of projects matching the search criteria
-     *     @var bool   $search_namespaces           Include ancestor namespaces when matching search criteria. 
+     *     @var bool   $search_namespaces           Include ancestor namespaces when matching search criteria
      *     @var bool   $simple                      return only the ID, URL, name, and path of each project
      *     @var bool   $owned                       limit by projects owned by the current user
      *     @var bool   $membership                  limit by projects that the current user is a member of

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -125,7 +125,6 @@ class ProjectsTest extends TestCase
         $this->assertEquals($expectedArray, $api->all(['search' => 'a project']));
     }
     
-    
     /**
      * @test
      */

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -113,7 +113,7 @@ class ProjectsTest extends TestCase
 
         $this->assertEquals($expectedArray, $api->all(['min_access_level' => $level]));
     }
-    
+
     /**
      * @test
      */
@@ -124,7 +124,7 @@ class ProjectsTest extends TestCase
         $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['search' => 'a project']);
         $this->assertEquals($expectedArray, $api->all(['search' => 'a project']));
     }
-    
+
     /**
      * @test
      */
@@ -1924,15 +1924,15 @@ class ProjectsTest extends TestCase
             ['id' => 2, 'name' => 'Another project'],
         ];
     }
-    
+
     protected function getMultipleProjectsDataWithNamespace()
     {
         return [
             ['id' => 1, 'name' => 'A project', 'namespace' => ['id' => 4, 'name' => 'A namespace', 'path' => 'a_namespace']],
             ['id' => 2, 'name' => 'Another project', 'namespace' => ['id' => 5, 'name' => 'Another namespace', 'path' => 'another_namespace']],
         ];
-    }  
-    
+    }
+
     public function possibleAccessLevels()
     {
         return [

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -132,8 +132,8 @@ class ProjectsTest extends TestCase
     {
         $expectedArray = $this->getMultipleProjectsDataWithNamespace();
 
-        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['search' => 'a_project', 'search_namespaces' => true]);
-        $this->assertEquals($expectedArray, $api->all(['search' => 'a_project', 'search_namespaces' => true]));
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['search' => 'a_project', 'search_namespaces' => 'true']);
+        $this->assertEquals($expectedArray, $api->all(['search' => 'a_project', 'search_namespaces' => 'true']));
     }
 
     /**

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -132,7 +132,7 @@ class ProjectsTest extends TestCase
     {
         $expectedArray = $this->getMultipleProjectsDataWithNamespace();
 
-        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['search' => 'a_project', 'search_namespaces' => true]);
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['search' => 'a_project', 'search_namespaces' => 'true']);
         $this->assertEquals($expectedArray, $api->all(['search' => 'a_project', 'search_namespaces' => true]));
     }
 

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -132,8 +132,8 @@ class ProjectsTest extends TestCase
     {
         $expectedArray = $this->getMultipleProjectsDataWithNamespace();
 
-        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['search' => 'a_project', 'search_namespaces' => 'true']);
-        $this->assertEquals($expectedArray, $api->all(['search' => 'a_project', 'search_namespaces' => 'true']));
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['search' => 'a_project', 'search_namespaces' => true]);
+        $this->assertEquals($expectedArray, $api->all(['search' => 'a_project', 'search_namespaces' => true]));
     }
 
     /**

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -113,7 +113,7 @@ class ProjectsTest extends TestCase
 
         $this->assertEquals($expectedArray, $api->all(['min_access_level' => $level]));
     }
-
+    
     /**
      * @test
      */
@@ -123,6 +123,18 @@ class ProjectsTest extends TestCase
 
         $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['search' => 'a project']);
         $this->assertEquals($expectedArray, $api->all(['search' => 'a project']));
+    }
+    
+    
+    /**
+     * @test
+     */
+    public function shouldSearchProjectsWithNamespace(): void
+    {
+        $expectedArray = $this->getMultipleProjectsDataWithNamespace();
+
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['search' => 'a_project', 'search_namespaces' => true]);
+        $this->assertEquals($expectedArray, $api->all(['search' => 'a_project', 'search_namespaces' => true]));
     }
 
     /**
@@ -1913,7 +1925,15 @@ class ProjectsTest extends TestCase
             ['id' => 2, 'name' => 'Another project'],
         ];
     }
-
+    
+    protected function getMultipleProjectsDataWithNamespace()
+    {
+        return [
+            ['id' => 1, 'name' => 'A project', 'namespace' => ['id' => 4, 'name' => 'A namespace', 'path' => 'a_namespace']],
+            ['id' => 2, 'name' => 'Another project', 'namespace' => ['id' => 5, 'name' => 'Another namespace', 'path' => 'another_namespace']],
+        ];
+    }  
+    
     public function possibleAccessLevels()
     {
         return [


### PR DESCRIPTION
It must be possible to set this parameter for searching the namespace.
https://docs.gitlab.com/ee/api/projects.html#list-all-projects
