### PR TITLE
[11.11] Add support for additional parameters in `Projects::deployment`

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1238,10 +1238,59 @@ class Projects extends AbstractApi
      * @param array      $parameters
      *
      * @return mixed
+     *
+     * @see https://docs.gitlab.com/ee/api/deployments.html#list-project-deployments
      */
     public function deployments($project_id, array $parameters = [])
     {
         $resolver = $this->createOptionsResolver();
+
+        $resolver->setDefined('order_by')
+            ->setAllowedTypes('order_by', 'string')
+            ->setAllowedValues('order_by', ['id', 'iid', 'created_at', 'updated_at', 'finished_at', 'ref'])
+        ;
+
+        $resolver->setDefined('sort')
+            ->setAllowedTypes('sort', 'string')
+            ->setAllowedValues('sort', ['asc', 'desc'])
+        ;
+
+        $resolver->setDefined('updated_after')
+            ->setAllowedTypes('updated_after', 'string')
+            ->setAllowedValues('updated_after', function ($value): bool {
+                return (bool) \DateTime::createFromFormat(\DateTimeInterface::ISO8601, $value);
+            })
+        ;
+
+        $resolver->setDefined('updated_before')
+            ->setAllowedTypes('updated_before', 'string')
+            ->setAllowedValues('updated_before', function ($value): bool {
+                return (bool) \DateTime::createFromFormat(\DateTimeInterface::ISO8601, $value);
+            })
+        ;
+
+        $resolver->setDefined('finished_after')
+            ->setAllowedTypes('finished_after', 'string')
+            ->setAllowedValues('finished_after', function ($value): bool {
+                return (bool) \DateTime::createFromFormat(\DateTimeInterface::ISO8601, $value);
+            })
+        ;
+
+        $resolver->setDefined('finished_before')
+            ->setAllowedTypes('finished_before', 'string')
+            ->setAllowedValues('finished_before', function ($value): bool {
+                return (bool) \DateTime::createFromFormat(\DateTimeInterface::ISO8601, $value);
+            })
+        ;
+
+        $resolver->setDefined('environment')
+            ->setAllowedTypes('environment', 'string')
+        ;
+
+        $resolver->setDefined('status')
+            ->setAllowedTypes('status', 'string')
+            ->setAllowedValues('status', ['created', 'running', 'success', 'failed', 'canceled', 'blocked'])
+        ;
 
         return $this->get($this->getProjectPath($project_id, 'deployments'), $resolver->resolve($parameters));
     }

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1245,6 +1245,10 @@ class Projects extends AbstractApi
     {
         $resolver = $this->createOptionsResolver();
 
+        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
+            return $value->format('c');
+        };
+
         $resolver->setDefined('order_by')
             ->setAllowedTypes('order_by', 'string')
             ->setAllowedValues('order_by', ['id', 'iid', 'created_at', 'updated_at', 'finished_at', 'ref'])
@@ -1256,31 +1260,23 @@ class Projects extends AbstractApi
         ;
 
         $resolver->setDefined('updated_after')
-            ->setAllowedTypes('updated_after', 'string')
-            ->setAllowedValues('updated_after', function ($value): bool {
-                return (bool) \DateTime::createFromFormat(\DateTimeInterface::ISO8601, $value);
-            })
+            ->setAllowedTypes('updated_after', \DateTimeInterface::class)
+            ->setNormalizer('updated_after', $datetimeNormalizer)
         ;
 
         $resolver->setDefined('updated_before')
-            ->setAllowedTypes('updated_before', 'string')
-            ->setAllowedValues('updated_before', function ($value): bool {
-                return (bool) \DateTime::createFromFormat(\DateTimeInterface::ISO8601, $value);
-            })
+            ->setAllowedTypes('updated_before', \DateTimeInterface::class)
+            ->setNormalizer('updated_before', $datetimeNormalizer)
         ;
 
         $resolver->setDefined('finished_after')
-            ->setAllowedTypes('finished_after', 'string')
-            ->setAllowedValues('finished_after', function ($value): bool {
-                return (bool) \DateTime::createFromFormat(\DateTimeInterface::ISO8601, $value);
-            })
+            ->setAllowedTypes('finished_after', \DateTimeInterface::class)
+            ->setNormalizer('finished_after', $datetimeNormalizer)
         ;
 
         $resolver->setDefined('finished_before')
-            ->setAllowedTypes('finished_before', 'string')
-            ->setAllowedValues('finished_before', function ($value): bool {
-                return (bool) \DateTime::createFromFormat(\DateTimeInterface::ISO8601, $value);
-            })
+            ->setAllowedTypes('finished_before', \DateTimeInterface::class)
+            ->setNormalizer('finished_before', $datetimeNormalizer)
         ;
 
         $resolver->setDefined('environment')

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2355,6 +2355,64 @@ class ProjectsTest extends TestCase
         $this->assertEquals($expectedArray, $api->deployments(1, ['page' => 2, 'per_page' => 15]));
     }
 
+    /**
+     * @test
+     */
+    public function shouldGetDeploymentsSorted(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'sha' => '0000001'],
+            ['id' => 2, 'sha' => '0000002'],
+            ['id' => 3, 'sha' => '0000003'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/deployments', [
+                'order_by' => 'id',
+                'sort' => 'asc',
+            ])
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->deployments(1, ['order_by' => 'id', 'sort' => 'asc']));
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/deployments', [
+                'order_by' => 'id',
+                'sort' => 'desc',
+            ])
+            ->will($this->returnValue(array_reverse($expectedArray)));
+
+        $this->assertEquals(array_reverse($expectedArray), $api->deployments(1, ['order_by' => 'id', 'sort' => 'desc']));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetDeploymentsFiltered(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'sha' => '0000001'],
+            ['id' => 2, 'sha' => '0000002'],
+            ['id' => 3, 'sha' => '0000003'],
+        ];
+
+        $time = new DateTime('now');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/deployments', [
+                'updated_after' => $time->format('c'),
+            ])
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->deployments(1, ['updated_after' => $time]));
+    }
+
     protected function getMultipleProjectsData()
     {
         return [

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2384,9 +2384,9 @@ class ProjectsTest extends TestCase
                 'order_by' => 'id',
                 'sort' => 'desc',
             ])
-            ->will($this->returnValue(array_reverse($expectedArray)));
+            ->will($this->returnValue(\array_reverse($expectedArray)));
 
-        $this->assertEquals(array_reverse($expectedArray), $api->deployments(1, ['order_by' => 'id', 'sort' => 'desc']));
+        $this->assertEquals(\array_reverse($expectedArray), $api->deployments(1, ['order_by' => 'id', 'sort' => 'desc']));
     }
 
     /**


### PR DESCRIPTION
When getting deployments from projects, adding any of the options listed on https://docs.gitlab.com/ee/api/deployments.html#list-project-deployments results in an error like:

```
In OptionsResolver.php line 871: The option "status" does not exist. Defined options are: "page", "per_page". 
```

This adds the missing parameters.