### PR TITLE
[11.9] Add `Projects::patchProtectedBranches()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Allow specifying params in `SystemHooks::create()`
 * Implement group merge requests endpoints
 * Implement event endpoints
+* Add support for `Projects::patchProtectedBranch()`
 
 [11.8.0]: https://github.com/GitLabPHP/Client/compare/11.7.0...11.8.0
 

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -156,6 +156,33 @@ abstract class AbstractApi
      * @param string               $uri
      * @param array<string,mixed>  $params
      * @param array<string,string> $headers
+     * @param array<string,string> $files
+     *
+     * @return mixed
+     */
+    protected function patch(string $uri, array $params = [], array $headers = [], array $files = [])
+    {
+        if (0 < \count($files)) {
+            $builder = $this->createMultipartStreamBuilder($params, $files);
+            $body = self::prepareMultipartBody($builder);
+            $headers = self::addMultipartContentType($headers, $builder);
+        } else {
+            $body = self::prepareJsonBody($params);
+
+            if (null !== $body) {
+                $headers = self::addJsonContentType($headers);
+            }
+        }
+
+        $response = $this->client->getHttpClient()->patch(self::prepareUri($uri), $headers, $body ?? '');
+
+        return ResponseMediator::getContent($response);
+    }
+
+    /**
+     * @param string               $uri
+     * @param array<string,mixed>  $params
+     * @param array<string,string> $headers
      *
      * @return mixed
      */

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1236,6 +1236,18 @@ class Projects extends AbstractApi
 
     /**
      * @param int|string $project_id
+     * @param string     $branch_name
+     * @param array      $parameters
+     *
+     * @return mixed
+     */
+    public function patchProtectedBranch($project_id, string $branch_name, array $parameters = [])
+    {
+        return $this->patch($this->getProjectPath($project_id, 'protected_branches/'.self::encodePath($branch_name)), $parameters);
+    }
+
+    /**
+     * @param int|string $project_id
      *
      * @return mixed
      */

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2260,7 +2260,7 @@ class ProjectsTest extends TestCase
     public function shouldPatchProtectedBranch(): void
     {
         $expectedArray = [
-            'code_owner_approval_required' => true
+            'code_owner_approval_required' => true,
         ];
         $api = $this->getApiMock();
         $api->expects($this->once())

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2260,15 +2260,14 @@ class ProjectsTest extends TestCase
     public function shouldPatchProtectedBranch(): void
     {
         $expectedArray = [
-            'name' => 'master',
-            'code_owner_approval_required' => true,
+            'code_owner_approval_required' => true
         ];
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('patch')
             ->with(
                 'projects/1/protected_branches/test-branch',
-                ['name' => 'master', 'code_owner_approval_required' => true,]
+                ['code_owner_approval_required' => true]
             )
             ->will($this->returnValue($expectedArray));
         $this->assertEquals($expectedArray, $api->patchProtectedBranch(1, 'test-branch', ['code_owner_approval_required' => true]));

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2257,6 +2257,26 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldPatchProtectedBranch(): void
+    {
+        $expectedArray = [
+            'name' => 'master',
+            'code_owner_approval_required' => true,
+        ];
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('patch')
+            ->with(
+                'projects/1/protected_branches/test-branch',
+                ['name' => 'master', 'code_owner_approval_required' => true,]
+            )
+            ->will($this->returnValue($expectedArray));
+        $this->assertEquals($expectedArray, $api->patchProtectedBranch(1, 'test-branch', ['code_owner_approval_required' => true]));
+    }
+
+    /**
+     * @test
+     */
     public function shoudGetApprovalsConfiguration(): void
     {
         $expectedArray = [


### PR DESCRIPTION
add support for Projects::patchProtectedBranches (https://docs.gitlab.com/ee/api/protected_branches.html#require-code-owner-approvals-for-a-single-branch)