### PR TITLE
[11.9] Add support for `Projects::projectAccessToken`

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1310,6 +1310,17 @@ class Projects extends AbstractApi
 
     /**
      * @param int|string $project_id
+     * @param int|string $token_id
+     *
+     * @return mixed
+     */
+    public function projectAccessToken($project_id, $token_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'access_tokens/'.self::encodePath($token_id)));
+    }
+
+    /**
+     * @param int|string $project_id
      * @param array      $parameters {
      *
      *     @var string $name                    the name of the project access token

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2453,6 +2453,33 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetProjectAccessToken(): void
+    {
+        $expectedArray = [
+            'user_id' => 141,
+            'scopes' => [
+                'api',
+            ],
+            'name' => 'token',
+            'expires_at' => '2021-01-31',
+            'id' => 42,
+            'active' => true,
+            'created_at' => '2021-01-20T22:11:48.151Z',
+            'revoked' => false,
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/access_tokens/42')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->projectAccessToken(1, 42));
+    }
+
+    /**
+     * @test
+     */
     public function shouldCreateProjectAccessToken(): void
     {
         $expectedArray = [


### PR DESCRIPTION
List project access tokens was already possible, but retrieving one project access token by id was not. This adds the endpoint 'Get a project access token' as can be found in the [documentation](https://docs.gitlab.com/ee/api/project_access_tokens.html#get-a-project-access-token)