### PR TITLE
[11.11] Add support for `Users::removeUserIdentity`

### DIFF
--- a/src/Api/Users.php
+++ b/src/Api/Users.php
@@ -603,6 +603,6 @@ class Users extends AbstractApi
      */
     public function removeUserIdentity(int $user_id, string $provider)
     {
-        return $this->delete('users/'.self::encodePath($user_id).'/identities/'.$provider);
+        return $this->delete('users/'.self::encodePath($user_id).'/identities/'.self::encodePath($provider));
     }
 }

--- a/src/Api/Users.php
+++ b/src/Api/Users.php
@@ -592,4 +592,15 @@ class Users extends AbstractApi
 
         return $this->get('users/'.self::encodePath($user_id).'/events', $resolver->resolve($parameters));
     }
+
+    /**
+     * Deletes a user’s authentication identity using the provider name associated with that identity
+     * @param int $user_id
+     * @param string $provider
+     * @return mixed
+     */
+    public function removeUserIdentity(int $user_id, string $provider)
+    {
+        return $this->delete('users/'.self::encodePath($user_id).'/identities/'.$provider);
+    }
 }

--- a/src/Api/Users.php
+++ b/src/Api/Users.php
@@ -596,8 +596,9 @@ class Users extends AbstractApi
     /**
      * Deletes a user’s authentication identity using the provider name associated with that identity.
      *
-     * @param int $user_id
+     * @param int    $user_id
      * @param string $provider
+     *
      * @return mixed
      */
     public function removeUserIdentity(int $user_id, string $provider)

--- a/src/Api/Users.php
+++ b/src/Api/Users.php
@@ -594,7 +594,8 @@ class Users extends AbstractApi
     }
 
     /**
-     * Deletes a user’s authentication identity using the provider name associated with that identity
+     * Deletes a user’s authentication identity using the provider name associated with that identity.
+     *
      * @param int $user_id
      * @param string $provider
      * @return mixed

--- a/tests/Api/UsersTest.php
+++ b/tests/Api/UsersTest.php
@@ -980,4 +980,22 @@ class UsersTest extends TestCase
 
         $this->assertEquals($expectedArray, $api->events(1, ['page' => 2, 'per_page' => 15]));
     }
+
+    /**
+     * @test
+     */
+    public function getRemoveUserIdentity(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'identities' => []],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('users/1/identities/test')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->removeUserIdentity(1, 'test'));
+    }
 }


### PR DESCRIPTION
Add missing API to remove an external Identity mapping from a user

https://docs.gitlab.com/ee/api/users.html#delete-authentication-identity-from-user