### PR TITLE
[11.3] Add support for a single inherited member

### DIFF
--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -158,6 +158,17 @@ class Groups extends AbstractApi
     /**
      * @param int|string $group_id
      * @param int        $user_id
+     *
+     * @return mixed
+     */
+    public function allMember($group_id, int $user_id)
+    {
+        return $this->get('groups/'.self::encodePath($group_id).'/members/all/'.self::encodePath($user_id));
+    }
+
+    /**
+     * @param int|string $group_id
+     * @param int        $user_id
      * @param int        $access_level
      *
      * @return mixed

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -511,6 +511,17 @@ class Projects extends AbstractApi
     /**
      * @param int|string $project_id
      * @param int        $user_id
+     *
+     * @return mixed
+     */
+    public function allMember($project_id, int $user_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'members/all/'.self::encodePath($user_id)));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $user_id
      * @param int        $access_level
      *
      * @return mixed

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -223,6 +223,22 @@ class GroupsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetAllMember(): void
+    {
+        $expectedArray = ['id' => 2, 'name' => 'Bob'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/members/all/2')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->allMember(1, 2));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetMembers(): void
     {
         $expectedArray = [

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -948,6 +948,22 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetAllMember(): void
+    {
+        $expectedArray = ['id' => 2, 'name' => 'Bob'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/members/all/2')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->allMember(1, 2));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetMembers(): void
     {
         $expectedArray = [


### PR DESCRIPTION
This adds support for reading the permissions of a specific member for a group/project including inherited permissions:
https://docs.gitlab.com/ee/api/members.html#get-a-member-of-a-group-or-project-including-inherited-members

I tried to respect the naming logic already used:

|                     | All members  | Single member |
|---------------------|--------------|---------------|
| Without inheritance | `members`    | `member`      |
| With inheritance    | `allMembers` | `allMember`   |

If you think this might be confusing, i could also name it `inheritedMember` (although this might not be perfect either, since both regular AND inherited members will be returned)