### PR TITLE
[11.10] Add support for `Schedules::takeOwnership` and `Schedules::play`

### DIFF
--- a/src/Api/Schedules.php
+++ b/src/Api/Schedules.php
@@ -113,4 +113,26 @@ class Schedules extends AbstractApi
 
         return $this->delete($this->getProjectPath($project_id, $path));
     }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $schedule_id
+     *
+     * @return mixed
+     */
+    public function takeOwnership($project_id, int $schedule_id)
+    {
+        return $this->post($this->getProjectPath($project_id, 'pipeline_schedules/'.self::encodePath($schedule_id)).'/take_ownership');
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param int        $schedule_id
+     *
+     * @return mixed
+     */
+    public function play($project_id, int $schedule_id)
+    {
+        return $this->post($this->getProjectPath($project_id, 'pipeline_schedules/'.self::encodePath($schedule_id)).'/play');
+    }
 }

--- a/tests/Api/ScheduleTest.php
+++ b/tests/Api/ScheduleTest.php
@@ -202,6 +202,40 @@ class ScheduleTest extends TestCase
         $this->assertEquals($expectedBool, $api->removeVariable(1, 2, 'FOO_BAR'));
     }
 
+    /**
+     * @test
+     */
+    public function shouldTakeOwnership(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/pipeline_schedules/2/take_ownership')
+            ->will($this->returnValue($expectedBool))
+        ;
+
+        $this->assertEquals($expectedBool, $api->takeOwnership(1, 2));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldPlay(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/pipeline_schedules/2/play')
+            ->will($this->returnValue($expectedBool))
+        ;
+
+        $this->assertEquals($expectedBool, $api->play(1, 2));
+    }
+
     protected function getApiClass()
     {
         return Schedules::class;


### PR DESCRIPTION
During using this library, I noticed that these two API calls are not implemented yet. Taking ownership is especially necessary to be able to edit a schedule originally created by another GitLab account.