### PR TITLE
[11.6] Add support for uploading avatars

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1049,6 +1049,17 @@ class Projects extends AbstractApi
 
     /**
      * @param int|string $project_id
+     * @param string     $file
+     *
+     * @return mixed
+     */
+    public function uploadAvatar($project_id, string $file)
+    {
+        return $this->put($this->getProjectPath($project_id, ''), [], [], ['avatar' => $file]);
+    }
+
+    /**
+     * @param int|string $project_id
      * @param array      $parameters
      *
      * @return mixed

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2411,6 +2411,25 @@ class ProjectsTest extends TestCase
         $this->assertEquals($expectedBool, $api->deleteProjectAccessToken(1, 2));
     }
 
+    /**
+     * @test
+     */
+    public function shouldUploadAvatar(): void
+    {
+        $emptyPNGContents = 'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAACYElEQVR42u3UMQEAAAjDMFCO9GEAByQSerQrmQJeagMAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwADAAAwADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMAAzAAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwADMAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAMAAZwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAOCybrx+H1CTHLYAAAAASUVORK5CYII=';
+        $fileName = \uniqid().'.png';
+        $expectedArray = ['id' => 1, 'name' => 'Project Name', 'avatar_url' => 'https://gitlab.example.com/uploads/-/system/project/avatar/1/'.$fileName];
+        \file_put_contents($fileName, \base64_decode($emptyPNGContents));
+        $this->assertFileExists($fileName);
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('projects/1/', [], [], ['avatar' => $fileName])
+            ->will($this->returnValue($expectedArray));
+        $this->assertEquals($expectedArray, $api->uploadAvatar(1, $fileName));
+        \unlink($fileName);
+    }
+
     protected function getApiClass()
     {
         return Projects::class;


### PR DESCRIPTION
Recently migrated to GitLab from SVN. Most of our projects have a project icon at a specific path in the repo, needed an automatic way of uploading these icons to GitLab.
NOTE works on Gitlab 12.9+