### PR TITLE
[11.10] Add support milestone merge requests endpoint

### DIFF
--- a/src/Api/Milestones.php
+++ b/src/Api/Milestones.php
@@ -109,4 +109,15 @@ class Milestones extends AbstractApi
     {
         return $this->get($this->getProjectPath($project_id, 'milestones/'.self::encodePath($milestone_id).'/issues'));
     }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $milestone_id
+     *
+     * @return mixed
+     */
+    public function mergeRequests($project_id, int $milestone_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'milestones/'.self::encodePath($milestone_id).'/merge_requests'));
+    }
 }

--- a/tests/Api/MilestonesTest.php
+++ b/tests/Api/MilestonesTest.php
@@ -126,6 +126,26 @@ class MilestonesTest extends TestCase
         $this->assertEquals($expectedArray, $api->issues(1, 3));
     }
 
+    /**
+     * @test
+     */
+    public function shouldGetMilestonesMergeRequests(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'title' => 'A merge request'],
+            ['id' => 2, 'title' => 'Another merge request'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/milestones/3/merge_requests')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->mergeRequests(1, 3));
+    }
+
     protected function getApiClass()
     {
         return Milestones::class;


### PR DESCRIPTION
This adds support (and test case) for the [milestone merge requests](https://docs.gitlab.com/ee/api/milestones.html#get-all-merge-requests-assigned-to-a-single-milestone) endpoint.