### PR TITLE
[11.15] Add support for listing merge requests associated with a commit

### DIFF
--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -270,6 +270,19 @@ class Repositories extends AbstractApi
 
     /**
      * @param int|string $project_id
+     * @param string     $sha
+     *
+     * @return mixed
+     */
+    public function commitMergeRequests($project_id, string $sha)
+    {
+        return $this->get(
+            $this->getProjectPath($project_id, 'repository/commits/'.self::encodePath($sha).'/merge_requests'),
+        );
+    }
+
+    /**
+     * @param int|string $project_id
      * @param array      $parameters {
      *
      *     @var string $branch         Name of the branch to commit into. To create a new branch, also provide start_branch.

--- a/tests/Api/RepositoriesTest.php
+++ b/tests/Api/RepositoriesTest.php
@@ -363,6 +363,26 @@ class RepositoriesTest extends TestCase
 
     /**
      * @test
+     */
+    public function shouldGetCommitMergeRequests(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'title' => 'A merge request'],
+            ['id' => 2, 'title' => 'Another merge request'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/repository/commits/abcd1234/merge_requests')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->commitMergeRequests(1, 'abcd1234'));
+    }
+
+    /**
+     * @test
      *
      * @dataProvider dataGetCommitRefsWithParams
      *


### PR DESCRIPTION
Api specification: https://docs.gitlab.com/ee/api/commits.html#list-merge-requests-associated-with-a-commit