### PR TITLE
[11.2] Add missing parameters to the `GitLab\Api\Projects:all` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [11.2.0] - UPCOMING
 
 * UPCOMING
+* Add support for the following projects parameters: id_after, id_before, last_activity_after, last_activity_before, repository_checksum_failed, repository_storage, wiki_checksum_failed, with_custom_attributes, with_programming_language
 
 ## [11.1.0] - 2021-01-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [11.2.0] - UPCOMING
 
-* UPCOMING
 * Add support for the following projects parameters: id_after, id_before, last_activity_after, last_activity_before, repository_checksum_failed, repository_storage, wiki_checksum_failed, with_custom_attributes, with_programming_language
 
 ## [11.1.0] - 2021-01-25

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -24,31 +24,31 @@ class Projects extends AbstractApi
     /**
      * @param array $parameters {
      *
-     *     @var bool   $archived                    limit by archived status
-     *     @var string $visibility                  limit by visibility public, internal, or private
-     *     @var string $order_by                    Return projects ordered by id, name, path, created_at, updated_at,
-     *                                              last_activity_at, repository_size, storage_size, packages_size or
-     *                                              wiki_size fields (default is created_at)
-     *     @var string $sort                        Return projects sorted in asc or desc order (default is desc)
-     *     @var string $search                      return list of projects matching the search criteria
-     *     @var bool   $search_namespaces           Include ancestor namespaces when matching search criteria
-     *     @var bool   $simple                      return only the ID, URL, name, and path of each project
-     *     @var bool   $owned                       limit by projects owned by the current user
-     *     @var bool   $membership                  limit by projects that the current user is a member of
-     *     @var bool   $starred                     limit by projects starred by the current user
-     *     @var bool   $statistics                  include project statistics
-     *     @var bool   $with_issues_enabled         limit by enabled issues feature
-     *     @var bool   $with_merge_requests_enabled limit by enabled merge requests feature
-     *     @var int    $min_access_level            Limit by current user minimal access level
-     *     @var int    $id_after                    Limit by project id's greater than the specified id
-     *     @var int    $id_before                   Limit by project id's less than the specified id
-     *     @var \DateTimeInterface $last_activity_after  Limit by last_activity after specified time
-     *     @var \DateTimeInterface $last_activity_before Limit by last_activity before specified time
-     *     @var bool   $repository_checksum_failed  Limit by failed repository checksum calculation
-     *     @var string $repository_storage          Limit by repository storage type
-     *     @var bool   $wiki_checksum_failed        Limit by failed wiki checksum calculation
-     *     @var bool   $with_custom_attributes      Include custom attributes in response
-     *     @var string $with_programming_language   Limit by programming language
+     *     @var bool               $archived                    limit by archived status
+     *     @var string             $visibility                  limit by visibility public, internal, or private
+     *     @var string             $order_by                    Return projects ordered by id, name, path, created_at, updated_at,
+     *                                                          last_activity_at, repository_size, storage_size, packages_size or
+     *                                                          wiki_size fields (default is created_at)
+     *     @var string             $sort                        Return projects sorted in asc or desc order (default is desc)
+     *     @var string             $search                      return list of projects matching the search criteria
+     *     @var bool               $search_namespaces           Include ancestor namespaces when matching search criteria
+     *     @var bool               $simple                      return only the ID, URL, name, and path of each project
+     *     @var bool               $owned                       limit by projects owned by the current user
+     *     @var bool               $membership                  limit by projects that the current user is a member of
+     *     @var bool               $starred                     limit by projects starred by the current user
+     *     @var bool               $statistics                  include project statistics
+     *     @var bool               $with_issues_enabled         limit by enabled issues feature
+     *     @var bool               $with_merge_requests_enabled limit by enabled merge requests feature
+     *     @var int                $min_access_level            Limit by current user minimal access level
+     *     @var int                $id_after                    Limit by project id's greater than the specified id
+     *     @var int                $id_before                   Limit by project id's less than the specified id
+     *     @var \DateTimeInterface $last_activity_after         Limit by last_activity after specified time
+     *     @var \DateTimeInterface $last_activity_before        Limit by last_activity before specified time
+     *     @var bool               $repository_checksum_failed  Limit by failed repository checksum calculation
+     *     @var string             $repository_storage          Limit by repository storage type
+     *     @var bool               $wiki_checksum_failed        Limit by failed wiki checksum calculation
+     *     @var bool               $with_custom_attributes      Include custom attributes in response
+     *     @var string             $with_programming_language   Limit by programming language
      * }
      *
      * @throws UndefinedOptionsException If an option name is undefined

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -127,11 +127,11 @@ class Projects extends AbstractApi
             ->setAllowedTypes('id_before', 'integer')
         ;
         $resolver->setDefined('last_activity_after')
-            ->setAllowedTypes('last_activity_after', \DateTimeInterface::class)
+            ->setAllowedTypes('last_activity_after', DateTimeInterface::class)
             ->setNormalizer('last_activity_after', $datetimeNormalizer)
         ;
         $resolver->setDefined('last_activity_before')
-            ->setAllowedTypes('last_activity_before', \DateTimeInterface::class)
+            ->setAllowedTypes('last_activity_before', DateTimeInterface::class)
             ->setNormalizer('last_activity_before', $datetimeNormalizer)
         ;
         $resolver->setDefined('repository_checksum_failed')

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -129,10 +129,6 @@ class Projects extends AbstractApi
             ->setNormalizer('repository_checksum_failed', $booleanNormalizer)
         ;
         $resolver->setDefined('repository_storage');
-        $resolver->setDefined('starred')
-            ->setAllowedTypes('starred', 'bool')
-            ->setNormalizer('starred', $booleanNormalizer)
-        ;
         $resolver->setDefined('wiki_checksum_failed')
             ->setAllowedTypes('wiki_checksum_failed', 'bool')
             ->setNormalizer('wiki_checksum_failed', $booleanNormalizer)

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Gitlab\Api;
 
+use DateTimeInterface;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Symfony\Component\OptionsResolver\Options;
@@ -54,7 +55,7 @@ class Projects extends AbstractApi
         $booleanNormalizer = function (Options $resolver, $value): string {
             return $value ? 'true' : 'false';
         };
-        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
+        $datetimeNormalizer = function (Options $resolver, DateTimeInterface $value): string {
             return $value->format('c');
         };
         $resolver->setDefined('archived')

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -41,6 +41,15 @@ class Projects extends AbstractApi
      *     @var bool   $with_issues_enabled         limit by enabled issues feature
      *     @var bool   $with_merge_requests_enabled limit by enabled merge requests feature
      *     @var int    $min_access_level            Limit by current user minimal access level
+     *     @var int    $id_after                    Limit by project id's greater than the specified id
+     *     @var int    $id_before                   Limit by project id's less than the specified id
+     *     @var DateTimeInterface $last_activity_after  Limit by last_activity after specified time
+     *     @var DateTimeInterface $last_activity_before Limit by last_activity before specified time
+     *     @var bool   $repository_checksum_failed  Limit by failed repository checksum calculation
+     *     @var string $repository_storage          Limit by repository storage type
+     *     @var bool   $wiki_checksum_failed        Limit by failed wiki checksum calculation
+     *     @var bool   $with_custom_attributes      Include custom attributes in response
+     *     @var string $with_programming_language   Limit by programming language
      * }
      *
      * @throws UndefinedOptionsException If an option name is undefined

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -54,6 +54,9 @@ class Projects extends AbstractApi
         $booleanNormalizer = function (Options $resolver, $value): string {
             return $value ? 'true' : 'false';
         };
+        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
+            return $value->format('c');
+        };
         $resolver->setDefined('archived')
             ->setAllowedTypes('archived', 'bool')
             ->setNormalizer('archived', $booleanNormalizer)
@@ -107,6 +110,38 @@ class Projects extends AbstractApi
         $resolver->setDefined('min_access_level')
             ->setAllowedValues('min_access_level', [null, 10, 20, 30, 40, 50])
         ;
+        $resolver->setDefined('id_after')
+            ->setAllowedTypes('id_after', 'integer')
+        ;
+        $resolver->setDefined('id_before')
+            ->setAllowedTypes('id_before', 'integer')
+        ;
+        $resolver->setDefined('last_activity_after')
+            ->setAllowedTypes('last_activity_after', \DateTimeInterface::class)
+            ->setNormalizer('last_activity_after', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('last_activity_before')
+            ->setAllowedTypes('last_activity_before', \DateTimeInterface::class)
+            ->setNormalizer('last_activity_before', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('repository_checksum_failed')
+            ->setAllowedTypes('repository_checksum_failed', 'bool')
+            ->setNormalizer('repository_checksum_failed', $booleanNormalizer)
+        ;
+        $resolver->setDefined('repository_storage');
+        $resolver->setDefined('starred')
+            ->setAllowedTypes('starred', 'bool')
+            ->setNormalizer('starred', $booleanNormalizer)
+        ;
+        $resolver->setDefined('wiki_checksum_failed')
+            ->setAllowedTypes('wiki_checksum_failed', 'bool')
+            ->setNormalizer('wiki_checksum_failed', $booleanNormalizer)
+        ;
+        $resolver->setDefined('with_custom_attributes')
+            ->setAllowedTypes('with_custom_attributes', 'bool')
+            ->setNormalizer('with_custom_attributes', $booleanNormalizer)
+        ;
+        $resolver->setDefined('with_programming_language');
 
         return $this->get('projects', $resolver->resolve($parameters));
     }

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Gitlab\Api;
 
-use DateTimeInterface;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Symfony\Component\OptionsResolver\Options;
@@ -43,8 +42,8 @@ class Projects extends AbstractApi
      *     @var int    $min_access_level            Limit by current user minimal access level
      *     @var int    $id_after                    Limit by project id's greater than the specified id
      *     @var int    $id_before                   Limit by project id's less than the specified id
-     *     @var DateTimeInterface $last_activity_after  Limit by last_activity after specified time
-     *     @var DateTimeInterface $last_activity_before Limit by last_activity before specified time
+     *     @var \DateTimeInterface $last_activity_after  Limit by last_activity after specified time
+     *     @var \DateTimeInterface $last_activity_before Limit by last_activity before specified time
      *     @var bool   $repository_checksum_failed  Limit by failed repository checksum calculation
      *     @var string $repository_storage          Limit by repository storage type
      *     @var bool   $wiki_checksum_failed        Limit by failed wiki checksum calculation
@@ -64,7 +63,7 @@ class Projects extends AbstractApi
         $booleanNormalizer = function (Options $resolver, $value): string {
             return $value ? 'true' : 'false';
         };
-        $datetimeNormalizer = function (Options $resolver, DateTimeInterface $value): string {
+        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
             return $value->format('c');
         };
         $resolver->setDefined('archived')
@@ -127,11 +126,11 @@ class Projects extends AbstractApi
             ->setAllowedTypes('id_before', 'integer')
         ;
         $resolver->setDefined('last_activity_after')
-            ->setAllowedTypes('last_activity_after', DateTimeInterface::class)
+            ->setAllowedTypes('last_activity_after', \DateTimeInterface::class)
             ->setNormalizer('last_activity_after', $datetimeNormalizer)
         ;
         $resolver->setDefined('last_activity_before')
-            ->setAllowedTypes('last_activity_before', DateTimeInterface::class)
+            ->setAllowedTypes('last_activity_before', \DateTimeInterface::class)
             ->setNormalizer('last_activity_before', $datetimeNormalizer)
         ;
         $resolver->setDefined('repository_checksum_failed')

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Gitlab\Tests\Api;
 
+use DateTime;
 use Gitlab\Api\Projects;
 
 class ProjectsTest extends TestCase
@@ -134,6 +135,118 @@ class ProjectsTest extends TestCase
 
         $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['search' => 'a_project', 'search_namespaces' => 'true']);
         $this->assertEquals($expectedArray, $api->all(['search' => 'a_project', 'search_namespaces' => true]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetProjectsAfterId(): void
+    {
+        $expectedArray = $this->getMultipleProjectsData();
+
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['id_after' => 0]);
+
+        $this->assertEquals($expectedArray, $api->all(['id_after' => 0]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetProjectsWithLastActivityAfter(): void
+    {
+        $unixEpochDateTime = new DateTime('@0');
+
+        $expectedArray = $this->getMultipleProjectsData();
+
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['last_activity_after' => $unixEpochDateTime->format('c')]);
+
+        $this->assertEquals($expectedArray, $api->all(['last_activity_after' => $unixEpochDateTime]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetProjectsWithLastActivityBefore(): void
+    {
+        $now = new DateTime();
+
+        $expectedArray = $this->getMultipleProjectsData();
+
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['last_activity_before' => $now->format('c')]);
+
+        $this->assertEquals($expectedArray, $api->all(['last_activity_before' => $now]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetProjectsWithoutFailedRepositoryChecksum(): void
+    {
+        $expectedArray = $this->getMultipleProjectsData();
+
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['repository_checksum_failed' => 'false']);
+
+        $this->assertEquals($expectedArray, $api->all(['repository_checksum_failed' => false]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetProjectsWithDefaultRepositoryStorage(): void
+    {
+        $expectedArray = $this->getMultipleProjectsData();
+
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['repository_storage' => 'default']);
+
+        $this->assertEquals($expectedArray, $api->all(['repository_storage' => 'default']));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetStarredProjects(): void
+    {
+        $expectedArray = $this->getMultipleProjectsData();
+
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['starred' => 'true']);
+
+        $this->assertEquals($expectedArray, $api->all(['starred' => true]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetProjectsWithoutFailedWikiChecksum(): void
+    {
+        $expectedArray = $this->getMultipleProjectsData();
+
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['wiki_checksum_failed' => 'false']);
+
+        $this->assertEquals($expectedArray, $api->all(['wiki_checksum_failed' => false]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetProjectsWithCustomAttributes(): void
+    {
+        $expectedArray = $this->getMultipleProjectsData();
+
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['with_custom_attributes' => 'true']);
+
+        $this->assertEquals($expectedArray, $api->all(['with_custom_attributes' => true]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetProjectsWithPhpProgrammingLanguage(): void
+    {
+        $expectedArray = $this->getMultipleProjectsData();
+
+        $api = $this->getMultipleProjectsRequestMock('projects', $expectedArray, ['with_programming_language' => 'php']);
+
+        $this->assertEquals($expectedArray, $api->all(['with_programming_language' => 'php']));
     }
 
     /**


### PR DESCRIPTION
The following missing parameters are added to the `\GitLab\Api\Projects:all` method:
* `id_after` (integer)
* `id_before` (integer)
* `last_activity_after` (datetime)
* `last_activity_before` (datetime)
* `repository_checksum_failed` (boolean)
* `repository_storage` (string)
* `starred` (boolean)
* `wiki_checksum_failed` (boolean)
* `with_custom_attributes` (boolean)
* `with_programming_language` (string)

---

Closes #622.