### PR TITLE
[11.9] Add support for `Jobs::artifactByJobId`

### DIFF
--- a/src/Api/Jobs.php
+++ b/src/Api/Jobs.php
@@ -176,8 +176,8 @@ class Jobs extends AbstractApi
      *
      * @return StreamInterface
      */
-    public function artifactByJobId($project_id, $job_id, string $artifact_path) {
-
+    public function artifactByJobId($project_id, $job_id, string $artifact_path) 
+    {
         return $this->getAsResponse('projects/'.self::encodePath($project_id).'/jobs/'.self::encodePath($job_id).'/artifacts/'.self::encodePath($artifact_path))->getBody();
 
     }

--- a/src/Api/Jobs.php
+++ b/src/Api/Jobs.php
@@ -179,9 +179,7 @@ class Jobs extends AbstractApi
     public function artifactByJobId($project_id, $job_id, string $artifact_path)
     {
         return $this->getAsResponse('projects/'.self::encodePath($project_id).'/jobs/'.self::encodePath($job_id).'/artifacts/'.self::encodePath($artifact_path))->getBody();
-
     }
-
 
     /**
      * @param int|string $project_id

--- a/src/Api/Jobs.php
+++ b/src/Api/Jobs.php
@@ -172,6 +172,20 @@ class Jobs extends AbstractApi
     /**
      * @param int|string $project_id
      * @param int        $job_id
+     * @param string     $artifact_path
+     *
+     * @return StreamInterface
+     */
+    public function artifactByJobId($project_id, $job_id, string $artifact_path) {
+
+        return $this->getAsResponse('projects/'.self::encodePath($project_id).'/jobs/'.self::encodePath($job_id).'/artifacts/'.self::encodePath($artifact_path))->getBody();
+
+    }
+
+
+    /**
+     * @param int|string $project_id
+     * @param int        $job_id
      *
      * @return mixed
      */

--- a/src/Api/Jobs.php
+++ b/src/Api/Jobs.php
@@ -176,7 +176,7 @@ class Jobs extends AbstractApi
      *
      * @return StreamInterface
      */
-    public function artifactByJobId($project_id, $job_id, string $artifact_path) 
+    public function artifactByJobId($project_id, $job_id, string $artifact_path)
     {
         return $this->getAsResponse('projects/'.self::encodePath($project_id).'/jobs/'.self::encodePath($job_id).'/artifacts/'.self::encodePath($artifact_path))->getBody();
 

--- a/tests/Api/JobsTest.php
+++ b/tests/Api/JobsTest.php
@@ -125,7 +125,6 @@ class JobsTest extends TestCase
     public function shouldGetArtifactsByJobId(): void
     {
         $returnedStream = new Response(200, [], 'foobar');
-// GET /projects/:id/jobs/:job_id/artifacts/*artifact_path
 
         $api = $this->getApiMock();
         $api->expects($this->once())
@@ -134,7 +133,7 @@ class JobsTest extends TestCase
             ->will($this->returnValue($returnedStream))
         ;
 
-        $this->assertEquals('foobar', $api->artifactsByJobId(1, 3, 'artifact_path')->getContents());
+        $this->assertEquals('foobar', $api->artifactByJobId(1, 3, 'artifact_path')->getContents());
     }
 
     /**

--- a/tests/Api/JobsTest.php
+++ b/tests/Api/JobsTest.php
@@ -122,6 +122,24 @@ class JobsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetArtifactsByJobId(): void
+    {
+        $returnedStream = new Response(200, [], 'foobar');
+// GET /projects/:id/jobs/:job_id/artifacts/*artifact_path
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('getAsResponse')
+            ->with('projects/1/jobs/3/artifacts/artifact_path')
+            ->will($this->returnValue($returnedStream))
+        ;
+
+        $this->assertEquals('foobar', $api->artifactsByJobId(1, 3, 'artifact_path')->getContents());
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetArtifactsByRefName(): void
     {
         $returnedStream = new Response(200, [], 'foobar');


### PR DESCRIPTION
I'd like to be able to download an artifact by the jobId, and since  I noticed that wasn't yet available in the code I would add it.. . 

https://docs.gitlab.com/ee/api/job_artifacts.html#download-a-single-artifact-file-by-job-id

Additional code and test added..  