### PR TITLE
[11.14] Group milestones API: able to call GitLab API with addtional parameters updated_before and updated_after

### DIFF
--- a/src/Api/GroupsMilestones.php
+++ b/src/Api/GroupsMilestones.php
@@ -33,6 +33,10 @@ class GroupsMilestones extends AbstractApi
      *     @var int[]  $iids   return only the milestones having the given iids
      *     @var string $state  return only active or closed milestones
      *     @var string $search Return only milestones with a title or description matching the provided string.
+     *     @var string $updated_before Return only milestones updated before the given datetime.
+     *                                 Expected in ISO 8601 format (2019-03-15T08:00:00Z). Introduced in GitLab 15.10
+     *     @var string $updated_after  Return only milestones updated after the given datetime.
+     *                                 Expected in ISO 8601 format (2019-03-15T08:00:00Z). Introduced in GitLab 15.10
      * }
      *
      * @return mixed
@@ -50,6 +54,8 @@ class GroupsMilestones extends AbstractApi
             ->setAllowedValues('state', [self::STATE_ACTIVE, self::STATE_CLOSED])
         ;
         $resolver->setDefined('search');
+        $resolver->setDefined('updated_before');
+        $resolver->setDefined('updated_after');
 
         return $this->get('groups/'.self::encodePath($group_id).'/milestones', $resolver->resolve($parameters));
     }

--- a/src/Api/GroupsMilestones.php
+++ b/src/Api/GroupsMilestones.php
@@ -32,10 +32,10 @@ class GroupsMilestones extends AbstractApi
      *
      *     @var int[]  $iids   return only the milestones having the given iids
      *     @var string $state  return only active or closed milestones
-     *     @var string $search Return only milestones with a title or description matching the provided string.
-     *     @var string $updated_before Return only milestones updated before the given datetime.
+     *     @var string $search Return only milestones with a title or description matching the provided string
+     *     @var string $updated_before Return only milestones updated before the given datetime
      *                                 Expected in ISO 8601 format (2019-03-15T08:00:00Z). Introduced in GitLab 15.10
-     *     @var string $updated_after  Return only milestones updated after the given datetime.
+     *     @var string $updated_after  Return only milestones updated after the given datetime
      *                                 Expected in ISO 8601 format (2019-03-15T08:00:00Z). Introduced in GitLab 15.10
      * }
      *

--- a/src/Api/GroupsMilestones.php
+++ b/src/Api/GroupsMilestones.php
@@ -45,7 +45,9 @@ class GroupsMilestones extends AbstractApi
     {
         $resolver = $this->createOptionsResolver();
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
-            return $value->format('c');
+            $utc = (new \DateTimeImmutable($value->format(\DateTimeImmutable::RFC3339_EXTENDED)))->setTimezone(new \DateTimeZone('UTC'));
+
+            return $utc->format('Y-m-d\TH:i:s.v\Z');
         };
         $resolver->setDefined('iids')
             ->setAllowedTypes('iids', 'array')

