### PR TITLE
[11.11] Add support for additional parameters in `Projects::forks`

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1052,8 +1052,8 @@ class Projects extends AbstractApi
      *     @var bool               $with_issues_enabled         Limit by enabled issues feature
      *     @var bool               $with_merge_requests_enabled Limit by enabled merge requests feature
      *     @var int                $min_access_level            Limit by current user minimal access level
-     *     @var \DateTimeInterface $updated_before              Limit results to projects last updated before the specified time.
-     *     @var \DateTimeInterface $updated_after               Limit results to projects last updated after the specified time.
+     *     @var \DateTimeInterface $updated_before              limit results to projects last updated before the specified time
+     *     @var \DateTimeInterface $updated_after               limit results to projects last updated after the specified time
      *     @var bool               $with_custom_attributes      Include custom attributes in response
      * }
      *

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1035,13 +1035,17 @@ class Projects extends AbstractApi
 
     /**
      * @param int|string $project_id
-     * @param array      $parameters
+     * @param array      $parameters {
+     *
+     *     @var string $search         Return list of forks matching the search criteria (optional)
+     * }
      *
      * @return mixed
      */
     public function forks($project_id, array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('search');
 
         return $this->get($this->getProjectPath($project_id, 'forks'), $resolver->resolve($parameters));
     }

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -42,8 +42,8 @@ class Projects extends AbstractApi
      *     @var int                $min_access_level            Limit by current user minimal access level
      *     @var int                $id_after                    Limit by project id's greater than the specified id
      *     @var int                $id_before                   Limit by project id's less than the specified id
-     *     @var \DateTimeInterface $last_activity_after         Limit by last_activity after specified time
-     *     @var \DateTimeInterface $last_activity_before        Limit by last_activity before specified time
+     *     @var \DateTimeInterface $last_activity_after         limit by last_activity after specified time
+     *     @var \DateTimeInterface $last_activity_before        limit by last_activity before specified time
      *     @var bool               $repository_checksum_failed  Limit by failed repository checksum calculation
      *     @var string             $repository_storage          Limit by repository storage type
      *     @var bool               $wiki_checksum_failed        Limit by failed wiki checksum calculation

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -285,6 +285,17 @@ class Projects extends AbstractApi
 
     /**
      * @param int|string $project_id
+     * @param int        $trigger_id
+     *
+     * @return mixed
+     */
+    public function removeTrigger($project_id, int $trigger_id)
+    {
+        return $this->delete($this->getProjectPath($project_id, 'triggers/'.self::encodePath($trigger_id)));
+    }
+
+    /**
+     * @param int|string $project_id
      * @param string     $ref
      * @param string     $token
      * @param array      $variables
@@ -383,23 +394,8 @@ class Projects extends AbstractApi
             ->setAllowedValues('sort', ['asc', 'desc'])
         ;
         $resolver->setDefined('source')
-            ->setAllowedValues('source', [
-                'push',
-                'web',
-                'trigger',
-                'schedule',
-                'api',
-                'external',
-                'pipeline',
-                'chat',
-                'webide',
-                'merge_request_event',
-                'external_pull_request_event',
-                'parent_pipeline',
-                'ondemand_dast_scan',
-                'ondemand_dast_validation',
-            ]
-        );
+            ->setAllowedValues('source', ['push', 'web', 'trigger', 'schedule', 'api', 'external', 'pipeline', 'chat', 'webide', 'merge_request_event', 'external_pull_request_event', 'parent_pipeline', 'ondemand_dast_scan', 'ondemand_dast_validation'])
+        ;
 
         return $this->get($this->getProjectPath($project_id, 'pipelines'), $resolver->resolve($parameters));
     }
@@ -586,32 +582,44 @@ class Projects extends AbstractApi
     }
 
     /**
-     * @param int|string $project_id
-     * @param int        $user_id
-     * @param int        $access_level
+     * @param int|string  $project_id
+     * @param int         $user_id
+     * @param int         $access_level
+     * @param string|null $expires_at
      *
      * @return mixed
      */
