### PR TITLE
[11.5] Add packages endpoints

### DIFF
--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -433,6 +433,58 @@ class Groups extends AbstractApi
     }
 
     /**
+     * @param int|string $group_id
+     * @param array      $parameters {
+     *
+     *     @var bool   $exclude_subgroups   if the parameter is included as true, packages from projects from subgroups
+     *                                      are not listed. default is false.
+     *     @var string $order_by            the field to use as order. one of created_at (default), name, version, type,
+     *                                      or project_path.
+     *     @var string $sort                the direction of the order, either asc (default) for ascending order
+     *                                      or desc for descending order.
+     *     @var string $package_type        filter the returned packages by type. one of conan, maven, npm, pypi,
+     *                                      composer, nuget, or golang.
+     *     @var string $package_name        filter the project packages with a fuzzy search by name.
+     *     @var bool   $include_versionless when set to true, versionless packages are included in the response.
+     *     @var string $status              filter the returned packages by status. one of default (default),
+     *                                      hidden, or processing.
+     * }
+     *
+     * @return mixed
+     */
+    public function packages($group_id, array $parameters = [])
+    {
+        $resolver = $this->createOptionsResolver();
+        $booleanNormalizer = function (Options $resolver, $value): string {
+            return $value ? 'true' : 'false';
+        };
+
+        $resolver->setDefined('exclude_subgroups')
+            ->setAllowedTypes('exclude_subgroups', 'bool')
+            ->setNormalizer('exclude_subgroups', $booleanNormalizer)
+        ;
+        $resolver->setDefined('order_by')
+            ->setAllowedValues('order_by', ['created_at', 'name', 'version', 'type'])
+        ;
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['asc', 'desc'])
+        ;
+        $resolver->setDefined('package_type')
+            ->setAllowedValues('package_type', ['conan', 'maven', 'npm', 'pypi', 'composer', 'nuget', 'golang'])
+        ;
+        $resolver->setDefined('package_name');
+        $resolver->setDefined('include_versionless')
+            ->setAllowedTypes('include_versionless', 'bool')
+            ->setNormalizer('include_versionless', $booleanNormalizer)
+        ;
+        $resolver->setDefined('status')
+            ->setAllowedValues('status', ['default', 'hidden', 'processing'])
+        ;
+
+        return $this->get('groups/'.self::encodePath($group_id).'/packages', $resolver->resolve($parameters));
+    }
+
+    /**
      * @return OptionsResolver
      */
     private function getGroupSearchResolver()

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -441,11 +441,11 @@ class Groups extends AbstractApi
      *     @var string $order_by            the field to use as order. one of created_at (default), name, version, type,
      *                                      or project_path.
      *     @var string $sort                the direction of the order, either asc (default) for ascending order
-     *                                      or desc for descending order.
+     *                                      or desc for descending order
      *     @var string $package_type        filter the returned packages by type. one of conan, maven, npm, pypi,
      *                                      composer, nuget, or golang.
-     *     @var string $package_name        filter the project packages with a fuzzy search by name.
-     *     @var bool   $include_versionless when set to true, versionless packages are included in the response.
+     *     @var string $package_name        filter the project packages with a fuzzy search by name
+     *     @var bool   $include_versionless when set to true, versionless packages are included in the response
      *     @var string $status              filter the returned packages by status. one of default (default),
      *                                      hidden, or processing.
      * }

