### PR TITLE
[11.5] Add `deleteProtectedBranch` method to projects api

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1190,6 +1190,17 @@ class Projects extends AbstractApi
 
     /**
      * @param int|string $project_id
+     * @param string     $branch
+     *
+     * @return mixed
+     */
+    public function deleteProtectedBranch($project_id, string $branch)
+    {
+        return $this->delete($this->getProjectPath($project_id, 'protected_branches/'.self::encodePath($branch)));
+    }
+
+    /**
+     * @param int|string $project_id
      *
      * @return mixed
      */

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1190,13 +1190,13 @@ class Projects extends AbstractApi
 
     /**
      * @param int|string $project_id
-     * @param string     $branch
+     * @param string     $branch_name
      *
      * @return mixed
      */
-    public function deleteProtectedBranch($project_id, string $branch)
+    public function deleteProtectedBranch($project_id, string $branch_name)
     {
-        return $this->delete($this->getProjectPath($project_id, 'protected_branches/'.self::encodePath($branch)));
+        return $this->delete($this->getProjectPath($project_id, 'protected_branches/'.self::encodePath($branch_name)));
     }
 
     /**

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2220,6 +2220,23 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldRemoveProtectedBranch(): void
+    {
+        $expectedBool = true;
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with(
+                'projects/1/protected_branches/test-branch'
+            )
+            ->will($this->returnValue($expectedBool));
+
+        $this->assertEquals($expectedBool, $api->deleteProtectedBranch(1, 'test-branch'));
+    }
+
+    /**
+     * @test
+     */
     public function shoudGetApprovalsConfiguration(): void
     {
         $expectedArray = [


### PR DESCRIPTION
Handles the functionality to delete/unprotect a protected branch which is documented here:
https://docs.gitlab.com/ee/api/protected_branches.html#unprotect-repository-branches