### PR TITLE
[11.5] Add support for filtering projects by topic

### DIFF
--- a/src/Api/Environments.php
+++ b/src/Api/Environments.php
@@ -54,7 +54,7 @@ class Environments extends AbstractApi
         $resolver->setDefined('external_url')
             ->setAllowedTypes('external_url', 'string');
 
-        return $this->post($this->getProjectPath($project_id, 'environment'), $resolver->resolve($parameters));
+        return $this->post($this->getProjectPath($project_id, 'environments'), $resolver->resolve($parameters));
     }
 
     /**

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -49,6 +49,7 @@ class Projects extends AbstractApi
      *     @var bool               $wiki_checksum_failed        Limit by failed wiki checksum calculation
      *     @var bool               $with_custom_attributes      Include custom attributes in response
      *     @var string             $with_programming_language   Limit by programming language
+     *     @var string             $topic                       Limit by topic
      * }
      *
      * @throws UndefinedOptionsException If an option name is undefined
@@ -147,6 +148,7 @@ class Projects extends AbstractApi
             ->setNormalizer('with_custom_attributes', $booleanNormalizer)
         ;
         $resolver->setDefined('with_programming_language');
+        $resolver->setDefined('topic');
 
         return $this->get('projects', $resolver->resolve($parameters));
     }

--- a/tests/Api/EnvironmentsTest.php
+++ b/tests/Api/EnvironmentsTest.php
@@ -166,7 +166,7 @@ See merge request !1',
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('projects/1/environment', $params)
+            ->with('projects/1/environments', $params)
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->create(1, $params));


### PR DESCRIPTION
With this change it is now possible to search projects by topic:

$projects = $this->gitlabClient->projects()->all(["topic" => "foo"]);