### PR TITLE
[11.4] Fix double encoding of query parameters in `Repositories::compare`

### DIFF
--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -413,9 +413,9 @@ class Repositories extends AbstractApi
     public function compare($project_id, string $fromShaOrMaster, string $toShaOrMaster, bool $straight = false)
     {
         $params = [
-            'from' => self::encodePath($fromShaOrMaster),
-            'to' => self::encodePath($toShaOrMaster),
-            'straight' => self::encodePath($straight ? 'true' : 'false'),
+            'from' => $fromShaOrMaster,
+            'to' => $toShaOrMaster,
+            'straight' => $straight ? 'true' : 'false',
         ];
 
         return $this->get($this->getProjectPath($project_id, 'repository/compare'), $params);

--- a/tests/Api/RepositoriesTest.php
+++ b/tests/Api/RepositoriesTest.php
@@ -544,6 +544,23 @@ class RepositoriesTest extends TestCase
     /**
      * @test
      */
+    public function shouldCompareComplexBranchName(): void
+    {
+        $expectedArray = ['commit' => 'object'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/repository/compare', ['from' => 'master', 'to' => 'feature/760.fake-branch', 'straight' => 'true'])
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->compare(1, 'master', 'feature/760.fake-branch', true));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetDiff(): void
     {
         $expectedArray = [


### PR DESCRIPTION
Closes #672.