### PR TITLE
[11.4] Add parameters to the list project issue discussions

### DIFF
--- a/src/Api/Issues.php
+++ b/src/Api/Issues.php
@@ -207,7 +207,7 @@ class Issues extends AbstractApi
     /**
      * @param int|string $project_id
      * @param int        $issue_iid
-     * @param array $params
+     * @param array      $params
      * @return mixed
      */
     public function showDiscussions($project_id, int $issue_iid, array $params)

--- a/src/Api/Issues.php
+++ b/src/Api/Issues.php
@@ -207,12 +207,12 @@ class Issues extends AbstractApi
     /**
      * @param int|string $project_id
      * @param int        $issue_iid
-     *
+     * @param array $params
      * @return mixed
      */
-    public function showDiscussions($project_id, int $issue_iid)
+    public function showDiscussions($project_id, int $issue_iid, array $params)
     {
-        return $this->get($this->getProjectPath($project_id, 'issues/'.self::encodePath($issue_iid)).'/discussions');
+        return $this->get($this->getProjectPath($project_id, 'issues/'.self::encodePath($issue_iid)).'/discussions', $params);
     }
 
     /**

--- a/src/Api/Issues.php
+++ b/src/Api/Issues.php
@@ -208,6 +208,7 @@ class Issues extends AbstractApi
      * @param int|string $project_id
      * @param int        $issue_iid
      * @param array      $params
+     *
      * @return mixed
      */
     public function showDiscussions($project_id, int $issue_iid, array $params)

--- a/tests/Api/IssuesTest.php
+++ b/tests/Api/IssuesTest.php
@@ -326,7 +326,7 @@ class IssuesTest extends TestCase
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->showDiscussions(1, 2));
+        $this->assertEquals($expectedArray, $api->showDiscussions(1, 2, ['per_page' => 5]));
     }
 
     /**


### PR DESCRIPTION
Implementing additional parameters for pagination: https://docs.gitlab.com/ce/api/#pagination
This way we can set parameter 'per_page' to custom value and get more results than the default value of 20.