### PR TITLE
[11.4] Fix project events not allowing approved action

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -954,7 +954,7 @@ class Projects extends AbstractApi
         };
 
         $resolver->setDefined('action')
-            ->setAllowedValues('action', ['created', 'updated', 'closed', 'reopened', 'pushed', 'commented', 'merged', 'joined', 'left', 'destroyed', 'expired'])
+            ->setAllowedValues('action', ['created', 'updated', 'closed', 'reopened', 'pushed', 'commented', 'merged', 'joined', 'left', 'destroyed', 'expired', 'approved'])
         ;
         $resolver->setDefined('target_type')
             ->setAllowedValues('target_type', ['issue', 'milestone', 'merge_request', 'note', 'project', 'snippet', 'user'])


### PR DESCRIPTION
Add the `approved` action type in project events according to the [documentation](https://docs.gitlab.com/ee/user/profile/contributions_calendar.html#user-contribution-events)