### PR TITLE
[11.10] Added include_retried option on pipeline jobs API call

### DIFF
--- a/src/Api/Jobs.php
+++ b/src/Api/Jobs.php
@@ -263,6 +263,9 @@ class Jobs extends AbstractApi
             })
         ;
 
+        $resolver->setDefined('include_retried')
+            ->setAllowedTypes('include_retried', ['bool']);
+
         return $resolver;
     }
 }

--- a/tests/Api/JobsTest.php
+++ b/tests/Api/JobsTest.php
@@ -72,7 +72,6 @@ class JobsTest extends TestCase
             ['id' => 1, 'name' => 'A job'],
             ['id' => 2, 'name' => 'Another job'],
             ['id' => 3, 'name' => 'A job'],
-
         ];
 
         $api = $this->getApiMock();

--- a/tests/Api/JobsTest.php
+++ b/tests/Api/JobsTest.php
@@ -66,6 +66,31 @@ class JobsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetPipelineJobsIncludingRetried(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'A job'],
+            ['id' => 2, 'name' => 'Another job'],
+            ['id' => 3, 'name' => 'A job'],
+
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/pipelines/2/jobs', [
+                'scope' => ['pending', 'running'],
+                'include_retried' => true,
+            ])
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->pipelineJobs(1, 2, ['scope' => [Jobs::SCOPE_PENDING, Jobs::SCOPE_RUNNING], 'include_retried' => true]));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetPipelineBridges(): void
     {
         $expectedArray = [


### PR DESCRIPTION
Added include_retried option on pipeline jobs API call.
Introduced with GitLab 13.9 @see https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs