### PR TITLE
[11.11] Added `include_retried` option on to `Jobs::pipelineBridges`

### DIFF
--- a/src/Api/Jobs.php
+++ b/src/Api/Jobs.php
@@ -263,6 +263,9 @@ class Jobs extends AbstractApi
             })
         ;
 
+        $resolver->setDefined('include_retried')
+            ->setAllowedTypes('include_retried', ['bool']);
+
         return $resolver;
     }
 }

--- a/src/Api/Jobs.php
+++ b/src/Api/Jobs.php
@@ -102,8 +102,9 @@ class Jobs extends AbstractApi
      * @param int        $pipeline_id
      * @param array      $parameters  {
      *
-     *     @var string|string[] $scope The scope of bridge jobs to show, one or array of: created, pending, running, failed,
-     *                                 success, canceled, skipped, manual; showing all jobs if none provided.
+     *     @var string|string[] $scope            The scope of bridge jobs to show, one or array of: created, pending, running, failed,
+     *                                            success, canceled, skipped, manual; showing all jobs if none provided.
+     *     @var bool            $include_retried  Include retried jobs in the response. Defaults to false. Introduced in GitLab 13.9.
      * }
      *
      * @return mixed

--- a/src/Api/Jobs.php
+++ b/src/Api/Jobs.php
@@ -103,7 +103,7 @@ class Jobs extends AbstractApi
      * @param array      $parameters  {
      *
      *     @var string|string[] $scope            The scope of bridge jobs to show, one or array of: created, pending, running, failed,
-     *                                            success, canceled, skipped, manual; showing all jobs if none provided.
+     *                                            success, canceled, skipped, manual; showing all jobs if none provided
      *     @var bool            $include_retried  Include retried jobs in the response. Defaults to false. Introduced in GitLab 13.9.
      * }
      *

--- a/tests/Api/JobsTest.php
+++ b/tests/Api/JobsTest.php
@@ -72,7 +72,6 @@ class JobsTest extends TestCase
             ['id' => 1, 'name' => 'A job'],
             ['id' => 2, 'name' => 'Another job'],
             ['id' => 3, 'name' => 'A job'],
-
         ];
 
         $api = $this->getApiMock();

--- a/tests/Api/JobsTest.php
+++ b/tests/Api/JobsTest.php
@@ -66,6 +66,31 @@ class JobsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetPipelineJobsIncludingRetried(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'A job'],
+            ['id' => 2, 'name' => 'Another job'],
+            ['id' => 3, 'name' => 'A job'],
+
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/pipelines/2/jobs', [
+                'scope' => ['pending', 'running'],
+                'include_retried' => true,
+            ])
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->pipelineJobs(1, 2, ['scope' => [Jobs::SCOPE_PENDING, Jobs::SCOPE_RUNNING], 'include_retried' => true]));
+    }
+
+    /**
+     * @test
+     */
     public function shouldGetPipelineBridges(): void
     {
         $expectedArray = [


### PR DESCRIPTION
Added include_retried option on pipeline jobs API call.
Introduced with GitLab 13.9 https://github.com/see https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs

Same as #716 with added parameter to phpdoc