### PR TITLE
[11.5] Add `from_project_id` to `Repositories::compare`

### DIFF
--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -420,7 +420,7 @@ class Repositories extends AbstractApi
         ];
         
         if (null !== $fromProjectId) {
-            $params['from_project_id'] = self::encodePath($fromProjectId)
+            $params['from_project_id'] = self::encodePath($fromProjectId);
         }
 
         return $this->get($this->getProjectPath($project_id, 'repository/compare'), $params);

--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -403,21 +403,25 @@ class Repositories extends AbstractApi
     }
 
     /**
-     * @param int|string $project_id
-     * @param string     $fromShaOrMaster
-     * @param string     $toShaOrMaster
-     * @param bool       $straight
+     * @param int|string  $project_id
+     * @param string      $fromShaOrMaster
+     * @param string      $toShaOrMaster
+     * @param bool        $straight
+     * @param string|null $fromProjectId
      *
      * @return mixed
      */
-    public function compare($project_id, string $fromShaOrMaster, string $toShaOrMaster, bool $straight = false, string $fromProjectId = '')
+    public function compare($project_id, string $fromShaOrMaster, string $toShaOrMaster, bool $straight = false, string $fromProjectId = null)
     {
         $params = [
             'from' => self::encodePath($fromShaOrMaster),
             'to' => self::encodePath($toShaOrMaster),
-            'from_project_id' => self::encodePath($fromProjectId),
             'straight' => self::encodePath($straight ? 'true' : 'false'),
         ];
+        
+        if (null !== $fromProjectId) {
+            $params['from_project_id'] = self::encodePath($fromProjectId)
+        }
 
         return $this->get($this->getProjectPath($project_id, 'repository/compare'), $params);
     }

--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -410,11 +410,12 @@ class Repositories extends AbstractApi
      *
      * @return mixed
      */
-    public function compare($project_id, string $fromShaOrMaster, string $toShaOrMaster, bool $straight = false)
+    public function compare($project_id, string $fromShaOrMaster, string $toShaOrMaster, bool $straight = false, string $fromProjectId = '')
     {
         $params = [
             'from' => self::encodePath($fromShaOrMaster),
             'to' => self::encodePath($toShaOrMaster),
+            'from_project_id' => self::encodePath($fromProjectId),
             'straight' => self::encodePath($straight ? 'true' : 'false'),
         ];
 

--- a/tests/Api/RepositoriesTest.php
+++ b/tests/Api/RepositoriesTest.php
@@ -551,7 +551,7 @@ class RepositoriesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/repository/compare', ['from' => 'master', 'to' => 'feature', 'straight' => 'true', 'from_project_id' => '123])
+            ->with('projects/1/repository/compare', ['from' => 'master', 'to' => 'feature', 'straight' => 'true', 'from_project_id' => '123'])
             ->will($this->returnValue($expectedArray))
         ;
 

--- a/tests/Api/RepositoriesTest.php
+++ b/tests/Api/RepositoriesTest.php
@@ -555,7 +555,7 @@ class RepositoriesTest extends TestCase
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->compare(1, 'master', 'feature', false, '123'));
+        $this->assertEquals($expectedArray, $api->compare(1, 'master', 'feature', true, '123'));
     }
 
     /**

--- a/tests/Api/RepositoriesTest.php
+++ b/tests/Api/RepositoriesTest.php
@@ -517,7 +517,7 @@ class RepositoriesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/repository/compare', ['from' => 'master', 'to' => 'feature', 'straight' => 'true'])
+            ->with('projects/1/repository/compare', ['from' => 'master', 'to' => 'feature', 'straight' => 'true', 'from_project_id' => null])
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -534,7 +534,7 @@ class RepositoriesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/repository/compare', ['from' => 'master', 'to' => 'feature', 'straight' => 'false'])
+            ->with('projects/1/repository/compare', ['from' => 'master', 'to' => 'feature', 'straight' => 'false', 'from_project_id' => null])
             ->will($this->returnValue($expectedArray))
         ;
 

--- a/tests/Api/RepositoriesTest.php
+++ b/tests/Api/RepositoriesTest.php
@@ -517,7 +517,7 @@ class RepositoriesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/repository/compare', ['from' => 'master', 'to' => 'feature', 'straight' => 'true', 'from_project_id' => null])
+            ->with('projects/1/repository/compare', ['from' => 'master', 'to' => 'feature', 'straight' => 'true'])
             ->will($this->returnValue($expectedArray))
         ;
 
@@ -534,11 +534,28 @@ class RepositoriesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/repository/compare', ['from' => 'master', 'to' => 'feature', 'straight' => 'false', 'from_project_id' => null])
+            ->with('projects/1/repository/compare', ['from' => 'master', 'to' => 'feature', 'straight' => 'false'])
             ->will($this->returnValue($expectedArray))
         ;
 
         $this->assertEquals($expectedArray, $api->compare(1, 'master', 'feature'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCompareWithFromProjectId(): void
+    {
+        $expectedArray = ['commit' => 'object'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/repository/compare', ['from' => 'master', 'to' => 'feature', 'straight' => 'true', 'from_project_id' => '123])
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->compare(1, 'master', 'feature', false, '123'));
     }
 
     /**


### PR DESCRIPTION
fix #651 adds from_project_id to Compare branches, tags or commits

before pr, I've ran ```make test``` and found no issues in my local👍🏻 