### PR TITLE
[11.12] Passing parameters to removeVariable method

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1203,9 +1203,9 @@ class Projects extends AbstractApi
     /**
      * @param int|string           $project_id
      * @param string               $key
-     * @param array<string, mixed> $parameters {
+     * @param array<string, mixed> $parameters    {
      *
-     *    @var array $filter {
+     *    @var array $filter    {
      *
      *        @var string $environment_scope    Use filter[environment_scope] to select the variable with the matching environment_scope attribute.
      *    }

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1203,13 +1203,18 @@ class Projects extends AbstractApi
     /**
      * @param int|string           $project_id
      * @param string               $key
-     * @param array<string, mixed> $parameters
+     * @param array<string, mixed> $parameters {
+     *     @var string $environment_scope    Use filter[environment_scope] to select the variable with the matching environment_scope attribute.
+     * }
      *
      * @return mixed
      */
     public function removeVariable($project_id, string $key, array $parameters = [])
     {
-        return $this->delete($this->getProjectPath($project_id, 'variables/'.self::encodePath($key)), $parameters);
+        $resolver = new OptionsResolver();
+        $resolver->setDefined('environment_scope')
+            ->setAllowedTypes('environment_scope', 'string')
+        return $this->delete($this->getProjectPath($project_id, 'variables/'.self::encodePath($key)), $resolver->resolve($parameters));
     }
 
     /**

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1215,7 +1215,7 @@ class Projects extends AbstractApi
     {
         $resolver = new OptionsResolver();
         $resolver->setDefined('filter')
-            ->setAllowedTypes('filter', 'array')
+            ->setAllowedTypes('filter', 'array');
         return $this->delete($this->getProjectPath($project_id, 'variables/'.self::encodePath($key)), $resolver->resolve($parameters));
     }
 

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1204,7 +1204,7 @@ class Projects extends AbstractApi
      * @param int|string           $project_id
      * @param string               $key
      * @param array<string, mixed> $parameters
-     * 
+     *
      * @return mixed
      */
     public function removeVariable($project_id, string $key, array $parameters = [])

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1201,8 +1201,8 @@ class Projects extends AbstractApi
     }
 
     /**
-     * @param int|string $project_id
-     * @param string     $key
+     * @param int|string           $project_id
+     * @param string               $key
      * @param array<string, mixed> $parameters
      * 
      * @return mixed

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1204,7 +1204,9 @@ class Projects extends AbstractApi
      * @param int|string           $project_id
      * @param string               $key
      * @param array<string, mixed> $parameters {
+     *
      *    @var array $filter {
+     *
      *        @var string $environment_scope    Use filter[environment_scope] to select the variable with the matching environment_scope attribute.
      *    }
      * }

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1204,7 +1204,9 @@ class Projects extends AbstractApi
      * @param int|string           $project_id
      * @param string               $key
      * @param array<string, mixed> $parameters {
-     *     @var string $environment_scope    Use filter[environment_scope] to select the variable with the matching environment_scope attribute.
+     *    @var array $filter {
+     *        @var string $environment_scope    Use filter[environment_scope] to select the variable with the matching environment_scope attribute.
+     *    }
      * }
      *
      * @return mixed
@@ -1212,8 +1214,8 @@ class Projects extends AbstractApi
     public function removeVariable($project_id, string $key, array $parameters = [])
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefined('environment_scope')
-            ->setAllowedTypes('environment_scope', 'string')
+        $resolver->setDefined('filter')
+            ->setAllowedTypes('filter', 'array')
         return $this->delete($this->getProjectPath($project_id, 'variables/'.self::encodePath($key)), $resolver->resolve($parameters));
     }
 

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1203,12 +1203,13 @@ class Projects extends AbstractApi
     /**
      * @param int|string $project_id
      * @param string     $key
-     *
+     * @param array<string, mixed> $parameters
+     * 
      * @return mixed
      */
-    public function removeVariable($project_id, string $key)
+    public function removeVariable($project_id, string $key, array $parameters = [])
     {
-        return $this->delete($this->getProjectPath($project_id, 'variables/'.self::encodePath($key)));
+        return $this->delete($this->getProjectPath($project_id, 'variables/'.self::encodePath($key)), $parameters);
     }
 
     /**


### PR DESCRIPTION
With this change, it is possible to pass filter to the method https://docs.gitlab.com/ee/api/project_level_variables.html#delete-a-variable. 

This should keep it universal in future, but maybe separate filter parameter would be also possible
