### PR TITLE
[11.10] Add support for `Project::removeTrigger`

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -285,6 +285,17 @@ class Projects extends AbstractApi
 
     /**
      * @param int|string $project_id
+     * @param int        $trigger_id
+     *
+     * @return mixed
+     */
+    public function removeTrigger($project_id, int $trigger_id)
+    {
+        return $this->delete($this->getProjectPath($project_id, 'triggers/'.self::encodePath($trigger_id)));
+    }
+
+    /**
+     * @param int|string $project_id
      * @param string     $ref
      * @param string     $token
      * @param array      $variables

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -729,6 +729,22 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldRemoveTrigger(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/triggers/2')
+            ->will($this->returnValue($expectedBool));
+
+        $this->assertEquals($expectedBool, $api->removeTrigger(1, 2));
+    }
+
+    /**
+     * @test
+     */
     public function shouldTriggerPipeline(): void
     {
         $expectedArray = [


### PR DESCRIPTION
Added support for a trigger removal endpoint.
https://docs.gitlab.com/ee/api/pipeline_triggers.html#remove-a-project-trigger-token