### PR TITLE
[11.14] Add v4 Releases API

### DIFF
--- a/src/Api/Releases.php
+++ b/src/Api/Releases.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Api;
+
+class Releases extends AbstractApi
+{
+    /**
+     * @param int|string $project_id
+     * @param array $parameters {
+     *
+     * @return mixed
+     * @var string $sort Return tags sorted in asc or desc order. Default is desc.
+     * @var string $search Return list of tags matching the search criteria. You can use `^term` and `term$` to
+     *                           find tags that begin and end with term respectively.
+     * }
+     *
+     * @var string $order_by Return tags ordered by `name`, `updated` or `version` fields. Default is `updated`.
+     */
+    public function all($project_id, array $parameters = [])
+    {
+        $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('order_by')
+            ->setAllowedValues('order_by', ['name', 'updated', 'version']);
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['asc', 'desc']);
+        $resolver->setDefined('include_html_description')
+            ->setAllowedTypes('include_html_description', 'boolean');
+
+        return $this->get($this->getProjectPath($project_id, 'releases'), $resolver->resolve($parameters));
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param string $tag_name
+     *
+     * @return mixed
+     */
+    public function show($project_id, string $tag_name)
+    {
+        return $this->get($this->getProjectPath($project_id, 'releases/' . self::encodePath($tag_name)));
+    }
+
+    /**
+     * @param int|string $project_id
+     *
+     * @return mixed
+     */
+    public function showLatest($project_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'releases/permalink/latest'));
+
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param array $parametersgit
+     *
+     * @return mixed
+     */
+    public function create($project_id, array $parameters = [])
+    {
+        return $this->post($this->getProjectPath($project_id, 'releases'), $parameters);
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param string $tag_name
+     * @param array $parameters
+     *
+     * @return mixed
+     */
+    public function update($project_id, string $tag_name, array $parameters)
+    {
+        return $this->put($this->getProjectPath($project_id, 'releases/' . self::encodePath($tag_name)), $parameters);
+    }
+
+    /**
+     * @param int|string $project_id
+     * @param string $tag_name
+     *
+     * @return mixed
+     */
+    public function remove($project_id, string $tag_name)
+    {
+        return $this->delete($this->getProjectPath($project_id, 'releases' . self::encodePath($tag_name)));
+    }
+}

--- a/src/Api/Releases.php
+++ b/src/Api/Releases.php
@@ -21,11 +21,9 @@ class Releases extends AbstractApi
      * @param array $parameters {
      *
      * @return mixed
-     * @var string $sort Return tags sorted in asc or desc order. Default is desc.
-     * @var string $search Return list of tags matching the search criteria. You can use `^term` and `term$` to
-     *                           find tags that begin and end with term respectively.
-     * }
      *
+     * @var string $sort Return releases sorted in asc or desc order. Default is desc.
+     * }
      * @var string $order_by Return tags ordered by `name`, `updated` or `version` fields. Default is `updated`.
      */
     public function all($project_id, array $parameters = [])
@@ -49,7 +47,7 @@ class Releases extends AbstractApi
      */
     public function show($project_id, string $tag_name)
     {
-        return $this->get($this->getProjectPath($project_id, 'releases/' . self::encodePath($tag_name)));
+        return $this->get($this->getProjectPath($project_id, 'releases/'.self::encodePath($tag_name)));
     }
 
     /**
@@ -60,7 +58,6 @@ class Releases extends AbstractApi
     public function showLatest($project_id)
     {
         return $this->get($this->getProjectPath($project_id, 'releases/permalink/latest'));
-
     }
 
     /**
@@ -83,7 +80,7 @@ class Releases extends AbstractApi
      */
     public function update($project_id, string $tag_name, array $parameters)
     {
-        return $this->put($this->getProjectPath($project_id, 'releases/' . self::encodePath($tag_name)), $parameters);
+        return $this->put($this->getProjectPath($project_id, 'releases/'.self::encodePath($tag_name)), $parameters);
     }
 
     /**
@@ -94,6 +91,6 @@ class Releases extends AbstractApi
      */
     public function remove($project_id, string $tag_name)
     {
-        return $this->delete($this->getProjectPath($project_id, 'releases' . self::encodePath($tag_name)));
+        return $this->delete($this->getProjectPath($project_id, 'releases/'.self::encodePath($tag_name)));
     }
 }

