### PR TITLE
drop patchlevel for php in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^7.4.15 || ^8.0.2",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "ext-xml": "*",
         "php-http/cache-plugin": "^1.7.5",


### PR DESCRIPTION
You should do without the patch level of PHP in the composer.json. 
Many operating systems (for example Ubuntu 20.04 (PHP 7.4.3)) rarely support the latest PHP version. 
This repository does not necessarily require changes from the respective patch levels. 