### PR TITLE
[11.9] Add custom attribute support to `Users`

### DIFF
--- a/src/Api/Users.php
+++ b/src/Api/Users.php
@@ -64,6 +64,13 @@ class Users extends AbstractApi
             ->setAllowedTypes('blocked', 'bool')
             ->setAllowedValues('blocked', true)
         ;
+        $resolver->setDefined('with_custom_attributes')
+            ->setAllowedTypes('with_custom_attributes', 'bool')
+            ->setAllowedValues('with_custom_attributes', true)
+        ;
+        $resolver->setDefined('custom_attributes')
+            ->setAllowedTypes('custom_attributes', 'array')
+        ;
 
         return $this->get('users', $resolver->resolve($parameters));
     }
@@ -510,4 +517,66 @@ class Users extends AbstractApi
 
         return $this->get('users/'.self::encodePath($user_id).'/events', $resolver->resolve($parameters));
     }
+
+    /**
+     * @param int   $id
+     *
+     * @return mixed
+     */
+    public function customAttributes(int $id)
+    {
+        return $this->get('users/'.self::encodePath($id).'/custom_attributes');
+    }
+
+    /**
+     * @param int    $id
+     * @param string $key
+     * @param string $value
+     *
+     * @return mixed
+     */
+    public function customAttribute(int $id, string $key)
+    {
+        return $this->get('users/'.self::encodePath($id).'/custom_attributes/'.$key);
+    }
+
+    /**
+     * @param int    $id
+     * @param string $key
+     * @param string $value
+     *
+     * @return mixed
+     */
+    public function createCustomAttribute(int $id, string $key, string $value)
+    {
+        return $this->put('users/'.self::encodePath($id).'/custom_attributes/'.$key, [
+            'value' => $value,
+        ]);
+    }
+
+    /**
+     * @param int    $id
+     * @param string $key
+     * @param string $value
+     *
+     * @return mixed
+     */
+    public function updateCustomAttribute(int $id, string $key, string $value)
+    {
+        return $this->put('users/'.self::encodePath($id).'/custom_attributes/'.$key, [
+            'value' => $value,
+        ]);
+    }
+
+    /**
+     * @param int $id
+     * @param string $key
+     *
+     * @return mixed
+     */
+    public function removeCustomAttribute(int $id, string $key)
+    {
+        return $this->delete('users/'.self::encodePath($id).'/custom_attributes/'.$key);
+    }
+
 }


### PR DESCRIPTION
Added options to user lookup functions:
- "with_custom_attributes" (true|false) to also get users custom attributes in resulting array
- "custom_attributes" can contain an array of custom attributes to lookup users

Added functions:
- "customAttributes(int $id)" to get all custom attributes defined for the user
- "customAttribute(int $id, string $key)" to get single attribute by name
- "createCustomAttribute(int $id, string $key, string $value)" to add another attribute (key/value)
- "updateCustomAttribute(int $id, string $key, string $value)" to update (or create) an existing attribute
- "removeCustomAttribute(int $id, string $key)" to delete an custom attribute by key
