### PR TITLE
[11.8] Add reviewer_id and wip fields to "merge_request -> all" route

### DIFF
--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -61,6 +61,8 @@ class MergeRequests extends AbstractApi
      *     @var string             $labels         return merge requests matching a comma separated list of labels
      *     @var \DateTimeInterface $created_after  return merge requests created after the given time (inclusive)
      *     @var \DateTimeInterface $created_before return merge requests created before the given time (inclusive)
+     *     @var int                $reviewer_id    returns merge requests which have the user as a reviewer with the given user id
+     *     @var string             $wip            return only draft merge requests (yes) or only non-draft merge requests (no)
      * }
      *
      * @throws UndefinedOptionsException if an option name is undefined
@@ -136,6 +138,10 @@ class MergeRequests extends AbstractApi
                 return \count($value) === \count(\array_filter($value, 'is_int'));
             })
         ;
+        $resolver->setDefined('reviewer_id')
+            ->setAllowedTypes('reviewer_id', 'integer');
+        $resolver->setDefined('wip')
+            ->setAllowedValues('wip', ['yes', 'no']);
 
         $path = null === $project_id ? 'merge_requests' : $this->getProjectPath($project_id, 'merge_requests');
 

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -142,7 +142,7 @@ class MergeRequests extends AbstractApi
             ->setAllowedTypes('reviewer_id', 'integer');
         $resolver->setDefined('wip')
             ->setAllowedTypes('wip', 'boolean')
-            ->addNormalizer('wip', static function($resolver, $wip) {
+            ->addNormalizer('wip', static function ($resolver, $wip) {
                 return $wip ? 'yes' : 'no';
             });
 

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -61,7 +61,7 @@ class MergeRequests extends AbstractApi
      *     @var string             $labels         return merge requests matching a comma separated list of labels
      *     @var \DateTimeInterface $created_after  return merge requests created after the given time (inclusive)
      *     @var \DateTimeInterface $created_before return merge requests created before the given time (inclusive)
-     *     @var int                $reviewer_id    returns merge requests which have the user as a reviewer with the given user id
+     *     @var int                $reviewer_id    return merge requests which have the user as a reviewer with the given user id
      *     @var bool               $wip            return only draft merge requests (true) or only non-draft merge requests (false)
      * }
      *

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -62,7 +62,7 @@ class MergeRequests extends AbstractApi
      *     @var \DateTimeInterface $created_after  return merge requests created after the given time (inclusive)
      *     @var \DateTimeInterface $created_before return merge requests created before the given time (inclusive)
      *     @var int                $reviewer_id    returns merge requests which have the user as a reviewer with the given user id
-     *     @var string             $wip            return only draft merge requests (yes) or only non-draft merge requests (no)
+     *     @var bool               $wip            return only draft merge requests (true) or only non-draft merge requests (false)
      * }
      *
      * @throws UndefinedOptionsException if an option name is undefined
@@ -141,7 +141,10 @@ class MergeRequests extends AbstractApi
         $resolver->setDefined('reviewer_id')
             ->setAllowedTypes('reviewer_id', 'integer');
         $resolver->setDefined('wip')
-            ->setAllowedValues('wip', ['yes', 'no']);
+            ->setAllowedTypes('wip', 'boolean')
+            ->addNormalizer('wip', static function($resolver, $wip) {
+                return $wip ? 'yes' : 'no';
+            });
 
         $path = null === $project_id ? 'merge_requests' : $this->getProjectPath($project_id, 'merge_requests');
 


### PR DESCRIPTION
Hello there 👋 

I've added the fields `reviewer_id` and `wip` as described in the documentation: https://docs.gitlab.com/ee/api/merge_requests.html to the merge request route.

I wasn't sure about the changelog, so I didn't touch it for now. Should I add an entry to it?

Thanks, and have a nice day!