### PR TITLE
[11.9] Add support for `Projects::pipelineTestReport` & `Projects::pipelineTestReportSummary`

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -420,6 +420,17 @@ class Projects extends AbstractApi
 
     /**
      * @param int|string $project_id
+     * @param int        $pipeline_id
+     *
+     * @return mixed
+     */
+    public function pipelineTestReport($project_id, int $pipeline_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'pipelines/'.self::encodePath($pipeline_id).'/test_report'));
+    }
+
+    /**
+     * @param int|string $project_id
      * @param string     $commit_ref
      * @param array|null $variables  {
      *

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -431,6 +431,17 @@ class Projects extends AbstractApi
 
     /**
      * @param int|string $project_id
+     * @param int        $pipeline_id
+     *
+     * @return mixed
+     */
+    public function pipelineTestReportSummary($project_id, int $pipeline_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'pipelines/'.self::encodePath($pipeline_id).'/test_report_summary'));
+    }
+
+    /**
+     * @param int|string $project_id
      * @param string     $commit_ref
      * @param array|null $variables  {
      *

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -850,6 +850,30 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetPipelineTestReport(): void
+    {
+        $expectedArray = [
+            'total_time' => 0.011809,
+            'total_count' => 8,
+            'success_count' => 8,
+            'failed_count' => 0,
+            'skipped_count' => 0,
+            'error_count' => 0,
+            'test_suites' => [],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/pipelines/3/test_report')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->pipelineTestReport(1, 3));
+    }
+
+    /**
+     * @test
+     */
     public function shouldCreatePipeline(): void
     {
         $expectedArray = [

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -874,6 +874,30 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetPipelineTestReportSummary(): void
+    {
+        $expectedArray = [
+            'total_time' => 0.011809,
+            'total_count' => 8,
+            'success_count' => 8,
+            'failed_count' => 0,
+            'skipped_count' => 0,
+            'error_count' => 0,
+            'test_suites' => [],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/pipelines/3/test_report_summary')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->pipelineTestReportSummary(1, 3));
+    }
+
+    /**
+     * @test
+     */
     public function shouldCreatePipeline(): void
     {
         $expectedArray = [


### PR DESCRIPTION
Add support for:
* https://docs.gitlab.com/ee/api/pipelines.html#get-a-pipelines-test-report
* https://docs.gitlab.com/ee/api/pipelines.html#get-a-pipelines-test-report-summary