### PR TITLE
[11.9] Add optional parameter "access_level" to create project access token

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1345,6 +1345,11 @@ class Projects extends AbstractApi
             })
         ;
 
+        $resolver->setDefined('access_level')
+            ->setAllowedTypes('access_level', 'int')
+            ->setAllowedValues('access_level', [10, 20, 30, 40])
+        ;
+
         $resolver->setDefined('expires_at')
             ->setAllowedTypes('expires_at', \DateTimeInterface::class)
             ->setNormalizer('expires_at', $datetimeNormalizer)

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1347,7 +1347,7 @@ class Projects extends AbstractApi
 
         $resolver->setDefined('access_level')
             ->setAllowedTypes('access_level', 'int')
-            ->setAllowedValues('access_level', [10, 20, 30, 40])
+            ->setAllowedValues('access_level', [10, 20, 30, 40, 50])
         ;
 
         $resolver->setDefined('expires_at')

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1314,7 +1314,7 @@ class Projects extends AbstractApi
      *
      *     @var string $name                    the name of the project access token
      *     @var array  $scopes                  the scopes, one or many of: api, read_api, read_registry, write_registry, read_repository, write_repository
-     *     @var int    $access_level            the access level, one or many of: 10 (Guest), 20 (Reporter), 30 (Developer), 40 (Maintainer), 50 (Owner)
+     *     @var int    $access_level            the access level: 10 (Guest), 20 (Reporter), 30 (Developer), 40 (Maintainer), 50 (Owner)
      *     @var \DateTimeInterface $expires_at  the token expires at midnight UTC on that date
      * }
      *

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1314,6 +1314,7 @@ class Projects extends AbstractApi
      *
      *     @var string $name                    the name of the project access token
      *     @var array  $scopes                  the scopes, one or many of: api, read_api, read_registry, write_registry, read_repository, write_repository
+     *     @var int    $access_level            the access level, one or many of: 10 (Guest), 20 (Reporter), 30 (Developer), 40 (Maintainer), 50 (Owner)
      *     @var \DateTimeInterface $expires_at  the token expires at midnight UTC on that date
      * }
      *

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2480,6 +2480,7 @@ class ProjectsTest extends TestCase
                         'api',
                         'read_repository',
                     ],
+                    'access_level' => 30,
                     'expires_at' => '2021-01-31',
                 ]
             )


### PR DESCRIPTION
Add the `access_level` parameter, as specified in the [documentation](https://docs.gitlab.com/ee/api/project_access_tokens.html#create-a-project-access-token).