--- a/src/Api/Packages.php
+++ b/src/Api/Packages.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Api;
+
+use Symfony\Component\OptionsResolver\Options;
+
+class Packages extends AbstractApi
+{
+    /**
+     * @param int|string $project_id
+     * @param array      $parameters {
+     *
+     *     @var string $order_by            the field to use as order. one of created_at (default), name,
+     *                                      version, or type
+     *     @var string $sort                the direction of the order, either asc (default) for ascending order or
+     *                                      desc for descending order.
+     *     @var string $package_type        filter the returned packages by type. one of conan, maven, npm, pypi,
+     *                                      composer, nuget, or golang.
+     *     @var string $package_name        filter the project packages with a fuzzy search by name.
+     *     @var bool   $include_versionless when set to true, versionless packages are included in the response.
+     *     @var string $status              filter the returned packages by status. one of default (default),
+     *                                      hidden, or processing.
+     * }
+     *
+     * @return mixed
+     */
+    public function all($project_id, array $parameters = [])
+    {
+        $resolver = $this->createOptionsResolver();
+
+        $resolver->setDefined('order_by')
+            ->setAllowedValues('order_by', ['created_at', 'name', 'version', 'type'])
+        ;
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['asc', 'desc'])
+        ;
+        $resolver->setDefined('package_type')
+            ->setAllowedValues('package_type', ['conan', 'maven', 'npm', 'pypi', 'composer', 'nuget', 'golang'])
+        ;
+        $resolver->setDefined('package_name');
+        $resolver->setDefined('include_versionless')
+            ->setAllowedTypes('include_versionless', 'bool')
+            ->setNormalizer('include_versionless', function (Options $resolver, $value): string {
+                return $value ? 'true' : 'false';
+            })
+        ;
+        $resolver->setDefined('status')
+            ->setAllowedValues('status', ['default', 'hidden', 'processing'])
+        ;
+
+        return $this->get($this->getProjectPath($project_id, 'packages'), $resolver->resolve($parameters));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $package_id
+     *
+     * @return mixed
+     */
+    public function show($project_id, int $package_id)
+    {
+        return $this->get($this->getPackagePath($project_id, $package_id));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $package_id
+     *
+     * @return mixed
+     */
+    public function allFiles($project_id, int $package_id)
+    {
+        return $this->get($this->getPackagePath($project_id, $package_id).'/package_files');
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $package_id
+     *
+     * @return mixed
+     */
+    public function remove($project_id, int $package_id)
+    {
+        return $this->delete($this->getPackagePath($project_id, $package_id));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $package_id
+     * @param int        $package_file_id
+     *
+     * @return mixed
+     */
+    public function removeFile($project_id, int $package_id, int $package_file_id)
+    {
+        return $this->delete(
+            $this->getPackagePath($project_id, $package_id).'/package_files/'.self::encodePath($package_file_id)
+        );
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $package_id
+     *
+     * @return string
+     */
+    private function getPackagePath($project_id, int $package_id): string
+    {
+        return $this->getProjectPath($project_id, 'packages/'.self::encodePath($package_id));
+    }
+}

--- a/src/Api/Packages.php
+++ b/src/Api/Packages.php
@@ -25,11 +25,11 @@ class Packages extends AbstractApi
      *     @var string $order_by            the field to use as order. one of created_at (default), name,
      *                                      version, or type
      *     @var string $sort                the direction of the order, either asc (default) for ascending order or
-     *                                      desc for descending order.
+     *                                      desc for descending order
      *     @var string $package_type        filter the returned packages by type. one of conan, maven, npm, pypi,
      *                                      composer, nuget, or golang.
-     *     @var string $package_name        filter the project packages with a fuzzy search by name.
-     *     @var bool   $include_versionless when set to true, versionless packages are included in the response.
+     *     @var string $package_name        filter the project packages with a fuzzy search by name
+     *     @var bool   $include_versionless when set to true, versionless packages are included in the response
      *     @var string $status              filter the returned packages by status. one of default (default),
      *                                      hidden, or processing.
      * }

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -655,4 +655,44 @@ class GroupsTest extends TestCase
 
         $this->assertEquals($expectedArray, $api->projects(1, ['with_custom_attributes' => true]));
     }
+
+    /**
+     * @test
+     */
+    public function shouldGetPackages(): void
+    {
+        $expectedArray = [
+            'id' => 2,
+            'name' => '@foo/bar',
+            'version' => '1.0.3',
+            'package_type' => 'npm',
+            '_links' => [
+                'web_path' => '/namespace1/project1/-/packages/1',
+                'delete_api_path' => '/namespace1/project1/-/packages/1',
+            ],
+            'created_at' => '2019-11-27T03:37:38.711Z',
+            'pipelines' => [
+                'id' => 123,
+                'status' => 'pending',
+                'ref' => 'new-pipeline',
+                'sha' => 'a91957a858320c0e17f3a0eca7cfacbff50ea29a',
+                'web_url' => 'https://example.com/foo/bar/pipelines/47',
+                'created_at' => '2016-08-11T11:28:34.085Z',
+                'updated_at' => '2016-08-11T11:32:35.169Z',
+                'user' => [
+                    'name' => 'Administrator',
+                    'avatar_url' => 'https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                ],
+            ],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/packages')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->packages(1));
+    }
 }

--- a/tests/Api/PackagesTest.php
+++ b/tests/Api/PackagesTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Tests\Api;
+
+use Gitlab\Api\Packages;
+
+final class PackagesTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllPackages(): void
+    {
+        $expectedArray = [
+            [
+                'id' => 3,
+                'name' => 'Hello/0.1@mycompany/stable',
+                'conan_package_name' => 'Hello',
+                'version' => '0.1',
+                'package_type' => 'conan',
+                '_links' => [
+                    'web_path' => '/foo/bar/-/packages/3',
+                    'delete_api_path' => 'https://gitlab.example.com/api/v4/projects/1/packages/3',
+                ],
+                'created_at' => '2029-12-16T20:33:34.316Z',
+                'tags' => [],
+            ],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/packages')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->all(1));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldShowPackage(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'com/mycompany/my-app', 'version' => '1.0-SNAPSHOT', 'package_type' => 'maven'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/packages/1')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->show(1, 1));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetAllPackageFiles(): void
+    {
+        $expectedArray = [
+            ['id' => 25, 'file_name' => 'my-app-1.5-20181107.152550-1.jar', 'size' => 2421],
+            ['id' => 26, 'file_name' => 'my-app-1.5-20181107.152550-1.pom', 'size' => 1122],
+            ['id' => 27, 'file_name' => 'maven-metadata.xml', 'size' => 767],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/packages/1/package_files')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->allFiles(1, 1));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRemovePackage(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/packages/1')
+            ->will($this->returnValue($expectedBool));
+
+        $this->assertEquals($expectedBool, $api->remove(1, 1));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRemovePackageFile(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/packages/1/package_files/25')
+            ->will($this->returnValue($expectedBool));
+
+        $this->assertEquals($expectedBool, $api->removeFile(1, 1, 25));
+    }
+
+    protected function getApiClass()
+    {
+        return Packages::class;
+    }
+}


### PR DESCRIPTION
I've added the [Gitlab Packages](https://docs.gitlab.com/ee/api/packages.html) endpoints.

For Groups a `packages` method to list all packages within that group, the other methods are in the `Packages` class.