### PR TITLE
[11.9] Add support for `allowed_to_create` in `Projects::addProtectedTag`

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1402,6 +1402,18 @@ class Projects extends AbstractApi
             ->setAllowedTypes('create_access_level', 'int')
             ->setAllowedValues('create_access_level', [0, 30, 40])
         ;
+        $resolver->setDefined('allowed_to_create')
+            ->setAllowedTypes('allowed_to_create', 'array')
+            ->setAllowedValues('allowed_to_create', function (array $value) {
+              $keys = \array_keys((array) \call_user_func_array('array_merge', $value));
+              $diff = \array_diff($keys, array('user_id', 'group_id', 'access_level'));
+              $values = \array_map(function ($item) {
+                return \array_values($item)[0] ?? '';
+              }, $value);
+              $integer = \count($values) === \count(\array_filter($values, 'is_int'));
+              return \count($value) > 0 && \count($diff) === 0 && $integer;
+            })
+        ;
 
         return $this->post($this->getProjectPath($project_id, 'protected_tags'), $resolver->resolve($parameters));
     }

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1411,6 +1411,7 @@ class Projects extends AbstractApi
                     return \array_values($item)[0] ?? '';
                 }, $value);
                 $integer = \count($values) === \count(\array_filter($values, 'is_int'));
+
                 return \count($value) > 0 && 0 === \count($diff) && $integer;
             })
         ;

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1406,12 +1406,12 @@ class Projects extends AbstractApi
             ->setAllowedTypes('allowed_to_create', 'array')
             ->setAllowedValues('allowed_to_create', function (array $value) {
                 $keys = \array_keys((array) \call_user_func_array('array_merge', $value));
-                $diff = \array_diff($keys, array('user_id', 'group_id', 'access_level'));
+                $diff = \array_diff($keys, ['user_id', 'group_id', 'access_level']);
                 $values = \array_map(function ($item) {
                     return \array_values($item)[0] ?? '';
                 }, $value);
                 $integer = \count($values) === \count(\array_filter($values, 'is_int'));
-                return \count($value) > 0 && \count($diff) === 0 && $integer;
+                return \count($value) > 0 && 0 === \count($diff) && $integer;
             })
         ;
 

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1405,13 +1405,13 @@ class Projects extends AbstractApi
         $resolver->setDefined('allowed_to_create')
             ->setAllowedTypes('allowed_to_create', 'array')
             ->setAllowedValues('allowed_to_create', function (array $value) {
-              $keys = \array_keys((array) \call_user_func_array('array_merge', $value));
-              $diff = \array_diff($keys, array('user_id', 'group_id', 'access_level'));
-              $values = \array_map(function ($item) {
-                return \array_values($item)[0] ?? '';
-              }, $value);
-              $integer = \count($values) === \count(\array_filter($values, 'is_int'));
-              return \count($value) > 0 && \count($diff) === 0 && $integer;
+                $keys = \array_keys((array) \call_user_func_array('array_merge', $value));
+                $diff = \array_diff($keys, array('user_id', 'group_id', 'access_level'));
+                $values = \array_map(function ($item) {
+                    return \array_values($item)[0] ?? '';
+                }, $value);
+                $integer = \count($values) === \count(\array_filter($values, 'is_int'));
+                return \count($value) > 0 && \count($diff) === 0 && $integer;
             })
         ;
 

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2538,19 +2538,21 @@ class ProjectsTest extends TestCase
         $expectedArray = [
             'name' => 'release-*',
             'create_access_level' => [
-                'access_level' => 40,
-                'access_level_description' => 'Maintainers',
+                ['access_level' => 40, 'access_level_description' => 'Maintainers'],
+                ['group_id' => 123]
             ],
         ];
         $api = $this->getApiMock();
+        $params = [
+            'name' => 'release-*',
+            'create_access_level' => 40,
+            'allowed_to_create' => [['group_id' => 123]],
+        ];
         $api->expects($this->once())
             ->method('post')
-            ->with(
-                'projects/1/protected_tags',
-                ['name' => 'release-*', 'create_access_level' => 40]
-            )
+            ->with('projects/1/protected_tags', $params)
             ->will($this->returnValue($expectedArray));
-        $this->assertEquals($expectedArray, $api->addProtectedTag(1, ['name' => 'release-*', 'create_access_level' => 40]));
+        $this->assertEquals($expectedArray, $api->addProtectedTag(1, $params));
     }
 
     /**

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2539,7 +2539,7 @@ class ProjectsTest extends TestCase
             'name' => 'release-*',
             'create_access_level' => [
                 ['access_level' => 40, 'access_level_description' => 'Maintainers'],
-                ['group_id' => 123]
+                ['group_id' => 123],
             ],
         ];
         $api = $this->getApiMock();


### PR DESCRIPTION
According to the documentation, is possible to use "allowed_to_create".
https://docs.gitlab.com/ee/api/protected_tags.html#protect-repository-tags