### PR TITLE
[11.8] Implement `Projects::pipelineJobs()`

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -402,6 +402,17 @@ class Projects extends AbstractApi
      *
      * @return mixed
      */
+    public function pipelineJobs($project_id, int $pipeline_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'pipelines/'.self::encodePath($pipeline_id).'/jobs'));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $pipeline_id
+     *
+     * @return mixed
+     */
     public function pipelineVariables($project_id, int $pipeline_id)
     {
         return $this->get($this->getProjectPath($project_id, 'pipelines/'.self::encodePath($pipeline_id).'/variables'));

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -825,7 +825,7 @@ class ProjectsTest extends TestCase
             ->with('projects/1/pipelines/3/jobs')
             ->will($this->returnValue($expectedArray));
 
-        $this->assertEquals($expectedArray, $api->pipeline(1, 3));
+        $this->assertEquals($expectedArray, $api->pipelineJobs(1, 3));
     }
 
     /**

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -811,6 +811,26 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetPipelineJobs(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'status' => 'success', 'stage' => 'Build'],
+            ['id' => 2, 'status' => 'failed', 'stage' => 'Build'],
+            ['id' => 3, 'status' => 'pending', 'stage' => 'Build'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/pipelines/3/jobs')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->pipeline(1, 3));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetPipelineVariables(): void
     {
         $expectedArray = [


### PR DESCRIPTION
Extend Projects.php with new method pipelineJobs to fetch all jobs related to a single pipeline. 