### PR TITLE
[11.14] Update `MergeRequests::all` to use millisecond precision

### DIFF
--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -74,7 +74,7 @@ class MergeRequests extends AbstractApi
     {
         $resolver = $this->createOptionsResolver();
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
-            return $value->format('c.u');
+            return $value->format('Y-m-d\TH:i:s.vp');
         };
         $resolver->setDefined('iids')
             ->setAllowedTypes('iids', 'array')

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -74,7 +74,8 @@ class MergeRequests extends AbstractApi
     {
         $resolver = $this->createOptionsResolver();
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
-            return $value->format('Y-m-d\TH:i:s.vp');
+            $utc = \DateTimeImmutable::createFromInterface($value)->setTimezone(new \DateTimeZone('UTC'));
+            return $utc->format('Y-m-d\TH:i:s.v\Z');
         };
         $resolver->setDefined('iids')
             ->setAllowedTypes('iids', 'array')

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -75,6 +75,7 @@ class MergeRequests extends AbstractApi
         $resolver = $this->createOptionsResolver();
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
             $utc = (new \DateTimeImmutable($value->format(\DateTimeImmutable::RFC3339_EXTENDED)))->setTimezone(new \DateTimeZone('UTC'));
+
             return $utc->format('Y-m-d\TH:i:s.v\Z');
         };
         $resolver->setDefined('iids')

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -74,7 +74,7 @@ class MergeRequests extends AbstractApi
     {
         $resolver = $this->createOptionsResolver();
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
-            return $value->format('c');
+            return $value->format('c.u');
         };
         $resolver->setDefined('iids')
             ->setAllowedTypes('iids', 'array')

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -74,7 +74,7 @@ class MergeRequests extends AbstractApi
     {
         $resolver = $this->createOptionsResolver();
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
-            $utc = \DateTimeImmutable::createFromInterface($value)->setTimezone(new \DateTimeZone('UTC'));
+            $utc = (new \DateTimeImmutable($value->format(\DateTimeImmutable::RFC3339_EXTENDED)))->setTimezone(new \DateTimeZone('UTC'));
             return $utc->format('Y-m-d\TH:i:s.v\Z');
         };
         $resolver->setDefined('iids')

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -111,7 +111,7 @@ class MergeRequestsTest extends TestCase
 
         $expectedWithArray = [
             'created_after' => '2018-01-01T00:00:00.000Z',
-            'created_before' => '2018-01-01T00:00:00.000Z',
+            'created_before' => '2018-01-31T00:00:00.000Z',
         ];
 
         $api = $this->getApiMock();

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -110,8 +110,8 @@ class MergeRequestsTest extends TestCase
         $createdBefore = new \DateTime('2018-01-31 00:00:00');
 
         $expectedWithArray = [
-            'created_after' => $createdAfter->format(\DATE_ATOM),
-            'created_before' => $createdBefore->format(\DATE_ATOM),
+            'created_after' => '2018-01-01T00:00:00.000Z',
+            'created_before' => '2018-01-01T00:00:00.000Z',
         ];
 
         $api = $this->getApiMock();

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -107,11 +107,11 @@ class MergeRequestsTest extends TestCase
         $expectedArray = $this->getMultipleMergeRequestsData();
 
         $createdAfter = new \DateTime('2018-01-01 00:00:00');
-        $createdBefore = new \DateTime('2018-01-31 12:00:00+03:00');
+        $createdBefore = new \DateTime('2018-01-31 12:00:00.123+03:00');
 
         $expectedWithArray = [
             'created_after' => '2018-01-01T00:00:00.000Z',
-            'created_before' => '2018-01-31T09:00:00.000Z',
+            'created_before' => '2018-01-31T09:00:00.123Z',
         ];
 
         $api = $this->getApiMock();

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -107,11 +107,11 @@ class MergeRequestsTest extends TestCase
         $expectedArray = $this->getMultipleMergeRequestsData();
 
         $createdAfter = new \DateTime('2018-01-01 00:00:00');
-        $createdBefore = new \DateTime('2018-01-31 00:00:00');
+        $createdBefore = new \DateTime('2018-01-31 12:00:00+03:00');
 
         $expectedWithArray = [
             'created_after' => '2018-01-01T00:00:00.000Z',
-            'created_before' => '2018-01-31T00:00:00.000Z',
+            'created_before' => '2018-01-31T09:00:00.000Z',
         ];
 
         $api = $this->getApiMock();


### PR DESCRIPTION
We are iteratively fetching new MRs via:
```
updated_after=2023-01-24T18:05:25.801Z
&sort=asc
&order_by=updated_at
```

And there is more than 100 MR updated within a second. Current implementation causes the same MRs to be analysed again every time. But the API seems to support microsecond precision, so this should fix it.