### PR TITLE
[11.5] Add addShare method

### DIFF
--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -207,7 +207,7 @@ class Groups extends AbstractApi
     }
 
     /**
-     * @param $group_id
+     * @param int|string $group_id
      * @param array $parameters
      *
      * @return mixed
@@ -232,7 +232,7 @@ class Groups extends AbstractApi
             ->setNormalizer('expires_at', $datetimeNormalizer)
         ;
 
-        return $this->post('groups/'.$this->encodePath($group_id).'/share', $resolver->resolve($parameters));
+        return $this->post('groups/'.self::encodePath($group_id).'/share', $resolver->resolve($parameters));
     }
 
     /**

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -208,7 +208,7 @@ class Groups extends AbstractApi
 
     /**
      * @param int|string $group_id
-     * @param array $parameters
+     * @param array      $parameters
      *
      * @return mixed
      */

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -207,6 +207,35 @@ class Groups extends AbstractApi
     }
 
     /**
+     * @param $group_id
+     * @param array $parameters
+     *
+     * @return mixed
+     */
+    public function addShare($group_id, array $parameters = [])
+    {
+        $resolver = $this->createOptionsResolver();
+
+        $datetimeNormalizer = function (OptionsResolver $optionsResolver, \DateTimeInterface $value) {
+            return $value->format('Y-m-d');
+        };
+
+        $resolver->setRequired('group_id')
+            ->setAllowedTypes('group_id', 'int');
+
+        $resolver->setRequired('group_access')
+            ->setAllowedTypes('group_access', 'int')
+            ->setAllowedValues('group_access', [0, 10, 20, 30, 40, 50]);
+
+        $resolver->setDefined('expires_at')
+            ->setAllowedTypes('expires_at', \DateTimeInterface::class)
+            ->setNormalizer('expires_at', $datetimeNormalizer)
+        ;
+
+        return $this->post('groups/'.$this->encodePath($group_id).'/share', $resolver->resolve($parameters));
+    }
+
+    /**
      * @param int|string $id
      * @param array      $parameters {
      *


### PR DESCRIPTION
To be able to share groups with groups. See documentation; https://docs.gitlab.com/ee/api/groups.html#share-groups-with-groups