### PR TITLE
[11.12] Add support for `filter` in `Projects::variable`

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1214,15 +1214,13 @@ class Projects extends AbstractApi
     /**
      * @param int|string $project_id
      * @param string     $key
-	 * @param array      $parameters
+     * @param array      $parameters
      *
      * @return mixed
      */
     public function variable($project_id, string $key, array $parameters = [])
     {
-		$resolver = $this->createOptionsResolver();
-
-		$resolver = $this->createOptionsResolver();
+        $resolver = $this->createOptionsResolver();
         $resolver->setDefined('filter')
             ->setAllowedTypes('filter', 'array');
 

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1214,12 +1214,19 @@ class Projects extends AbstractApi
     /**
      * @param int|string $project_id
      * @param string     $key
+	 * @param array      $parameters
      *
      * @return mixed
      */
-    public function variable($project_id, string $key)
+    public function variable($project_id, string $key, array $parameters = [])
     {
-        return $this->get($this->getProjectPath($project_id, 'variables/'.self::encodePath($key)));
+		$resolver = $this->createOptionsResolver();
+
+		$resolver = $this->createOptionsResolver();
+        $resolver->setDefined('filter')
+            ->setAllowedTypes('filter', 'array');
+
+        return $this->get($this->getProjectPath($project_id, 'variables/'.self::encodePath($key)), $resolver->resolve($parameters));
     }
 
     /**


### PR DESCRIPTION
This PR implements the option to add a filter[environment_scope] 
to a variable request, when multiple variables
with the same name exist, but have different
environment scopes.

See documentation for more information
https://docs.gitlab.com/ee/api/project_level_variables.html#get-a-single-variable

Example on how to use
```php
$client->projects()->variable(
    $project_id,
    'host',
    [
        'filter' => [
            'environment_scope' => 'production'
        ]
    ]
);

return $variable;
```