--- a/tests/Api/GroupsMilestonesTest.php
+++ b/tests/Api/GroupsMilestonesTest.php
@@ -111,12 +111,12 @@ class GroupsMilestonesTest extends TestCase
      */
     public function shouldGetAllMilestonesWithParameterUpdatedBefore(): void
     {
-        $updatedBefore = '2023-11-25T08:00:00Z';
+        $updatedBefore = new \DateTimeImmutable('2023-11-25T08:00:00Z');
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('groups/1/milestones', ['updated_before' => $updatedBefore])
+            ->with('groups/1/milestones', ['updated_before' => $updatedBefore->format('c')])
         ;
 
         $api->all(1, ['updated_before' => $updatedBefore]);
@@ -127,12 +127,12 @@ class GroupsMilestonesTest extends TestCase
      */
     public function shouldGetAllMilestonesWithParameterUpdatedAfter(): void
     {
-        $updatedAfter = '2023-11-25T08:00:00Z';
+        $updatedAfter = new \DateTimeImmutable('2023-11-25T08:00:00Z');
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('groups/1/milestones', ['updated_after' => $updatedAfter])
+            ->with('groups/1/milestones', ['updated_after' => $updatedAfter->format('c')])
         ;
 
         $api->all(1, ['updated_after' => $updatedAfter]);

--- a/tests/Api/GroupsMilestonesTest.php
+++ b/tests/Api/GroupsMilestonesTest.php
@@ -76,6 +76,7 @@ class GroupsMilestonesTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider getAllMilestonesWithParameterStateDataProvider
      */
     public function shouldGetAllMilestonesWithParameterState(string $state): void

--- a/tests/Api/GroupsMilestonesTest.php
+++ b/tests/Api/GroupsMilestonesTest.php
@@ -41,6 +41,107 @@ class GroupsMilestonesTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetAllMilestonesWithParameterOneIidsValue(): void
+    {
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/milestones', ['iids' => [456]])
+        ;
+
+        $api->all(1, ['iids' => [456]]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetAllMilestonesWithParameterTwoIidsValues(): void
+    {
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/milestones', ['iids' => [456, 789]])
+        ;
+
+        $api->all(1, ['iids' => [456, 789]]);
+    }
+
+    public function getAllMilestonesWithParameterStateDataProvider()
+    {
+        return [
+            GroupsMilestones::STATE_ACTIVE => [GroupsMilestones::STATE_ACTIVE],
+            GroupsMilestones::STATE_CLOSED => [GroupsMilestones::STATE_CLOSED],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider getAllMilestonesWithParameterStateDataProvider
+     */
+    public function shouldGetAllMilestonesWithParameterState(string $state): void
+    {
+        $updatedBefore = '2023-11-25T08:00:00Z';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/milestones', ['state' => $state])
+        ;
+
+        $api->all(1, ['state' => $state]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetAllMilestonesWithParameterSearch(): void
+    {
+        $searchValue = 'abc';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/milestones', ['search' => $searchValue])
+        ;
+
+        $api->all(1, ['search' => $searchValue]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetAllMilestonesWithParameterUpdatedBefore(): void
+    {
+        $updatedBefore = '2023-11-25T08:00:00Z';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/milestones', ['updated_before' => $updatedBefore])
+        ;
+
+        $api->all(1, ['updated_before' => $updatedBefore]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetAllMilestonesWithParameterUpdatedAfter(): void
+    {
+        $updatedBefore = '2023-11-25T08:00:00Z';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/milestones', ['updated_after' => $updatedBefore])
+        ;
+
+        $api->all(1, ['updated_after' => $updatedBefore]);
+    }
+
+    /**
+     * @test
+     */
     public function shouldShowMilestone(): void
     {
         $expectedArray = ['id' => 1, 'name' => 'A milestone'];

--- a/tests/Api/GroupsMilestonesTest.php
+++ b/tests/Api/GroupsMilestonesTest.php
@@ -116,7 +116,7 @@ class GroupsMilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('groups/1/milestones', ['updated_before' => $updatedBefore->format('c')])
+            ->with('groups/1/milestones', ['updated_before' => '2023-11-25T08:00:00.000Z'])
         ;
 
         $api->all(1, ['updated_before' => $updatedBefore]);
@@ -132,7 +132,7 @@ class GroupsMilestonesTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('groups/1/milestones', ['updated_after' => $updatedAfter->format('c')])
+            ->with('groups/1/milestones', ['updated_after' => '2023-11-25T08:00:00.000Z'])
         ;
 
         $api->all(1, ['updated_after' => $updatedAfter]);

--- a/tests/Api/GroupsMilestonesTest.php
+++ b/tests/Api/GroupsMilestonesTest.php
@@ -66,7 +66,7 @@ class GroupsMilestonesTest extends TestCase
         $api->all(1, ['iids' => [456, 789]]);
     }
 
-    public function getAllMilestonesWithParameterStateDataProvider()
+    public static function getAllMilestonesWithParameterStateDataProvider()
     {
         return [
             GroupsMilestones::STATE_ACTIVE => [GroupsMilestones::STATE_ACTIVE],

--- a/tests/Api/GroupsMilestonesTest.php
+++ b/tests/Api/GroupsMilestonesTest.php
@@ -81,8 +81,6 @@ class GroupsMilestonesTest extends TestCase
      */
     public function shouldGetAllMilestonesWithParameterState(string $state): void
     {
-        $updatedBefore = '2023-11-25T08:00:00Z';
-
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
@@ -129,15 +127,15 @@ class GroupsMilestonesTest extends TestCase
      */
     public function shouldGetAllMilestonesWithParameterUpdatedAfter(): void
     {
-        $updatedBefore = '2023-11-25T08:00:00Z';
+        $updatedAfter = '2023-11-25T08:00:00Z';
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('groups/1/milestones', ['updated_after' => $updatedBefore])
+            ->with('groups/1/milestones', ['updated_after' => $updatedAfter])
         ;
 
-        $api->all(1, ['updated_after' => $updatedBefore]);
+        $api->all(1, ['updated_after' => $updatedAfter]);
     }
 
     /**


### PR DESCRIPTION
[List group milestones new parameters](https://docs.gitlab.com/ee/api/group_milestones.html#list-group-milestones)

```
updated_before:
Return only milestones updated before the given datetime. Expected in ISO 8601 format (2019-03-15T08:00:00Z).
Introduced in GitLab 15.10

updated_after:
Return only milestones updated after the given datetime. Expected in ISO 8601 format (2019-03-15T08:00:00Z).
Introduced in GitLab 15.10
```

 - call Group milestones API with addtional parameters updated_before and updated_after and add unit tests
 - add missing unit tests on the parameters iids, state, search
