### PR TITLE
[11.11] Add support for `MergeRequests::showParticipants`

### DIFF
--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -381,6 +381,17 @@ class MergeRequests extends AbstractApi
     {
         return $this->delete($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/discussions/'.self::encodePath($discussion_id).'/notes/'.self::encodePath($note_id)));
     }
+    
+    /**
+     * @param int|string $project_id
+     * @param int        $mr_iid
+     *
+     * @return mixed
+     */
+    public function showParticipants($project_id, int $mr_iid)
+    {
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid)).'/participants');
+    }
 
     /**
      * @param int|string $project_id

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -381,7 +381,7 @@ class MergeRequests extends AbstractApi
     {
         return $this->delete($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/discussions/'.self::encodePath($discussion_id).'/notes/'.self::encodePath($note_id)));
     }
-    
+
     /**
      * @param int|string $project_id
      * @param int        $mr_iid

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -349,7 +349,7 @@ class MergeRequestsTest extends TestCase
 
         $this->assertEquals($expectedBool, $api->removeNote(1, 2, 3));
     }
-    
+
     /**
      * @test
      */

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -349,6 +349,40 @@ class MergeRequestsTest extends TestCase
 
         $this->assertEquals($expectedBool, $api->removeNote(1, 2, 3));
     }
+    
+    /**
+     * @test
+     */
+    public function shouldGetMergeRequestParticipants(): void
+    {
+        $expectedArray = [
+            [
+                'id' => 1,
+                'name' => 'John Doe1',
+                'username' => 'user1',
+                'state' => 'active',
+                'avatar_url' => 'http://www.gravatar.com/avatar/c922747a93b40d1ea88262bf1aebee62?s=80&d=identicon',
+                'web_url' => 'http://localhost/user1',
+            ],
+            [
+                'id' => 5,
+                'name' => 'John Doe5',
+                'username' => 'user5',
+                'state' => 'active',
+                'avatar_url' => 'http://www.gravatar.com/avatar/4aea8cf834ed91844a2da4ff7ae6b491?s=80&d=identicon',
+                'web_url' => 'http://localhost/user5',
+            ],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/merge_requests/2/participants')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->showParticipants(1, 2));
+    }
 
     /**
      * @test


### PR DESCRIPTION
The merge_requests endpoint allows to bring participants as seen here https://docs.gitlab.com/ee/api/merge_requests.html#get-single-merge-request-participants