### PR TITLE
[11.10] Add ProjectBoard and ProjectBoardList API

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -694,29 +694,69 @@ class Projects extends AbstractApi
     }
 
     /**
+     * Create an issue board
+     *
      * @param int|string $project_id
-     * @param array      $parameters
+     * @param array      $parameters {
+     *      @var string $name    The name of the new board
+     * }
      *
      * @return mixed
      */
     public function addBoard($project_id, array $parameters)
     {
-        return $this->post($this->getProjectPath($project_id, 'boards'), $parameters);
+        $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('name')
+            ->setAllowedTypes('name', 'string')
+            ->setRequired('name')
+        ;
+
+        return $this->post($this->getProjectPath($project_id, 'boards'), $resolver->resolve($parameters));
     }
 
     /**
+     * Update an issue board
+     *
      * @param int|string $project_id
      * @param int        $board_id
-     * @param array      $parameters
+     * @param array      $parameters {
+     *      @var string $name       The name of the new board
+     *      @var int $assignee_id   The assignee the board should be scoped to
+     *      @var int $milestone_id  The milestone the board should be scoped to
+     *      @var string $labels     Comma-separated list of label names which the board should be scoped to
+     *      @var int $weight        The weight range from 0 to 9, to which the board should be scoped to
+     * }
      *
      * @return mixed
      */
     public function updateBoard($project_id, int $board_id, array $parameters)
     {
-        return $this->put($this->getProjectPath($project_id, 'boards/'.self::encodePath($board_id)), $parameters);
+        $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('name')
+            ->setAllowedTypes('name', 'string')
+        ;
+        $resolver->setDefined('assignee_id')
+            ->setAllowedTypes('assignee_id', 'int')
+        ;
+        $resolver->setDefined('milestone_id')
+            ->setAllowedTypes('milestone_id', 'int')
+        ;
+        $resolver->setDefined('labels')
+            ->setAllowedTypes('labels', 'string')
+        ;
+        $resolver->setDefined('weight')
+            ->setAllowedTypes('weight', 'int')
+        ;
+
+        return $this->put(
+            $this->getProjectPath($project_id, 'boards/'.self::encodePath($board_id)),
+            $resolver->resolve($parameters)
+        );
     }
 
     /**
+     * Delete an issue board
+     *
      * @param int|string $project_id
      * @param int        $board_id
      *
@@ -743,18 +783,42 @@ class Projects extends AbstractApi
     }
 
     /**
+     * Create a board list
+     *
+     * See https://docs.gitlab.com/ee/api/boards.html#create-a-board-list for more info.
+     *
      * @param int|string $project_id
-     * @param int|string $board_id
-     * @param array      $parameters
+     * @param int        $board_id
+     * @param array      $parameters {
+     *      @var int $label_id      The ID of a label
+     *      @var int $assignee_id   The ID of a user
+     *      @var int $milestone_id  The ID of a milestone
+     * }
      *
      * @return mixed
      */