-    public function addMember($project_id, int $user_id, int $access_level)
+    public function addMember($project_id, int $user_id, int $access_level, string $expires_at = null)
     {
-        return $this->post($this->getProjectPath($project_id, 'members'), [
+        $params = [
             'user_id' => $user_id,
             'access_level' => $access_level,
-        ]);
+        ];
+        if (null !== $expires_at) {
+            $params['expires_at'] = $expires_at;
+        }
+
+        return $this->post($this->getProjectPath($project_id, 'members'), $params);
     }
 
     /**
-     * @param int|string $project_id
-     * @param int        $user_id
-     * @param int        $access_level
+     * @param int|string  $project_id
+     * @param int         $user_id
+     * @param int         $access_level
+     * @param string|null $expires_at
      *
      * @return mixed
      */
-    public function saveMember($project_id, int $user_id, int $access_level)
+    public function saveMember($project_id, int $user_id, int $access_level, string $expires_at = null)
     {
-        return $this->put($this->getProjectPath($project_id, 'members/'.self::encodePath($user_id)), [
+        $params = [
             'access_level' => $access_level,
-        ]);
+        ];
+        if (null !== $expires_at) {
+            $params['expires_at'] = $expires_at;
+        }
+
+        return $this->put($this->getProjectPath($project_id, 'members/'.self::encodePath($user_id)), $params);
     }
 
     /**
@@ -1309,7 +1317,7 @@ class Projects extends AbstractApi
      */
     public function uploadAvatar($project_id, string $file)
     {
-        return $this->put($this->getProjectPath($project_id, ''), [], [], ['avatar' => $file]);
+        return $this->put('projects/'.self::encodePath($project_id), [], [], ['avatar' => $file]);
     }
 
     /**
@@ -1555,6 +1563,7 @@ class Projects extends AbstractApi
      *
      *     @var string $name                    the name of the project access token
      *     @var array  $scopes                  the scopes, one or many of: api, read_api, read_registry, write_registry, read_repository, write_repository
+     *     @var int    $access_level            the access level: 10 (Guest), 20 (Reporter), 30 (Developer), 40 (Maintainer), 50 (Owner)
      *     @var \DateTimeInterface $expires_at  the token expires at midnight UTC on that date
      * }
      *
@@ -1584,6 +1593,11 @@ class Projects extends AbstractApi
 
                 return true;
             })
+        ;
+
+        $resolver->setDefined('access_level')
+            ->setAllowedTypes('access_level', 'int')
+            ->setAllowedValues('access_level', [10, 20, 30, 40, 50])
         ;
 
         $resolver->setDefined('expires_at')

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -42,8 +42,8 @@ class Projects extends AbstractApi
      *     @var int                $min_access_level            Limit by current user minimal access level
      *     @var int                $id_after                    Limit by project id's greater than the specified id
      *     @var int                $id_before                   Limit by project id's less than the specified id
-     *     @var \DateTimeInterface $last_activity_after         limit by last_activity after specified time
-     *     @var \DateTimeInterface $last_activity_before        limit by last_activity before specified time
+     *     @var \DateTimeInterface $last_activity_after         Limit by last_activity after specified time
+     *     @var \DateTimeInterface $last_activity_before        Limit by last_activity before specified time
      *     @var bool               $repository_checksum_failed  Limit by failed repository checksum calculation
      *     @var string             $repository_storage          Limit by repository storage type
      *     @var bool               $wiki_checksum_failed        Limit by failed wiki checksum calculation

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -1982,22 +1982,22 @@ class ProjectsTest extends TestCase
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->forks(1, [
-            'archived' => FALSE,
+            'archived' => false,
             'visibility' => 'public',
             'order_by' => 'id',
             'sort' => 'asc',
             'search' => 'term',
-            'simple' => TRUE,
-            'owned' => FALSE,
-            'membership' => FALSE,
-            'starred' => FALSE,
-            'statistics' => FALSE,
-            'with_issues_enabled' => FALSE,
-            'with_merge_requests_enabled' => FALSE,
+            'simple' => true,
+            'owned' => false,
+            'membership' => false,
+            'starred' => false,
+            'statistics' => false,
+            'with_issues_enabled' => false,
+            'with_merge_requests_enabled' => false,
             'min_access_level' => 30,
             'updated_after' => $updated_after,
             'updated_before' => $updated_before,
-            'with_custom_attributes' => TRUE,
+            'with_custom_attributes' => true,
         ]));
     }
 

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -1958,7 +1958,30 @@ class ProjectsTest extends TestCase
         $updated_after = new \DateTime('2018-01-01 00:00:00');
         $updated_before = new \DateTime('2018-01-31 00:00:00');
 
-        $params = [
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/forks', [
+                'archived' => 'false',
+                'visibility' => 'public',
+                'order_by' => 'id',
+                'sort' => 'asc',
+                'search' => 'term',
+                'simple' => 'true',
+                'owned' => 'false',
+                'membership' => 'false',
+                'starred' => 'false',
+                'statistics' => 'false',
+                'with_issues_enabled' => 'false',
+                'with_merge_requests_enabled' => 'false',
+                'min_access_level' => 30,
+                'updated_after' => $updated_after->format('c'),
+                'updated_before' => $updated_before->format('c'),
+                'with_custom_attributes' => 'true',
+            ])
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->forks(1, [
             'archived' => FALSE,
             'visibility' => 'public',
             'order_by' => 'id',
@@ -1975,15 +1998,7 @@ class ProjectsTest extends TestCase
             'updated_after' => $updated_after,
             'updated_before' => $updated_before,
             'with_custom_attributes' => TRUE,
-        ];
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('projects/1/forks', $params)
-            ->will($this->returnValue($expectedArray));
-
-        $this->assertEquals($expectedArray, $api->forks(1, $params));
+        ]));
     }
 
     /**

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -1939,6 +1939,56 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetForksUsingParameters(): void
+    {
+        $expectedArray = [
+            [
+                'id' => 2,
+                'forked_from_project' => [
+                    'id' => 1,
+                ],
+            ],
+            [
+                'id' => 3,
+                'forked_from_project' => [
+                    'id' => 1,
+                ],
+            ],
+        ];
+        $updated_after = new \DateTime('2018-01-01 00:00:00');
+        $updated_before = new \DateTime('2018-01-31 00:00:00');
+
+        $params = [
+            'archived' => FALSE,
+            'visibility' => 'public',
+            'order_by' => 'id',
+            'sort' => 'asc',
+            'search' => 'term',
+            'simple' => TRUE,
+            'owned' => FALSE,
+            'membership' => FALSE,
+            'starred' => FALSE,
+            'statistics' => FALSE,
+            'with_issues_enabled' => FALSE,
+            'with_merge_requests_enabled' => FALSE,
+            'min_access_level' => 30,
+            'updated_after' => $updated_after,
+            'updated_before' => $updated_before,
+            'with_custom_attributes' => TRUE,
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/forks', $params)
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->forks(1, $params));
+    }
+
+    /**
+     * @test
+     */
     public function shouldSetService(): void
     {
         $expectedBool = true;


### PR DESCRIPTION
The `forks` endpoint allows a handy `search` parameter, so define it as an option. 

See the options for forks endpoint: https://docs.gitlab.com/ee/api/projects.html#list-forks-of-a-project

With the following code:
```
      $forks = $gitlab_client->projects()->forks($project, [
        'search' => 'search_term',
      ]);
```

**Currently**: throws exception as parameter is not defined.
**After applying changes**: returns list of forks that match "search_term"