### PR TITLE
[11.8] Fixing `createPipeline` behavior to match API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [11.8.0] - UPCOMING
+
+* TBC
+
+[11.8.0]: https://github.com/GitLabPHP/Client/compare/11.7.0...11.8.0
+
 ## [11.7.0] - 2022-01-24
 
 * Dropped PHP 7.2 and 7.3 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [11.8.0] - UPCOMING
 
-* TBC
+* Add support for `reviewer_id` and `wip` params in `MergeRequests::all()`
+* Add support for `Projects::pipelineJobs()`
+* Allow specifying params in `Wiki::showAll()`
+* Allow specifying params in `SystemHooks::create()`
+* Implement group merge requests endpoints
+* Implement event endpoints
 
 [11.8.0]: https://github.com/GitLabPHP/Client/compare/11.7.0...11.8.0
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This version supports [PHP](https://php.net) 7.4-8.1. To get started, simply req
 ### Standard Installation
 
 ```bash
-$ composer require "m4tthumphrey/php-gitlab-api:^11.7" "guzzlehttp/guzzle:^7.4" "http-interop/http-factory-guzzle:^1.2"
+$ composer require "m4tthumphrey/php-gitlab-api:^11.8" "guzzlehttp/guzzle:^7.4" "http-interop/http-factory-guzzle:^1.2"
 ```
 
 ### Framework Integration
@@ -36,7 +36,7 @@ $ composer require "m4tthumphrey/php-gitlab-api:^11.7" "guzzlehttp/guzzle:^7.4" 
 #### Laravel:
 
 ```bash
-$ composer require "graham-campbell/gitlab:^6.0"
+$ composer require "graham-campbell/gitlab:^6.1"
 ```
 
 #### Symfony:

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -106,7 +106,7 @@ abstract class AbstractApi
      *
      * @return mixed
      */
-    protected function post(string $uri, array $params = [], array $headers = [], array $files = [])
+    protected function post(string $uri, array $params = [], array $headers = [], array $files = [], array $uriParams = [])
     {
         if (0 < \count($files)) {
             $builder = $this->createMultipartStreamBuilder($params, $files);
@@ -120,7 +120,7 @@ abstract class AbstractApi
             }
         }
 
-        $response = $this->client->getHttpClient()->post(self::prepareUri($uri), $headers, $body);
+        $response = $this->client->getHttpClient()->post(self::prepareUri($uri, $uriParams), $headers, $body);
 
         return ResponseMediator::getContent($response);
     }

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -61,6 +61,8 @@ class MergeRequests extends AbstractApi
      *     @var string             $labels         return merge requests matching a comma separated list of labels
      *     @var \DateTimeInterface $created_after  return merge requests created after the given time (inclusive)
      *     @var \DateTimeInterface $created_before return merge requests created before the given time (inclusive)
+     *     @var int                $reviewer_id    return merge requests which have the user as a reviewer with the given user id
+     *     @var bool               $wip            return only draft merge requests (true) or only non-draft merge requests (false)
      * }
      *
      * @throws UndefinedOptionsException if an option name is undefined
@@ -136,6 +138,13 @@ class MergeRequests extends AbstractApi
                 return \count($value) === \count(\array_filter($value, 'is_int'));
             })
         ;
+        $resolver->setDefined('reviewer_id')
+            ->setAllowedTypes('reviewer_id', 'integer');
+        $resolver->setDefined('wip')
+            ->setAllowedTypes('wip', 'boolean')
+            ->addNormalizer('wip', static function ($resolver, $wip) {
+                return $wip ? 'yes' : 'no';
+            });
 
         $path = null === $project_id ? 'merge_requests' : $this->getProjectPath($project_id, 'merge_requests');
 

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -432,15 +432,15 @@ class Projects extends AbstractApi
      */
     public function createPipeline($project_id, string $commit_ref, array $variables = null)
     {
-        $parameters = [
-            'ref' => $commit_ref,
-        ];
+        $parameters = [];
 
         if (null !== $variables) {
             $parameters['variables'] = $variables;
         }
 
-        return $this->post($this->getProjectPath($project_id, 'pipeline'), $parameters);
+        return $this->post($this->getProjectPath($project_id, 'pipeline'), $parameters, [], [], [
+            'ref' => $commit_ref,
+        ]);
     }
 
     /**

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -402,6 +402,17 @@ class Projects extends AbstractApi
      *
      * @return mixed
      */
