### PR TITLE
[11.10] Added tags order_by support for version value

### DIFF
--- a/src/Api/Tags.php
+++ b/src/Api/Tags.php
@@ -32,7 +32,7 @@ class Tags extends AbstractApi
     {
         $resolver = $this->createOptionsResolver();
         $resolver->setDefined('order_by')
-            ->setAllowedValues('order_by', ['name', 'updated']);
+            ->setAllowedValues('order_by', ['name', 'updated', 'version']);
         $resolver->setDefined('sort')
             ->setAllowedValues('sort', ['asc', 'desc']);
         $resolver->setDefined('search');

--- a/src/Api/Tags.php
+++ b/src/Api/Tags.php
@@ -20,7 +20,7 @@ class Tags extends AbstractApi
      * @param int|string $project_id
      * @param array      $parameters {
      *
-     *     @var string $order_by Return tags ordered by `name` or `updated` fields. Default is `updated`.
+     *     @var string $order_by Return tags ordered by `name`, `updated` or `version` fields. Default is `updated`.
      *     @var string $sort     Return tags sorted in asc or desc order. Default is desc.
      *     @var string $search   Return list of tags matching the search criteria. You can use `^term` and `term$` to
      *                           find tags that begin and end with term respectively.


### PR DESCRIPTION
added version value for the order_by attribute in GitLab 15.4.
https://gitlab.com/gitlab-org/gitlab/-/merge_requests/95150