### PR TITLE
[11.10] Add support for `Packages::addGenericFile()`

### DIFF
--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -155,6 +155,28 @@ abstract class AbstractApi
 
     /**
      * @param string               $uri
+     * @param string               $file
+     * @param array<string,string> $headers
+     * @param array<string,mixed>  $uriParams
+     *
+     * @return mixed
+     */
+    protected function putFile(string $uri, string $file, array $headers = [], array $uriParams = [])
+    {
+        $resource = self::tryFopen($file, 'r');
+        $body = $this->client->getStreamFactory()->createStreamFromResource($resource);
+
+        if ($body->isReadable()) {
+            $headers = \array_merge([ResponseMediator::CONTENT_TYPE_HEADER => self::guessFileContentType($file)], $headers);
+        }
+
+        $response = $this->client->getHttpClient()->put(self::prepareUri($uri, $uriParams), $headers, $body);
+
+        return ResponseMediator::getContent($response);
+    }
+
+    /**
+     * @param string               $uri
      * @param array<string,mixed>  $params
      * @param array<string,string> $headers
      *

--- a/src/Api/Packages.php
+++ b/src/Api/Packages.php
@@ -112,6 +112,28 @@ class Packages extends AbstractApi
 
     /**
      * @param int|string $project_id
+     * @param string     $package_name
+     * @param string     $package_version
+     * @param string     $file
+     * @param string     $status
+     *
+     * @return mixed
+     */
+    public function addGenericFile($project_id, string $package_name, string $package_version, string $file, string $status = 'default')
+    {
+        return $this->putFile(
+            $this->getProjectPath(
+                $project_id,
+                'packages/generic/'.self::encodePath($package_name).'/'.self::encodePath($package_version).'/'.self::encodePath(\basename($file))
+            ),
+            $file,
+            [],
+            ['status' => $status]
+        );
+    }
+
+    /**
+     * @param int|string $project_id
      * @param int        $package_id
      *
      * @return string


### PR DESCRIPTION
This an attempt to support the API call to add a generic file
https://docs.gitlab.com/ee/user/packages/generic_packages/index.html

The regular `->put()` call wasn't working because it adds multipart headers around the file and those are not stripped by gitlab. Something like:
```
--63347ec2cd1206.13859581
Content-Type: text/plain
Content-Disposition: form-data; name="executable"; filename="executable"
Content-Length: 11

echo hello

--63347ec2cd1206.13859581--
```
So I had to add the `putFile()` method.

The gitlab api handles multipart forms when you upload an avatar to a project (also a PUT call) but not in this case.

I tested it with a dummy project and so far it works.