### PR TITLE
Improve handling of non-array json responses to prevent unexpected errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,9 @@
         }
     },
     "config": {
-        "preferred-install": "dist"
+        "preferred-install": "dist",
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true
+        }
     }
 }

--- a/src/Exception/NonArrayJsonResponseException.php
+++ b/src/Exception/NonArrayJsonResponseException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Exception;
+
+class NonArrayJsonResponseException extends RuntimeException
+{
+}

--- a/src/HttpClient/Message/ResponseMediator.php
+++ b/src/HttpClient/Message/ResponseMediator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Gitlab\HttpClient\Message;
 
+use Gitlab\Exception\NonArrayJsonResponseException;
 use Gitlab\Exception\RuntimeException;
 use Gitlab\HttpClient\Util\JsonArray;
 use Psr\Http\Message\ResponseInterface;
@@ -62,8 +63,16 @@ final class ResponseMediator
     {
         $body = (string) $response->getBody();
 
-        if (!\in_array($body, ['', 'null', 'true', 'false'], true) && 0 === \strpos($response->getHeaderLine(self::CONTENT_TYPE_HEADER), self::JSON_CONTENT_TYPE)) {
-            return JsonArray::decode($body);
+        if ('' === $body) {
+            return $body;
+        }
+
+        if (0 === \strpos($response->getHeaderLine(self::CONTENT_TYPE_HEADER), self::JSON_CONTENT_TYPE)) {
+            try {
+                return JsonArray::decode($body);
+            } catch (NonArrayJsonResponseException $e) {
+                return $body;
+            }
         }
 
         return $body;

--- a/src/HttpClient/Util/JsonArray.php
+++ b/src/HttpClient/Util/JsonArray.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Gitlab\HttpClient\Util;
 
+use Gitlab\Exception\NonArrayJsonResponseException;
 use Gitlab\Exception\RuntimeException;
 
 /**
@@ -39,8 +40,8 @@ final class JsonArray
             throw new RuntimeException(\sprintf('json_decode error: %s', \json_last_error_msg()));
         }
 
-        if (null === $data || !\is_array($data)) {
-            throw new RuntimeException(\sprintf('json_decode error: Expected JSON of type array, %s given.', \get_debug_type($data)));
+        if (!\is_array($data)) {
+            throw new NonArrayJsonResponseException(\sprintf('json_decode error: Expected JSON of type array, %s given.', \get_debug_type($data)));
         }
 
         return $data;

--- a/tests/HttpClient/Message/ResponseMediatorTest.php
+++ b/tests/HttpClient/Message/ResponseMediatorTest.php
@@ -62,6 +62,20 @@ class ResponseMediatorTest extends TestCase
         ResponseMediator::getContent($response);
     }
 
+    /** @dataProvider nonArrayJsonResponsesProvider */
+    public function testGetContentNonArrayJson(string $json): void
+    {
+        $response = new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            Utils::streamFor($json)
+        );
+
+        $content = ResponseMediator::getContent($response);
+
+        $this->assertEquals($json, $content);
+    }
+
     public function testGetErrrorMessageInvalidJson(): void
     {
         $response = new Response(
@@ -94,5 +108,18 @@ TEXT;
         $result = ResponseMediator::getPagination($response);
 
         $this->assertSame($pagination, $result);
+    }
+
+    public function nonArrayJsonResponsesProvider(): array
+    {
+        return [
+            [''],
+            ['""'],
+            ['"foo"'],
+            ['null'],
+            ['true'],
+            ['false'],
+            ['202'],
+        ];
     }
 }


### PR DESCRIPTION
I was implementing the [container registry](https://docs.gitlab.com/ee/api/container_registry.html) endpoints on top of this library when I ran into an unexpected error when decoding the response body.
The [delete registry repository](https://docs.gitlab.com/ee/api/container_registry.html#delete-registry-repository) endpoint returns a response with status `202 Accepted` and body `202`.
The current implementation doesn't accept integers as safe non-array JSON responses.
The proposed new implementation will return the response body as is if it's not deserialized into an array.