### PR TITLE
[11.11] Fix double encoding of job name in artifacts download

### DIFF
--- a/src/Api/Jobs.php
+++ b/src/Api/Jobs.php
@@ -151,7 +151,7 @@ class Jobs extends AbstractApi
     public function artifactsByRefName($project_id, string $ref_name, string $job_name)
     {
         return $this->getAsResponse('projects/'.self::encodePath($project_id).'/jobs/artifacts/'.self::encodePath($ref_name).'/download', [
-            'job' => self::encodePath($job_name),
+            'job' => $job_name,
         ])->getBody();
     }
 
@@ -166,7 +166,7 @@ class Jobs extends AbstractApi
     public function artifactByRefName($project_id, string $ref_name, string $job_name, string $artifact_path)
     {
         return $this->getAsResponse('projects/'.self::encodePath($project_id).'/jobs/artifacts/'.self::encodePath($ref_name).'/raw/'.self::encodePath($artifact_path), [
-            'job' => self::encodePath($job_name),
+            'job' => $job_name,
         ])->getBody();
     }
 

--- a/tests/Api/JobsTest.php
+++ b/tests/Api/JobsTest.php
@@ -171,12 +171,12 @@ class JobsTest extends TestCase
         $api->expects($this->once())
             ->method('getAsResponse')
             ->with('projects/1/jobs/artifacts/master/download', [
-                'job' => 'job_name',
+                'job' => 'job name',
             ])
             ->will($this->returnValue($returnedStream))
         ;
 
-        $this->assertEquals('foobar', $api->artifactsByRefName(1, 'master', 'job_name')->getContents());
+        $this->assertEquals('foobar', $api->artifactsByRefName(1, 'master', 'job name')->getContents());
     }
 
     /**
@@ -189,11 +189,11 @@ class JobsTest extends TestCase
         $api->expects($this->once())
             ->method('getAsResponse')
             ->with('projects/1/jobs/artifacts/master/raw/artifact_path', [
-                'job' => 'job_name',
+                'job' => 'job name',
             ])
             ->will($this->returnValue($returnedStream))
         ;
-        $this->assertEquals('foobar', $api->artifactByRefName(1, 'master', 'job_name', 'artifact_path')->getContents());
+        $this->assertEquals('foobar', $api->artifactByRefName(1, 'master', 'job name', 'artifact_path')->getContents());
     }
 
     /**


### PR DESCRIPTION
I found a bug where methods `Jobs::shouldGetArtifactsByRefName` and `Jobs::shouldGetArtifactByRefName` unnecesarily call `self::encodePath()` to encode query parameters, while all the query parameters are later encoded again in `AbstractApi::prepareUri` by call to `QueryStringBuilder::build()`. 

I've corrected those two methods and modified tests acordingly. I have not checked other methods for similar bugs, but I think it is probable it is there.