### PR TITLE
[11.5] Fix release creation/update API paths

### DIFF
--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -152,7 +152,7 @@ class Repositories extends AbstractApi
      */
     public function createRelease($project_id, string $tag_name, string $description)
     {
-        return $this->post($this->getProjectPath($project_id, 'repository/tags/'.self::encodePath($tag_name).'/release'), [
+        return $this->post($this->getProjectPath($project_id, 'releases'), [
             'id' => $project_id,
             'tag_name' => $tag_name,
             'description' => $description,
@@ -168,7 +168,7 @@ class Repositories extends AbstractApi
      */
     public function updateRelease($project_id, string $tag_name, string $description)
     {
-        return $this->put($this->getProjectPath($project_id, 'repository/tags/'.self::encodePath($tag_name).'/release'), [
+        return $this->put($this->getProjectPath($project_id, 'releases/'.self::encodePath($tag_name)), [
             'id' => $project_id,
             'tag_name' => $tag_name,
             'description' => $description,

--- a/tests/Api/RepositoriesTest.php
+++ b/tests/Api/RepositoriesTest.php
@@ -195,7 +195,7 @@ class RepositoriesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('projects/'.$project_id.'/repository/tags/'.$tagName.'/release', [
+            ->with('projects/'.$project_id.'/releases', [
                 'id' => $project_id,
                 'tag_name' => $tagName,
                 'description' => $description,
@@ -220,7 +220,7 @@ class RepositoriesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('projects/'.$project_id.'/repository/tags/'.$tagName.'/release', [
+            ->with('projects/'.$project_id.'/releases/'.$tagName, [
                 'id' => $project_id,
                 'tag_name' => $tagName,
                 'description' => $description,


### PR DESCRIPTION
The `createRelease` and `updateRelease` methods were implemented in #365 as part of the Tags API, however the API paths have since changed and were not updated. This PR fixes the methods up.

Reorganizing the methods into a separate Releases class may be a good idea for a separate PR (breaking change!), as well as implementing other API endpoints. This is not the scope of this PR though.

The Releases API is documented at https://docs.gitlab.com/ee/api/releases/.