--- a/src/Api/Tags.php
+++ b/src/Api/Tags.php
@@ -77,6 +77,7 @@ class Tags extends AbstractApi
      * @param int|string $project_id
      * @param string     $tag_name
      * @param array      $params
+     * @deprecated
      *
      * @return mixed
      */
@@ -89,6 +90,7 @@ class Tags extends AbstractApi
      * @param int|string $project_id
      * @param string     $tag_name
      * @param array      $params
+     * @deprecated
      *
      * @return mixed
      */

--- a/src/Api/Tags.php
+++ b/src/Api/Tags.php
@@ -77,6 +77,7 @@ class Tags extends AbstractApi
      * @param int|string $project_id
      * @param string     $tag_name
      * @param array      $params
+     *
      * @deprecated
      *
      * @return mixed
@@ -90,6 +91,7 @@ class Tags extends AbstractApi
      * @param int|string $project_id
      * @param string     $tag_name
      * @param array      $params
+     *
      * @deprecated
      *
      * @return mixed

--- a/tests/Api/ReleasesTest.php
+++ b/tests/Api/ReleasesTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Gitlab\Tests\Api;
+namespace Tests\Gitlab\Api;
 
 use Gitlab\Api\Releases;
 
@@ -32,7 +32,7 @@ class ReleasesTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with('projects/1/releases')
-            ->will($this->returnValue($expectedArray));
+            ->willReturn($expectedArray);
         $this->assertEquals($expectedArray, $api->all(1));
     }
 
@@ -49,10 +49,9 @@ class ReleasesTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with('projects/1/releases/v1.0.0')
-            ->will($this->returnValue($expectedArray));
+            ->willReturn($expectedArray);
         $this->assertEquals($expectedArray, $api->show(1, 'v1.0.0'));
     }
-
 
     /**
      * @test
@@ -66,16 +65,17 @@ class ReleasesTest extends TestCase
     public function shouldCreateRelease(string $releaseName, string $description, array $expectedResult): void
     {
         $params = [
+            'name' => $releaseName,
             'description' => $description,
         ];
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('projects/1/releases/'. $releaseName, $params)
-            ->will($this->returnValue($expectedResult));
+            ->with('projects/1/releases', $params)
+            ->willReturn($expectedResult);
 
-        $this->assertEquals($expectedResult, $api->createRelease(1, $releaseName, $params));
+        $this->assertEquals($expectedResult, $api->create(1, $params));
     }
 
     /**
@@ -91,10 +91,9 @@ class ReleasesTest extends TestCase
         $api->expects($this->once())
             ->method('delete')
             ->with('projects/1/releases/v1.1.0')
-            ->will($this->returnValue($expectedArray));
+            ->willReturn($expectedArray);
         $this->assertEquals($expectedArray, $api->remove(1, 'v1.1.0'));
     }
-
 
     /**
      * @test
@@ -114,10 +113,10 @@ class ReleasesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('projects/1/releases/'. $releaseName, $params)
-            ->will($this->returnValue($expectedResult));
+            ->with('projects/1/releases/'.\str_replace('/', '%2F', $releaseName), $params)
+            ->willReturn($expectedResult);
 
-        $this->assertEquals($expectedResult, $api->updateRelease(1, $releaseName, $params));
+        $this->assertEquals($expectedResult, $api->update(1, $releaseName, $params));
     }
 
     public static function releaseDataProvider(): array

--- a/tests/Api/ReleasesTest.php
+++ b/tests/Api/ReleasesTest.php
@@ -14,24 +14,24 @@ declare(strict_types=1);
 
 namespace Gitlab\Tests\Api;
 
-use Gitlab\Api\Tags;
+use Gitlab\Api\Releases;
 
-class TagsTest extends TestCase
+class ReleasesTest extends TestCase
 {
     /**
      * @test
      */
-    public function shouldGetAllTags(): void
+    public function shouldGetAllReleases(): void
     {
         $expectedArray = [
-            ['name' => 'v1.0.0'],
-            ['name' => 'v1.1.0'],
+            ['tag_name' => 'v1.0.0'],
+            ['tag_name' => 'v1.1.0'],
         ];
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/repository/tags')
+            ->with('projects/1/releases')
             ->will($this->returnValue($expectedArray));
         $this->assertEquals($expectedArray, $api->all(1));
     }
