### PR TITLE
[11.9] Add group and project iterations

### DIFF
--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -638,7 +638,7 @@ class Groups extends AbstractApi
         };
 
         $resolver->setDefined('state')
-            ->setAllowedValues('state', ['opened', 'upcoming', 'current (previously started)', 'closed', 'all'])
+            ->setAllowedValues('state', ['opened', 'upcoming', 'current', 'current (previously started)', 'closed', 'all'])
         ;
         $resolver->setDefined('include_ancestors')
             ->setAllowedTypes('include_ancestors', 'bool')

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -622,6 +622,37 @@ class Groups extends AbstractApi
      * @param int|string $group_id
      * @param array      $parameters {
      *
+     *     @var string $state               Return opened, upcoming, current (previously started), closed, or all iterations.
+     *                                      Filtering by started state is deprecated starting with 14.1, please use current instead.
+     *     @var string $search              Return only iterations with a title matching the provided string.
+     *     @var bool   $include_ancestors   Include iterations from parent group and its ancestors. Defaults to true.
+     * }
+     *
+     * @return mixed
+     */
+    public function iterations($group_id, array $parameters = [])
+    {
+        $resolver = $this->createOptionsResolver();
+        $booleanNormalizer = function (Options $resolver, $value): string {
+            return $value ? 'true' : 'false';
+        };
+
+        $resolver->setDefined('state')
+            ->setAllowedValues('state', ['opened', 'upcoming', 'current (previously started)', 'closed', 'all'])
+        ;
+        $resolver->setDefined('include_ancestors')
+            ->setAllowedTypes('include_ancestors', 'bool')
+            ->setNormalizer('include_ancestors', $booleanNormalizer)
+            ->setDefault('include_ancestors', true)
+        ;
+
+        return $this->get('groups/'.self::encodePath($group_id).'/iterations', $resolver->resolve($parameters));
+    }
+
+    /**
+     * @param int|string $group_id
+     * @param array      $parameters {
+     *
      *     @var bool   $exclude_subgroups   if the parameter is included as true, packages from projects from subgroups
      *                                      are not listed. default is false.
      *     @var string $order_by            the field to use as order. one of created_at (default), name, version, type,

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -624,7 +624,7 @@ class Groups extends AbstractApi
      *
      *     @var string $state               Return opened, upcoming, current (previously started), closed, or all iterations.
      *                                      Filtering by started state is deprecated starting with 14.1, please use current instead.
-     *     @var string $search              Return only iterations with a title matching the provided string.
+     *     @var string $search              return only iterations with a title matching the provided string
      *     @var bool   $include_ancestors   Include iterations from parent group and its ancestors. Defaults to true.
      * }
      *

--- a/src/Api/Issues.php
+++ b/src/Api/Issues.php
@@ -41,8 +41,11 @@ class Issues extends AbstractApi
      *     @var int[]  $iids                 return only the issues having the given iid
      *     @var string $order_by             return requests ordered by created_at or updated_at fields (default is created_at)
      *     @var string $sort                 return requests sorted in asc or desc order (default is desc)
-     *     @var bool $confidential           filter confidential or public issues
+     *     @var bool   $confidential         filter confidential or public issues
      *     @var string $search               search issues against their title and description
+     *     @var int    $assignee_id          return issues assigned to the specified user id
+     *     @var int    $iteration_id         return issues assigned to the specified iteration id
+     *     @var string $iteration_title      return issues assigned to the specified iteration title
      * }
      *
      * @return mixed
@@ -494,6 +497,12 @@ class Issues extends AbstractApi
         $resolver->setDefined('updated_before');
         $resolver->setDefined('assignee_id')
             ->setAllowedTypes('assignee_id', 'integer')
+        ;
+        $resolver->setDefined('iteration_id')
+            ->setAllowedTypes('iteration_id', 'integer')
+        ;
+        $resolver->setDefined('iteration_title')
+            ->setAllowedTypes('iteration_title', 'string')
         ;
         $resolver->setDefined('weight')
             ->setAllowedTypes('weight', 'integer')

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -653,6 +653,37 @@ class Projects extends AbstractApi
     }
 
     /**
+     * @param int|string $project_id
+     * @param array      $parameters {
+     *
+     *     @var string $state               Return opened, upcoming, current (previously started), closed, or all iterations.
+     *                                      Filtering by started state is deprecated starting with 14.1, please use current instead.
+     *     @var string $search              Return only iterations with a title matching the provided string.
+     *     @var bool   $include_ancestors   Include iterations from parent group and its ancestors. Defaults to true.
+     * }
+     *
+     * @return mixed
+     */
+    public function iterations($project_id, array $parameters = [])
+    {
+        $resolver = $this->createOptionsResolver();
+        $booleanNormalizer = function (Options $resolver, $value): string {
+            return $value ? 'true' : 'false';
+        };
+
+        $resolver->setDefined('state')
+            ->setAllowedValues('state', ['opened', 'upcoming', 'current (previously started)', 'closed', 'all'])
+        ;
+        $resolver->setDefined('include_ancestors')
+            ->setAllowedTypes('include_ancestors', 'bool')
+            ->setNormalizer('include_ancestors', $booleanNormalizer)
+            ->setDefault('include_ancestors', true)
+        ;
+
+        return $this->get('projects/'.self::encodePath($project_id).'/iterations', $resolver->resolve($parameters));
+    }
+
+    /**
      * Gets a list of all discussion items for a single commit.
      *
      * Example:

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -658,7 +658,7 @@ class Projects extends AbstractApi
      *
      *     @var string $state               Return opened, upcoming, current (previously started), closed, or all iterations.
      *                                      Filtering by started state is deprecated starting with 14.1, please use current instead.
-     *     @var string $search              Return only iterations with a title matching the provided string.
+     *     @var string $search              return only iterations with a title matching the provided string
      *     @var bool   $include_ancestors   Include iterations from parent group and its ancestors. Defaults to true.
      * }
      *

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -672,7 +672,7 @@ class Projects extends AbstractApi
         };
 
         $resolver->setDefined('state')
-            ->setAllowedValues('state', ['opened', 'upcoming', 'current (previously started)', 'closed', 'all'])
+            ->setAllowedValues('state', ['opened', 'upcoming', 'current', 'current (previously started)', 'closed', 'all'])
         ;
         $resolver->setDefined('include_ancestors')
             ->setAllowedTypes('include_ancestors', 'bool')

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -679,6 +679,38 @@ class GroupsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetIterations(): void
+    {
+        $expectedArray = [
+            [
+                "id" => 5,
+                "iid" => 2,
+                "sequence" => 1,
+                "group_id" => 123,
+                "title" => "2022: Sprint 1",
+                "description" => "",
+                "state" => 3,
+                "created_at" => "2021-09-29T21:24:43.913Z",
+                "updated_at" => "2022-03-29T19:09:08.368Z",
+                "start_date" => "2022-01-10",
+                "due_date" => "2022-01-23",
+                "web_url" => "https://example.com/groups/example/-/iterations/34",
+              ]
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/iterations')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->iterations(1));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetPackages(): void
     {
         $expectedArray = [

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -683,19 +683,19 @@ class GroupsTest extends TestCase
     {
         $expectedArray = [
             [
-                "id" => 5,
-                "iid" => 2,
-                "sequence" => 1,
-                "group_id" => 123,
-                "title" => "2022: Sprint 1",
-                "description" => "",
-                "state" => 3,
-                "created_at" => "2021-09-29T21:24:43.913Z",
-                "updated_at" => "2022-03-29T19:09:08.368Z",
-                "start_date" => "2022-01-10",
-                "due_date" => "2022-01-23",
-                "web_url" => "https://example.com/groups/example/-/iterations/34",
-              ]
+                'id' => 5,
+                'iid' => 2,
+                'sequence' => 1,
+                'group_id' => 123,
+                'title' => '2022: Sprint 1',
+                'description' => '',
+                'state' => 3,
+                'created_at' => '2021-09-29T21:24:43.913Z',
+                'updated_at' => '2022-03-29T19:09:08.368Z',
+                'start_date' => '2022-01-10',
+                'due_date' => '2022-01-23',
+                'web_url' => 'https://example.com/groups/example/-/iterations/34',
+            ],
         ];
 
         $api = $this->getApiMock();

--- a/tests/Api/IssuesTest.php
+++ b/tests/Api/IssuesTest.php
@@ -91,11 +91,11 @@ class IssuesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('groups/1/issues', ['order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'opened'])
+            ->with('groups/1/issues', ['order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'opened', 'iteration_title' => 'Title', 'assignee_id' => 1])
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->group(1, ['order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'opened']));
+        $this->assertEquals($expectedArray, $api->group(1, ['order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'opened', 'iteration_title' => 'Title', 'assignee_id' => 1]));
     }
 
     /**
@@ -131,11 +131,11 @@ class IssuesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/issues', ['order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'opened'])
+            ->with('projects/1/issues', ['order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'opened', 'iteration_id' => 1, 'assignee_id' => 2])
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->all(1, ['order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'opened']));
+        $this->assertEquals($expectedArray, $api->all(1, ['order_by' => 'created_at', 'sort' => 'desc', 'labels' => 'foo,bar', 'state' => 'opened', 'iteration_id' => 1, 'assignee_id' => 2]));
     }
 
     /**

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -680,19 +680,19 @@ class ProjectsTest extends TestCase
     {
         $expectedArray = [
             [
-                "id" => 5,
-                "iid" => 2,
-                "sequence" => 1,
-                "group_id" => 123,
-                "title" => "2022: Sprint 1",
-                "description" => "",
-                "state" => 3,
-                "created_at" => "2021-09-29T21:24:43.913Z",
-                "updated_at" => "2022-03-29T19:09:08.368Z",
-                "start_date" => "2022-01-10",
-                "due_date" => "2022-01-23",
-                "web_url" => "https://example.com/groups/example/-/iterations/34",
-              ]
+                'id' => 5,
+                'iid' => 2,
+                'sequence' => 1,
+                'group_id' => 123,
+                'title' => '2022: Sprint 1',
+                'description' => '',
+                'state' => 3,
+                'created_at' => '2021-09-29T21:24:43.913Z',
+                'updated_at' => '2022-03-29T19:09:08.368Z',
+                'start_date' => '2022-01-10',
+                'due_date' => '2022-01-23',
+                'web_url' => 'https://example.com/groups/example/-/iterations/34',
+            ],
         ];
 
         $api = $this->getApiMock();

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -676,6 +676,38 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetIterations(): void
+    {
+        $expectedArray = [
+            [
+                "id" => 5,
+                "iid" => 2,
+                "sequence" => 1,
+                "group_id" => 123,
+                "title" => "2022: Sprint 1",
+                "description" => "",
+                "state" => 3,
+                "created_at" => "2021-09-29T21:24:43.913Z",
+                "updated_at" => "2022-03-29T19:09:08.368Z",
+                "start_date" => "2022-01-10",
+                "due_date" => "2022-01-23",
+                "web_url" => "https://example.com/groups/example/-/iterations/34",
+              ]
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/iterations')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->iterations(1));
+    }
+
+    /**
+     * @test
+     */
     public function shouldCreateTrigger(): void
     {
         $expectedArray = [


### PR DESCRIPTION
add support for [groups iterations](https://docs.gitlab.com/ee/api/group_iterations.html) and [project iterations](https://docs.gitlab.com/ee/api/iterations.html)