+    public function pipelineJobs($project_id, int $pipeline_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'pipelines/'.self::encodePath($pipeline_id).'/jobs'));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $pipeline_id
+     *
+     * @return mixed
+     */
     public function pipelineVariables($project_id, int $pipeline_id)
     {
         return $this->get($this->getProjectPath($project_id, 'pipelines/'.self::encodePath($pipeline_id).'/variables'));

--- a/src/Api/ResourceIterationEvents.php
+++ b/src/Api/ResourceIterationEvents.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Api;
+
+class ResourceIterationEvents extends AbstractApi
+{
+    /**
+     * @param int|string $project_id
+     * @param int        $issue_iid
+     *
+     * @return mixed
+     */
+    public function all($project_id, int $issue_iid)
+    {
+        $path = 'issues/'.self::encodePath($issue_iid).'/resource_iteration_events';
+
+        return $this->get($this->getProjectPath($project_id, $path));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $issue_iid
+     * @param int        $resource_iteration_event_id
+     *
+     * @return mixed
+     */
+    public function show($project_id, int $issue_iid, int $resource_iteration_event_id)
+    {
+        $path = 'issues/'.self::encodePath($issue_iid).'/resource_iteration_events/';
+        $path .= self::encodePath($resource_iteration_event_id);
+
+        return $this->get($this->getProjectPath($project_id, $path));
+    }
+}

--- a/src/Api/ResourceLabelEvents.php
+++ b/src/Api/ResourceLabelEvents.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Api;
+
+class ResourceLabelEvents extends AbstractApi
+{
+    /**
+     * @param int|string $project_id
+     * @param int        $issue_iid
+     *
+     * @return mixed
+     */
+    public function all($project_id, int $issue_iid)
+    {
+        $path = 'issues/'.self::encodePath($issue_iid).'/resource_label_events';
+
+        return $this->get($this->getProjectPath($project_id, $path));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $issue_iid
+     * @param int        $resource_label_event_id
+     *
+     * @return mixed
+     */
+    public function show($project_id, int $issue_iid, int $resource_label_event_id)
+    {
+        $path = 'issues/'.self::encodePath($issue_iid).'/resource_label_events/';
+        $path .= self::encodePath($resource_label_event_id);
+
+        return $this->get($this->getProjectPath($project_id, $path));
+    }
+}

--- a/src/Api/ResourceMilestoneEvents.php
+++ b/src/Api/ResourceMilestoneEvents.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Api;
+
+class ResourceMilestoneEvents extends AbstractApi
+{
+    /**
+     * @param int|string $project_id
+     * @param int        $issue_iid
+     *
+     * @return mixed
+     */
+    public function all($project_id, int $issue_iid)
+    {
+        $path = 'issues/'.self::encodePath($issue_iid).'/resource_milestone_events';
+
+        return $this->get($this->getProjectPath($project_id, $path));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $issue_iid
+     * @param int        $resource_milestone_event_id
+     *
+     * @return mixed
+     */
+    public function show($project_id, int $issue_iid, int $resource_milestone_event_id)
+    {
+        $path = 'issues/'.self::encodePath($issue_iid).'/resource_milestone_events/';
+        $path .= self::encodePath($resource_milestone_event_id);
+
+        return $this->get($this->getProjectPath($project_id, $path));
+    }
+}

--- a/src/Api/ResourceStateEvents.php
+++ b/src/Api/ResourceStateEvents.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Api;
+
+class ResourceStateEvents extends AbstractApi
+{
+    /**
+     * @param int|string $project_id
+     * @param int        $issue_iid
+     *
+     * @return mixed
+     */
+    public function all($project_id, int $issue_iid)
+    {
+        $path = 'issues/'.self::encodePath($issue_iid).'/resource_state_events';
+
+        return $this->get($this->getProjectPath($project_id, $path));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $issue_iid
+     * @param int        $resource_label_event_id
+     *
+     * @return mixed
+     */
+    public function show($project_id, int $issue_iid, int $resource_label_event_id)
+    {
+        $path = 'issues/'.self::encodePath($issue_iid).'/resource_state_events/';
+        $path .= self::encodePath($resource_label_event_id);
+
+        return $this->get($this->getProjectPath($project_id, $path));
+    }
+}

--- a/src/Api/ResourceWeightEvents.php
+++ b/src/Api/ResourceWeightEvents.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Api;
+
+class ResourceWeightEvents extends AbstractApi
+{
+    /**
+     * @param int|string $project_id
+     * @param int        $issue_iid
+     *
+     * @return mixed
+     */
+    public function all($project_id, int $issue_iid)
+    {
+        $path = 'issues/'.self::encodePath($issue_iid).'/resource_weight_events';
+
+        return $this->get($this->getProjectPath($project_id, $path));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $issue_iid
+     * @param int        $resource_label_event_id
+     *
+     * @return mixed
+     */
+    public function show($project_id, int $issue_iid, int $resource_label_event_id)
+    {
+        $path = 'issues/'.self::encodePath($issue_iid).'/resource_weight_events/';
+        $path .= self::encodePath($resource_label_event_id);
+
+        return $this->get($this->getProjectPath($project_id, $path));
+    }
+}

--- a/src/Api/SystemHooks.php
+++ b/src/Api/SystemHooks.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 
 namespace Gitlab\Api;
 
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
 class SystemHooks extends AbstractApi
 {
     /**
@@ -25,15 +28,26 @@ class SystemHooks extends AbstractApi
     }
 
     /**
-     * @param string $url
+     * @param string                    $url
+     * @param array<string,string|bool> $parameters {
+     *
+     *     @var string  $token                      secret token to validate received payloads
+     *     @var bool    $push_events                when true, the hook fires on push events
+     *     @var bool    $tag_push_events            when true, the hook fires on new tags being pushed
+     *     @var bool    $merge_requests_events      trigger hook on merge requests events
+     *     @var bool    $repository_update_events   trigger hook on repository update events
+     *     @var bool    $enable_ssl_verification    do SSL verification when triggering the hook
+     * }
      *
      * @return mixed
      */
-    public function create(string $url)
+    public function create(string $url, array $parameters = [])
     {
-        return $this->post('hooks', [
-            'url' => $url,
-        ]);
+        $parameters = $this->createOptionsResolver()->resolve($parameters);
+
+        $parameters['url'] = $url;
+
+        return $this->post('hooks', $parameters);
     }
 
     /**
@@ -54,5 +68,43 @@ class SystemHooks extends AbstractApi
     public function remove(int $id)
     {
         return $this->delete('hooks/'.self::encodePath($id));
+    }
+
+    protected function createOptionsResolver(): OptionsResolver
+    {
+        $resolver = new OptionsResolver();
+
+        $resolver->setDefined('token');
+
+        $booleanNormalizer = function (Options $resolver, $value): string {
+            return $value ? 'true' : 'false';
+        };
+
+        $resolver->setDefined('push_events')
+                 ->setAllowedTypes('push_events', 'bool')
+                 ->setNormalizer('push_events', $booleanNormalizer)
+        ;
+
+        $resolver->setDefined('tag_push_events')
+                 ->setAllowedTypes('tag_push_events', 'bool')
+                 ->setNormalizer('tag_push_events', $booleanNormalizer)
+        ;
+
+        $resolver->setDefined('merge_requests_events')
+                 ->setAllowedTypes('merge_requests_events', 'bool')
+                 ->setNormalizer('merge_requests_events', $booleanNormalizer)
+        ;
+
+        $resolver->setDefined('repository_update_events')
+                 ->setAllowedTypes('repository_update_events', 'bool')
+                 ->setNormalizer('repository_update_events', $booleanNormalizer)
+        ;
+
+        $resolver->setDefined('enable_ssl_verification')
+                 ->setAllowedTypes('enable_ssl_verification', 'bool')
+                 ->setNormalizer('enable_ssl_verification', $booleanNormalizer)
+        ;
+
+        return $resolver;
     }
 }

--- a/src/Api/Wiki.php
+++ b/src/Api/Wiki.php
@@ -17,8 +17,8 @@ namespace Gitlab\Api;
 class Wiki extends AbstractApi
 {
     /**
-     * @param int|string $project_id
-     * @param array      $params
+     * @param int|string          $project_id
+     * @param array<string,mixed> $params
      *
      * @return mixed
      */
@@ -39,19 +39,27 @@ class Wiki extends AbstractApi
     }
 
     /**
-     * @param int|string $project_id
+     * @param int|string          $project_id
+     * @param array<string,mixed> $params     {
+     *
+     *     @var bool $with_content Include pages' content
+     * }
      *
      * @return mixed
      */
-    public function showAll($project_id)
+    public function showAll($project_id, array $params)
     {
-        return $this->get($this->getProjectPath($project_id, 'wikis'));
+        $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('with_content')
+            ->setAllowedTypes('with_content', 'bool');
+
+        return $this->get($this->getProjectPath($project_id, 'wikis'), $resolver->resolve($params));
     }
 
     /**
-     * @param int|string $project_id
-     * @param string     $wiki_slug
-     * @param array      $params
+     * @param int|string          $project_id
+     * @param string              $wiki_slug
+     * @param array<string,mixed> $params
      *
      * @return mixed
      */

--- a/src/Client.php
+++ b/src/Client.php
@@ -86,7 +86,7 @@ class Client
      *
      * @var string
      */
-    private const USER_AGENT = 'gitlab-php-api-client/11.7';
+    private const USER_AGENT = 'gitlab-php-api-client/11.8';
 
     /**
      * The HTTP client builder.

--- a/src/Client.php
+++ b/src/Client.php
@@ -33,6 +33,11 @@ use Gitlab\Api\ProjectNamespaces;
 use Gitlab\Api\Projects;
 use Gitlab\Api\Repositories;
 use Gitlab\Api\RepositoryFiles;
+use Gitlab\Api\ResourceIterationEvents;
+use Gitlab\Api\ResourceLabelEvents;
+use Gitlab\Api\ResourceMilestoneEvents;
+use Gitlab\Api\ResourceStateEvents;
+use Gitlab\Api\ResourceWeightEvents;
 use Gitlab\Api\Schedules;
 use Gitlab\Api\Snippets;
 use Gitlab\Api\SystemHooks;
@@ -216,6 +221,46 @@ class Client
     public function issues(): Issues
     {
         return new Issues($this);
+    }
+
+    /**
+     * @return ResourceIterationEvents
+     */
+    public function resourceIterationEvents(): ResourceIterationEvents
+    {
+        return new ResourceIterationEvents($this);
+    }
+
+    /**
+     * @return ResourceLabelEvents
+     */
+    public function resourceLabelEvents(): ResourceLabelEvents
+    {
+        return new ResourceLabelEvents($this);
+    }
+
+    /**
+     * @return ResourceMilestoneEvents
+     */
+    public function resourceMilestoneEvents(): ResourceMilestoneEvents
+    {
+        return new ResourceMilestoneEvents($this);
+    }
+
+    /**
+     * @return ResourceStateEvents
+     */
+    public function resourceStateEvents(): ResourceStateEvents
+    {
+        return new ResourceStateEvents($this);
+    }
+
+    /**
+     * @return ResourceWeightEvents
+     */
+    public function resourceWeightEvents(): ResourceWeightEvents
+    {
+        return new ResourceWeightEvents($this);
     }
 
     /**

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -715,4 +715,24 @@ class GroupsTest extends TestCase
 
         $this->assertEquals($expectedArray, $api->packages(1));
     }
+
+    /**
+     * @test
+     */
+    public function shouldGetGroupMergeRequests(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'title' => 'A merge request'],
+            ['id' => 2, 'title' => 'Another merge request'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/merge_requests')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->mergeRequests(1, []));
+    }
 }

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -811,6 +811,26 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetPipelineJobs(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'status' => 'success', 'stage' => 'Build'],
+            ['id' => 2, 'status' => 'failed', 'stage' => 'Build'],
+            ['id' => 3, 'status' => 'pending', 'stage' => 'Build'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/pipelines/3/jobs')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->pipelineJobs(1, 3));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetPipelineVariables(): void
     {
         $expectedArray = [

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -859,7 +859,7 @@ class ProjectsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('projects/1/pipeline', ['ref' => 'test-pipeline'])
+            ->with('projects/1/pipeline', [], [], [], ['ref' => 'test-pipeline'])
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->createPipeline(1, 'test-pipeline'));
@@ -888,7 +888,7 @@ class ProjectsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('projects/1/pipeline', ['ref' => 'test-pipeline', 'variables' => $variables])
+            ->with('projects/1/pipeline', ['variables' => $variables], [], [], ['ref' => 'test-pipeline'])
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->createPipeline(1, 'test-pipeline', $variables));

--- a/tests/Api/ResourceIterationEventsTest.php
+++ b/tests/Api/ResourceIterationEventsTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Tests\Api;
+
+use Gitlab\Api\ResourceIterationEvents;
+
+class ResourceIterationEventsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllEvents(): void
+    {
+        $expectedArray = [
+            [
+                'id' => 142,
+                'user' => [
+                    'id' => 1,
+                    'name' => 'Administrator',
+                    'username' => 'root',
+                    'state' => 'active',
+                    'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                    'web_url' => 'http=>//gitlab.example.com/root',
+                ],
+                'created_at' => '2018-08-20T13=>38=>20.077Z',
+                'resource_type' => 'Issue',
+                'resource_id' => 253,
+                'iteration' => [
+                    'id' => 50,
+                    'iid' => 9,
+                    'group_id' => 5,
+                    'title' => 'Iteration I',
+                    'description' => 'Ipsum Lorem',
+                    'state' => 1,
+                    'created_at' => '2020-01-27T05=>07=>12.573Z',
+                    'updated_at' => '2020-01-27T05=>07=>12.573Z',
+                    'due_date' => null,
+                    'start_date' => null,
+                ],
+                'action' => 'add',
+            ],
+            [
+                'id' => 143,
+                'user' => [
+                    'id' => 1,
+                    'name' => 'Administrator',
+                    'username' => 'root',
+                    'state' => 'active',
+                    'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                    'web_url' => 'http=>//gitlab.example.com/root',
+                ],
+                'created_at' => '2018-08-21T14=>38=>20.077Z',
+                'resource_type' => 'Issue',
+                'resource_id' => 253,
+                'iteration' => [
+                    'id' => 53,
+                    'iid' => 13,
+                    'group_id' => 5,
+                    'title' => 'Iteration II',
+                    'description' => 'Ipsum Lorem ipsum',
+                    'state' => 2,
+                    'created_at' => '2020-01-27T05=>07=>12.573Z',
+                    'updated_at' => '2020-01-27T05=>07=>12.573Z',
+                    'due_date' => null,
+                    'start_date' => null,
+                ],
+                'action' => 'remove',
+            ],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/issues/253/resource_iteration_events', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->all(1, 253));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldShowEvent(): void
+    {
+        $expectedArray = [
+            'id' => 142,
+            'user' => [
+                'id' => 1,
+                'name' => 'Administrator',
+                'username' => 'root',
+                'state' => 'active',
+                'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                'web_url' => 'http=>//gitlab.example.com/root',
+            ],
+            'created_at' => '2018-08-20T13=>38=>20.077Z',
+            'resource_type' => 'Issue',
+            'resource_id' => 253,
+            'iteration' => [
+                'id' => 50,
+                'iid' => 9,
+                'group_id' => 5,
+                'title' => 'Iteration I',
+                'description' => 'Ipsum Lorem',
+                'state' => 1,
+                'created_at' => '2020-01-27T05=>07=>12.573Z',
+                'updated_at' => '2020-01-27T05=>07=>12.573Z',
+                'due_date' => null,
+                'start_date' => null,
+            ],
+            'action' => 'add',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/issues/253/resource_iteration_events/142', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->show(1, 253, 142));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getApiClass(): string
+    {
+        return ResourceIterationEvents::class;
+    }
+}

--- a/tests/Api/ResourceLabelEventsTest.php
+++ b/tests/Api/ResourceLabelEventsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Tests\Api;
+
+use Gitlab\Api\ResourceLabelEvents;
+
+class ResourceLabelEventsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllEvents(): void
+    {
+        $expectedArray = [
+            [
+                'id' => 142,
+                'user' => [
+                    'id' => 1,
+                    'name' => 'Administrator',
+                    'username' => 'root',
+                    'state' => 'active',
+                    'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                    'web_url' => 'http=>//gitlab.example.com/root',
+                ],
+                'created_at' => '2018-08-20T13=>38=>20.077Z',
+                'resource_type' => 'Issue',
+                'resource_id' => 253,
+                'label' => [
+                    'id' => 73,
+                    'name' => 'a1',
+                    'color' => '#34495E',
+                    'description' => '',
+                ],
+                'action' => 'add',
+            ],
+            [
+                'id' => 143,
+                'user' => [
+                    'id' => 1,
+                    'name' => 'Administrator',
+                    'username' => 'root',
+                    'state' => 'active',
+                    'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                    'web_url' => 'http=>//gitlab.example.com/root',
+                ],
+                'created_at' => '2018-08-20T13=>38=>20.077Z',
+                'resource_type' => 'Issue',
+                'resource_id' => 253,
+                'label' => [
+                    'id' => 74,
+                    'name' => 'p1',
+                    'color' => '#0033CC',
+                    'description' => '',
+                ],
+                'action' => 'remove',
+            ],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/issues/253/resource_label_events', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->all(1, 253));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldShowEvent(): void
+    {
+        $expectedArray = [
+            'id' => 142,
+            'user' => [
+                'id' => 1,
+                'name' => 'Administrator',
+                'username' => 'root',
+                'state' => 'active',
+                'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                'web_url' => 'http=>//gitlab.example.com/root',
+            ],
+            'created_at' => '2018-08-20T13=>38=>20.077Z',
+            'resource_type' => 'Issue',
+            'resource_id' => 253,
+            'label' => [
+                'id' => 73,
+                'name' => 'a1',
+                'color' => '#34495E',
+                'description' => '',
+            ],
+            'action' => 'add',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/issues/253/resource_label_events/142', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->show(1, 253, 142));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getApiClass(): string
+    {
+        return ResourceLabelEvents::class;
+    }
+}

--- a/tests/Api/ResourceMilestoneEventsTest.php
+++ b/tests/Api/ResourceMilestoneEventsTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Tests\Api;
+
+use Gitlab\Api\ResourceMilestoneEvents;
+
+class ResourceMilestoneEventsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllEvents(): void
+    {
+        $expectedArray = [
+            [
+                'id' => 142,
+                'user' => [
+                    'id' => 1,
+                    'name' => 'Administrator',
+                    'username' => 'root',
+                    'state' => 'active',
+                    'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                    'web_url' => 'http=>//gitlab.example.com/root',
+                ],
+                'created_at' => '2018-08-20T13=>38=>20.077Z',
+                'resource_type' => 'Issue',
+                'resource_id' => 253,
+                'milestone' => [
+                    'id' => 61,
+                    'iid' => 9,
+                    'project_id' => 7,
+                    'title' => 'v1.2',
+                    'description' => 'Ipsum Lorem',
+                    'state' => 'active',
+                    'created_at' => '2020-01-27T05=>07=>12.573Z',
+                    'updated_at' => '2020-01-27T05=>07=>12.573Z',
+                    'due_date' => null,
+                    'start_date' => null,
+                    'web_url' => 'http=>//gitlab.example.com=>3000/group/project/-/milestones/9',
+                ],
+                'action' => 'add',
+            ],
+            [
+                'id' => 143,
+                'user' => [
+                    'id' => 1,
+                    'name' => 'Administrator',
+                    'username' => 'root',
+                    'state' => 'active',
+                    'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                    'web_url' => 'http=>//gitlab.example.com/root',
+                ],
+                'created_at' => '2018-08-21T14=>38=>20.077Z',
+                'resource_type' => 'Issue',
+                'resource_id' => 253,
+                'milestone' => [
+                    'id' => 61,
+                    'iid' => 9,
+                    'project_id' => 7,
+                    'title' => 'v1.2',
+                    'description' => 'Ipsum Lorem',
+                    'state' => 'active',
+                    'created_at' => '2020-01-27T05=>07=>12.573Z',
+                    'updated_at' => '2020-01-27T05=>07=>12.573Z',
+                    'due_date' => null,
+                    'start_date' => null,
+                    'web_url' => 'http=>//gitlab.example.com=>3000/group/project/-/milestones/9',
+                ],
+                'action' => 'remove',
+            ],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/issues/253/resource_milestone_events', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->all(1, 253));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldShowEvent(): void
+    {
+        $expectedArray = [
+            'id' => 142,
+            'user' => [
+                'id' => 1,
+                'name' => 'Administrator',
+                'username' => 'root',
+                'state' => 'active',
+                'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                'web_url' => 'http=>//gitlab.example.com/root',
+            ],
+            'created_at' => '2018-08-20T13=>38=>20.077Z',
+            'resource_type' => 'Issue',
+            'resource_id' => 253,
+            'milestone' => [
+                'id' => 61,
+                'iid' => 9,
+                'project_id' => 7,
+                'title' => 'v1.2',
+                'description' => 'Ipsum Lorem',
+                'state' => 'active',
+                'created_at' => '2020-01-27T05=>07=>12.573Z',
+                'updated_at' => '2020-01-27T05=>07=>12.573Z',
+                'due_date' => null,
+                'start_date' => null,
+                'web_url' => 'http=>//gitlab.example.com=>3000/group/project/-/milestones/9',
+            ],
+            'action' => 'add',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/issues/253/resource_milestone_events/142', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->show(1, 253, 142));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getApiClass(): string
+    {
+        return ResourceMilestoneEvents::class;
+    }
+}

--- a/tests/Api/ResourceStateEventsTest.php
+++ b/tests/Api/ResourceStateEventsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Tests\Api;
+
+use Gitlab\Api\ResourceStateEvents;
+
+class ResourceStateEventsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllEvents(): void
+    {
+        $expectedArray = [
+            [
+                'id' => 142,
+                'user' => [
+                    'id' => 1,
+                    'name' => 'Administrator',
+                    'username' => 'root',
+                    'state' => 'active',
+                    'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                    'web_url' => 'http=>//gitlab.example.com/root',
+                ],
+                'created_at' => '2018-08-20T13=>38=>20.077Z',
+                'resource_type' => 'Issue',
+                'resource_id' => 11,
+                'state' => 'opened',
+            ],
+            [
+                'id' => 143,
+                'user' => [
+                    'id' => 1,
+                    'name' => 'Administrator',
+                    'username' => 'root',
+                    'state' => 'active',
+                    'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                    'web_url' => 'http=>//gitlab.example.com/root',
+                ],
+                'created_at' => '2018-08-21T14=>38=>20.077Z',
+                'resource_type' => 'Issue',
+                'resource_id' => 11,
+                'state' => 'closed',
+            ],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/issues/11/resource_state_events', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->all(1, 11));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldShowEvent(): void
+    {
+        $expectedArray = [
+            'id' => 142,
+            'user' => [
+                'id' => 1,
+                'name' => 'Administrator',
+                'username' => 'root',
+                'state' => 'active',
+                'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                'web_url' => 'http=>//gitlab.example.com/root',
+            ],
+            'created_at' => '2018-08-20T13=>38=>20.077Z',
+            'resource_type' => 'Issue',
+            'resource_id' => 11,
+            'state' => 'opened',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/issues/11/resource_state_events/142', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->show(1, 11, 142));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getApiClass(): string
+    {
+        return ResourceStateEvents::class;
+    }
+}

--- a/tests/Api/ResourceWeightEventsTest.php
+++ b/tests/Api/ResourceWeightEventsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Tests\Api;
+
+use Gitlab\Api\ResourceWeightEvents;
+
+class ResourceWeightEventsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetAllEvents(): void
+    {
+        $expectedArray = [
+            [
+                'id' => 142,
+                'user' => [
+                    'id' => 1,
+                    'name' => 'Administrator',
+                    'username' => 'root',
+                    'state' => 'active',
+                    'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                    'web_url' => 'http=>//gitlab.example.com/root',
+                ],
+                'created_at' => '2018-08-20T13=>38=>20.077Z',
+                'issue_id' => 253,
+                'weight' => 3,
+            ],
+            [
+                'id' => 143,
+                'user' => [
+                    'id' => 1,
+                    'name' => 'Administrator',
+                    'username' => 'root',
+                    'state' => 'active',
+                    'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                    'web_url' => 'http=>//gitlab.example.com/root',
+                ],
+                'created_at' => '2018-08-21T14=>38=>20.077Z',
+                'issue_id' => 253,
+                'weight' => 2,
+            ],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/issues/253/resource_weight_events', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->all(1, 253));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldShowEvent(): void
+    {
+        $expectedArray = [
+            'id' => 142,
+            'user' => [
+                'id' => 1,
+                'name' => 'Administrator',
+                'username' => 'root',
+                'state' => 'active',
+                'avatar_url' => 'https=>//www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon',
+                'web_url' => 'http=>//gitlab.example.com/root',
+            ],
+            'created_at' => '2018-08-20T13=>38=>20.077Z',
+            'issue_id' => 253,
+            'weight' => 3,
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/issues/253/resource_weight_events/142', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->show(1, 253, 142));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getApiClass(): string
+    {
+        return ResourceWeightEvents::class;
+    }
+}

--- a/tests/Api/WikiTest.php
+++ b/tests/Api/WikiTest.php
@@ -81,14 +81,16 @@ class WikiTest extends TestCase
             'format' => 'markdown',
         ];
 
+        $params = ['with_content' => true];
+
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/wikis')
+            ->with('projects/1/wikis', $params)
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->showAll(1));
+        $this->assertEquals($expectedArray, $api->showAll(1, $params));
     }
 
     /**


### PR DESCRIPTION
This PR stems from https://github.com/GitLabPHP/Client/issues/638 and closes it.

Tests are also fixed to match actual behavior.
