### PR TITLE
[11.11] Add `expires_at` parameter to `Groups::addMember()`

### DIFF
--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -43,7 +43,7 @@ abstract class AbstractApi
      * as defined in the Gitlab::Access module
      * @link https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/access.rb
      *
-     * @var string
+     * @var array
      */
     protected const ACCESS_LEVELS = [0, 10, 20, 30, 40, 50];
 

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -39,6 +39,15 @@ abstract class AbstractApi
     private const URI_PREFIX = '/api/v4/';
 
     /**
+     * The access levels for groups and projects
+     * as defined in the Gitlab::Access module
+     * @link https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/access.rb
+     *
+     * @var string
+     */
+    protected const ACCESS_LEVELS = [0, 10, 20, 30, 40, 50];
+
+    /**
      * The client instance.
      *
      * @var Client

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -40,8 +40,9 @@ abstract class AbstractApi
 
     /**
      * The access levels for groups and projects
-     * as defined in the Gitlab::Access module
-     * @link https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/access.rb
+     * as defined in the Gitlab::Access module.
+     *
+     * @see https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/access.rb
      *
      * @var array
      */

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -208,15 +208,36 @@ class Groups extends AbstractApi
      * @param int|string $group_id
      * @param int        $user_id
      * @param int        $access_level
+     * @param array      $parameters
      *
      * @return mixed
      */
