### PR TITLE
[11.6] Add method to fetch all groups the projects is shared with

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1077,6 +1077,17 @@ class Projects extends AbstractApi
      *
      * @return mixed
      */
+    public function groups($project_id, array $parameters = [])
+    {
+        return $this->get($this->getProjectPath($project_id, 'groups'), $parameters);
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param array      $parameters
+     *
+     * @return mixed
+     */
     public function addShare($project_id, array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2062,6 +2062,25 @@ class ProjectsTest extends TestCase
         ];
     }
 
+    /**
+     * @test
+     */
+    public function shouldGetGroups(): void
+    {
+        $expectedArray = [
+            ['id' => 2, 'web_url' => 'https://gitlab.com/groups/2', 'name' => 'Group 2'],
+            ['id' => 3, 'web_url' => 'https://gitlab.com/groups/3', 'name' => 'Group 3'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/groups')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->groups(1));
+    }
+
     public function possibleAccessLevels()
     {
         return [


### PR DESCRIPTION
https://docs.gitlab.com/ee/api/projects.html#list-a-projects-groups