@@ -39,66 +39,25 @@ class TagsTest extends TestCase
     /**
      * @test
      */
-    public function shouldShowTag(): void
+    public function shouldShowRelease(): void
     {
         $expectedArray = [
-            ['name' => 'v1.0.0'],
+            ['tag_name' => 'v1.0.0'],
         ];
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/repository/tags/v1.0.0')
+            ->with('projects/1/releases/v1.0.0')
             ->will($this->returnValue($expectedArray));
         $this->assertEquals($expectedArray, $api->show(1, 'v1.0.0'));
     }
 
-    /**
-     * @test
-     */
-    public function shouldCreateTag(): void
-    {
-        $expectedArray = [
-            ['name' => 'v1.1.0'],
-        ];
-
-        $params = [
-            'id' => 1,
-            'tag_name' => 'v1.1.0',
-            'ref' => 'ref/heads/master',
-        ];
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('post')
-            ->with('projects/1/repository/tags', $params)
-            ->will($this->returnValue($expectedArray));
-
-        $this->assertEquals($expectedArray, $api->create(1, $params));
-    }
-
-    /**
-     * @test
-     */
-    public function shouldRemoveTag(): void
-    {
-        $expectedArray = [
-            ['name' => 'v1.1.0'],
-        ];
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('delete')
-            ->with('projects/1/repository/tags/v1.1.0')
-            ->will($this->returnValue($expectedArray));
-        $this->assertEquals($expectedArray, $api->remove(1, 'v1.1.0'));
-    }
 
     /**
      * @test
      *
      * @dataProvider releaseDataProvider
-     * @deprecated
      *
      * @param string $releaseName
      * @param string $description
@@ -113,7 +72,7 @@ class TagsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('projects/1/repository/tags/'.\str_replace('/', '%2F', $releaseName).'/release', $params)
+            ->with('projects/1/releases/'. $releaseName, $params)
             ->will($this->returnValue($expectedResult));
 
         $this->assertEquals($expectedResult, $api->createRelease(1, $releaseName, $params));
@@ -121,9 +80,26 @@ class TagsTest extends TestCase
 
     /**
      * @test
+     */
+    public function shouldRemoveRelease(): void
+    {
+        $expectedArray = [
+            ['name' => 'v1.1.0'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/releases/v1.1.0')
+            ->will($this->returnValue($expectedArray));
+        $this->assertEquals($expectedArray, $api->remove(1, 'v1.1.0'));
+    }
+
+
+    /**
+     * @test
      *
      * @dataProvider releaseDataProvider
-     * @deprecated
      *
      * @param string $releaseName
      * @param string $description
@@ -138,15 +114,12 @@ class TagsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('put')
-            ->with('projects/1/repository/tags/'.\str_replace('/', '%2F', $releaseName).'/release', $params)
+            ->with('projects/1/releases/'. $releaseName, $params)
             ->will($this->returnValue($expectedResult));
 
         $this->assertEquals($expectedResult, $api->updateRelease(1, $releaseName, $params));
     }
 
-    /**
-     * @deprecated
-     */
     public static function releaseDataProvider(): array
     {
         return [
@@ -171,6 +144,6 @@ class TagsTest extends TestCase
 
     protected function getApiClass()
     {
-        return Tags::class;
+        return Releases::class;
     }
 }

--- a/tests/Api/TagsTest.php
+++ b/tests/Api/TagsTest.php
@@ -98,6 +98,7 @@ class TagsTest extends TestCase
      * @test
      *
      * @dataProvider releaseDataProvider
+     *
      * @deprecated
      *
      * @param string $releaseName
@@ -123,6 +124,7 @@ class TagsTest extends TestCase
      * @test
      *
      * @dataProvider releaseDataProvider
+     *
      * @deprecated
      *
      * @param string $releaseName


### PR DESCRIPTION
Hi there,

I've made some improvements to the GitLab library:

1. Moved Releases API calls to their own dedicated file.
1. Separated Releases requests from Tags.

I've also copied over the relevant tests for the Tags implementation.

What needs to be done, to get this merged?