-    public function addMember($group_id, int $user_id, int $access_level)
+    public function addMember($group_id, int $user_id, int $access_level, array $parameters = [])
     {
-        return $this->post('groups/'.self::encodePath($group_id).'/members', [
+        $resolver = $this->createOptionsResolver();
+
+        $dateNormalizer = function (OptionsResolver $optionsResolver, \DateTimeInterface $date): string {
+            return $date->format('Y-m-d');
+        };
+
+        $resolver->setRequired('user_id')
+            ->setAllowedTypes('user_id', 'int');
+
+        $resolver->setRequired('access_level')
+            ->setAllowedTypes('access_level', 'int')
+            ->setAllowedValues('access_level', [0, 10, 20, 30, 40, 50]);
+
+        $resolver->setDefined('expires_at')
+            ->setAllowedTypes('expires_at', \DateTimeInterface::class)
+            ->setNormalizer('expires_at', $dateNormalizer)
+        ;
+
+        $parameters = array_merge([
             'user_id' => $user_id,
             'access_level' => $access_level,
-        ]);
+        ], $parameters);
+
+        return $this->post('groups/'.self::encodePath($group_id).'/members', $resolver->resolve($parameters));
     }
 
     /**

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -228,7 +228,7 @@ class Groups extends AbstractApi
             ->setNormalizer('expires_at', $dateNormalizer)
         ;
 
-        $parameters = array_merge([
+        $parameters = \array_merge([
             'user_id' => $user_id,
             'access_level' => $access_level,
         ], $parameters);

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -225,7 +225,7 @@ class Groups extends AbstractApi
 
         $resolver->setRequired('access_level')
             ->setAllowedTypes('access_level', 'int')
-            ->setAllowedValues('access_level', [0, 10, 20, 30, 40, 50]);
+            ->setAllowedValues('access_level', self::ACCESS_LEVELS);
 
         $resolver->setDefined('expires_at')
             ->setAllowedTypes('expires_at', \DateTimeInterface::class)

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -219,21 +219,17 @@ class Groups extends AbstractApi
         };
 
         $resolver = $this->createOptionsResolver()
-            ->setRequired(['user_id', 'access_level'])
             ->setDefined('expires_at')
-            ->setAllowedTypes('user_id', 'int')
-            ->setAllowedTypes('access_level', 'int')
             ->setAllowedTypes('expires_at', \DateTimeInterface::class)
-            ->setAllowedValues('access_level', self::ACCESS_LEVELS)
             ->setNormalizer('expires_at', $dateNormalizer)
         ;
 
         $parameters = \array_merge([
             'user_id' => $user_id,
             'access_level' => $access_level,
-        ], $parameters);
+        ], $resolver->resolve($parameters));
 
-        return $this->post('groups/'.self::encodePath($group_id).'/members', $resolver->resolve($parameters));
+        return $this->post('groups/'.self::encodePath($group_id).'/members', $parameters);
     }
 
     /**

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -214,21 +214,17 @@ class Groups extends AbstractApi
      */
     public function addMember($group_id, int $user_id, int $access_level, array $parameters = [])
     {
-        $resolver = $this->createOptionsResolver();
-
         $dateNormalizer = function (OptionsResolver $optionsResolver, \DateTimeInterface $date): string {
             return $date->format('Y-m-d');
         };
 
-        $resolver->setRequired('user_id')
-            ->setAllowedTypes('user_id', 'int');
-
-        $resolver->setRequired('access_level')
+        $resolver = $this->createOptionsResolver()
+            ->setRequired(['user_id', 'access_level'])
+            ->setDefined('expires_at')
+            ->setAllowedTypes('user_id', 'int')
             ->setAllowedTypes('access_level', 'int')
-            ->setAllowedValues('access_level', self::ACCESS_LEVELS);
-
-        $resolver->setDefined('expires_at')
             ->setAllowedTypes('expires_at', \DateTimeInterface::class)
+            ->setAllowedValues('access_level', self::ACCESS_LEVELS)
             ->setNormalizer('expires_at', $dateNormalizer)
         ;
 

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1253,7 +1253,7 @@ class Projects extends AbstractApi
 
         $resolver->setRequired('group_access')
             ->setAllowedTypes('group_access', 'int')
-            ->setAllowedValues('group_access', [0, 10, 20, 30, 40, 50]);
+            ->setAllowedValues('group_access', self::ACCESS_LEVELS);
 
         $resolver->setDefined('expires_at')
             ->setAllowedTypes('expires_at', \DateTimeInterface::class)

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -282,16 +282,19 @@ class GroupsTest extends TestCase
      */
     public function shouldAddMember(): void
     {
-        $expectedArray = ['id' => 1, 'name' => 'Matt'];
+        $tomorrow = (new DateTime('tomorrow'));
+        $expectedArray = ['id' => 1, 'name' => 'Matt', 'expires_at' => $tomorrow];
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('groups/1/members', ['user_id' => 2, 'access_level' => 3])
+            ->with('groups/1/members', [
+                'user_id' => 2, 'access_level' => 3, 'expires_at' => $tomorrow->format('Y-m-d')
+            ])
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->addMember(1, 2, 3));
+        $this->assertEquals($expectedArray, $api->addMember(1, 2, 3, ['expires_at' => $tomorrow]));
     }
 
     /**

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -289,7 +289,7 @@ class GroupsTest extends TestCase
         $api->expects($this->once())
             ->method('post')
             ->with('groups/1/members', [
-                'user_id' => 2, 'access_level' => 10, 'expires_at' => $tomorrow->format('Y-m-d')
+                'user_id' => 2, 'access_level' => 10, 'expires_at' => $tomorrow->format('Y-m-d'),
             ])
             ->will($this->returnValue($expectedArray))
         ;

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -289,12 +289,12 @@ class GroupsTest extends TestCase
         $api->expects($this->once())
             ->method('post')
             ->with('groups/1/members', [
-                'user_id' => 2, 'access_level' => 3, 'expires_at' => $tomorrow->format('Y-m-d')
+                'user_id' => 2, 'access_level' => 10, 'expires_at' => $tomorrow->format('Y-m-d')
             ])
             ->will($this->returnValue($expectedArray))
         ;
 
-        $this->assertEquals($expectedArray, $api->addMember(1, 2, 3, ['expires_at' => $tomorrow]));
+        $this->assertEquals($expectedArray, $api->addMember(1, 2, 10, ['expires_at' => $tomorrow]));
     }
 
     /**


### PR DESCRIPTION
Fix: #738 

- [x] Updated test `ShouldaddMember` test
- [x] Moved/Made `ACCESS_LEVELS` const for project/group access levels
- [x] Updated phpdoc
- [x] All tests passing local

Hey, @GrahamCampbell I've added an optional parameter(of array type) to `addMember` method, I'd like to make another pr removing both `$user_id, $acess_level` from the method parameters, instead they will be passed inside the array like we're doing in other places to branch 12.0 once this gets merged

Thanks 😀
