### PR TITLE
[14.4] Fix the Create method for Environments

### DIFF
--- a/src/Api/Environments.php
+++ b/src/Api/Environments.php
@@ -54,7 +54,7 @@ class Environments extends AbstractApi
         $resolver->setDefined('external_url')
             ->setAllowedTypes('external_url', 'string');
 
-        return $this->post($this->getProjectPath($project_id, 'environment'), $resolver->resolve($parameters));
+        return $this->post($this->getProjectPath($project_id, 'environments'), $resolver->resolve($parameters));
     }
 
     /**

--- a/tests/Api/EnvironmentsTest.php
+++ b/tests/Api/EnvironmentsTest.php
@@ -166,7 +166,7 @@ See merge request !1',
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('projects/1/environment', $params)
+            ->with('projects/1/environments', $params)
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->create(1, $params));


### PR DESCRIPTION
As pointed out in #645 the endpoint for creating an environment had a typo.
This PR fixes that typo and the test accordingly.

replaces #646 
fixes #645 