-    public function addBoardList($project_id, $board_id, array $parameters)
+    public function addBoardList($project_id, int $board_id, array $parameters)
     {
+        $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('label_id')
+            ->setAllowedTypes('label_id', 'int')
+        ;
+        $resolver->setDefined('assignee_id')
+            ->setAllowedTypes('assignee_id', 'int')
+        ;
+        $resolver->setDefined('milestone_id')
+            ->setAllowedTypes('milestone_id', 'int')
+        ;
+
         return $this->post($this->getProjectPath($project_id, 'boards/'.self::encodePath($board_id).'/lists'), $parameters);
     }
 
     /**
+     * Reorder a list in a board
+     * Updates an existing issue board list. This call is used to change list position.
+     *
+     * See https://docs.gitlab.com/ee/api/boards.html#reorder-a-list-in-a-board for more info.
+     *
      * @param int|string $project_id
      * @param int        $board_id
      * @param int        $list_id
@@ -771,6 +835,11 @@ class Projects extends AbstractApi
     }
 
     /**
+     * Delete a board list from a board
+     * Only for administrators and project owners. Deletes a board list.
+     *
+     * See https://docs.gitlab.com/ee/api/boards.html#delete-a-board-list-from-a-board for more info.
+     *
      * @param int|string $project_id
      * @param int        $board_id
      * @param int        $list_id

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -695,6 +695,97 @@ class Projects extends AbstractApi
 
     /**
      * @param int|string $project_id
+     * @param array      $parameters
+     *
+     * @return mixed
+     */
+    public function addBoard($project_id, array $parameters)
+    {
+        return $this->post($this->getProjectPath($project_id, 'boards'), $parameters);
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $board_id
+     * @param array      $parameters
+     *
+     * @return mixed
+     */
+    public function updateBoard($project_id, int $board_id, array $parameters)
+    {
+        return $this->put($this->getProjectPath($project_id, 'boards/'.self::encodePath($board_id)), $parameters);
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $board_id
+     *
+     * @return mixed
+     */
+    public function removeBoard($project_id, int $board_id)
+    {
+        return $this->delete($this->getProjectPath($project_id, 'boards/'.self::encodePath($board_id)));
+    }
+
+    /**
+     * Get projects board lists list.
+     *
+     * See https://docs.gitlab.com/ee/api/boards.html#list-board-lists-in-a-project-issue-board for more info.
+     *
+     * @param int|string $project_id
+     * @param int|string $board_id
+     *
+     * @return mixed
+     */
+    public function boardLists($project_id, $board_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'boards/'.self::encodePath($board_id)));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int|string $board_id
+     * @param array      $parameters
+     *
+     * @return mixed
+     */
+    public function addBoardList($project_id, $board_id, array $parameters)
+    {
+        return $this->post($this->getProjectPath($project_id, 'boards/'.self::encodePath($board_id).'/lists'), $parameters);
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $board_id
+     * @param int        $list_id
+     * @param int        $position
+     *
+     * @return mixed
+     */
+    public function reorderBoardList($project_id, int $board_id, int $list_id, int $position)
+    {
+        return $this->put($this->getProjectPath($project_id,
+            'boards/'.self::encodePath($board_id).'/lists/'.self::encodePath($list_id)),
+            ['position' => $position]
+        );
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $board_id
+     * @param int        $list_id
+     *
+     * @return mixed
+     */
+    public function removeBoardList($project_id, int $board_id, int $list_id)
+    {
+        return $this->delete($this->getProjectPath($project_id,
+            'boards/'.self::encodePath($board_id).'/lists/'.self::encodePath($list_id))
+        );
+    }
+
+    /**
+     * @param int|string $project_id
      * @param array      $parameters {
      *
      *     @var string $state               Return opened, upcoming, current (previously started), closed, or all iterations.

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -653,6 +653,97 @@ class Projects extends AbstractApi
     }
 
     /**
+     * @param int|string $project_id
+     * @param array      $parameters
+     *
+     * @return mixed
+     */
+    public function addBoard($project_id, array $parameters)
+    {
+        return $this->post($this->getProjectPath($project_id, 'boards'), $parameters);
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $board_id
+     * @param array      $parameters
+     *
+     * @return mixed
+     */
+    public function updateBoard($project_id, int $board_id, array $parameters)
+    {
+        return $this->put($this->getProjectPath($project_id, 'boards/'.self::encodePath($board_id)), $parameters);
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $board_id
+     *
+     * @return mixed
+     */
+    public function removeBoard($project_id, int $board_id)
+    {
+        return $this->delete($this->getProjectPath($project_id, 'boards/'.self::encodePath($board_id)));
+    }
+
+    /**
+     * Get projects board lists list.
+     *
+     * See https://docs.gitlab.com/ee/api/boards.html#list-board-lists-in-a-project-issue-board for more info.
+     *
+     * @param int|string $project_id
+     * @param int|string $board_id
+     *
+     * @return mixed
+     */
+    public function boardLists($project_id, $board_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'boards/'.self::encodePath($board_id)));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int|string $board_id
+     * @param array      $parameters
+     *
+     * @return mixed
+     */
+    public function addBoardList($project_id, $board_id, array $parameters)
+    {
+        return $this->post($this->getProjectPath($project_id, 'boards/'.self::encodePath($board_id).'/lists'), $parameters);
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $board_id
+     * @param int        $list_id
+     * @param int        $position
+     *
+     * @return mixed
+     */
+    public function reorderBoardList($project_id, int $board_id, int $list_id, int $position)
+    {
+        return $this->put($this->getProjectPath($project_id,
+            'boards/'.self::encodePath($board_id).'/lists/'.self::encodePath($list_id)),
+            ['position' => $position]
+        );
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $board_id
+     * @param int        $list_id
+     *
+     * @return mixed
+     */
+    public function removeBoardList($project_id, int $board_id, int $list_id)
+    {
+        return $this->delete($this->getProjectPath($project_id,
+            'boards/'.self::encodePath($board_id).'/lists/'.self::encodePath($list_id))
+        );
+    }
+
+    /**
      * Gets a list of all discussion items for a single commit.
      *
      * Example:


### PR DESCRIPTION
Added missing API calls regarding project boards:

* addBoard: https://docs.gitlab.com/ee/api/boards.html#create-an-issue-board
* updateBoard: https://docs.gitlab.com/ee/api/boards.html#update-an-issue-board
* removeBoard: https://docs.gitlab.com/ee/api/boards.html#delete-an-issue-board

Also add API calls for board lists:

* boardLists: https://docs.gitlab.com/ee/api/boards.html#list-board-lists-in-a-project-issue-board
* addBoardList: https://docs.gitlab.com/ee/api/boards.html#create-a-board-list
* reorderBoardList: https://docs.gitlab.com/ee/api/boards.html#reorder-a-list-in-a-board
* removeBoardList: https://docs.gitlab.com/ee/api/boards.html#delete-a-board-list-from-a-board