### PR TITLE
Added params to /releases call

### DIFF
--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -183,7 +183,7 @@ class Repositories extends AbstractApi
     {
         $resolver = $this->createOptionsResolver();
 
-        return $this->get($this->getProjectPath($project_id, 'releases'), $parameters);
+        return $this->get($this->getProjectPath($project_id, 'releases'), $resolver->resolve($parameters));
     }
 
     /**

--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -178,11 +178,11 @@ class Repositories extends AbstractApi
      *
      * @return mixed
      */
-    public function releases($project_id)
+    public function releases($project_id, array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
 
-        return $this->get($this->getProjectPath($project_id, 'releases'));
+        return $this->get($this->getProjectPath($project_id, 'releases'), $parameters);
     }
 
     /**

--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -175,6 +175,7 @@ class Repositories extends AbstractApi
 
     /**
      * @param int|string $project_id
+     * @param array      $parameters
      *
      * @return mixed
      */


### PR DESCRIPTION
You can also use parameters like `per_page` and `page` on the `/releases` route.