### PR TITLE
[11.5] Add support for locked merge requests

### DIFF
--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -41,6 +41,11 @@ class MergeRequests extends AbstractApi
     public const STATE_CLOSED = 'closed';
 
     /**
+     * @var string
+     */
+    public const STATE_LOCKED = 'locked';
+
+    /**
      * @param int|string|null $project_id
      * @param array           $parameters {
      *

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -81,7 +81,7 @@ class MergeRequests extends AbstractApi
             })
         ;
         $resolver->setDefined('state')
-            ->setAllowedValues('state', [self::STATE_ALL, self::STATE_MERGED, self::STATE_OPENED, self::STATE_CLOSED])
+            ->setAllowedValues('state', [self::STATE_ALL, self::STATE_MERGED, self::STATE_OPENED, self::STATE_CLOSED, self::STATE_LOCKED])
         ;
         $resolver->setDefined('scope')
             ->setAllowedValues('scope', ['created-by-me', 'assigned-to-me', 'all'])


### PR DESCRIPTION
According to GITLAB API documentation, there is a special state for "locked" merge requests.

https://docs.gitlab.com/ee/api/merge_requests.html 