### PR TITLE
[11.15] Added functionality to handle access tokens

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout Code

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^7.4.15 || ^8.0.2",
+        "php": "^8.1",
         "ext-json": "*",
         "ext-xml": "*",
         "php-http/cache-plugin": "^1.8.1",

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -253,12 +253,12 @@ abstract class AbstractApi
         return 'projects/'.self::encodePath($id).'/'.$uri;
     }
 
-	/**
-	 * @param string|int $id
-	 * @param string $uri
-	 *
-	 * @return string
-	 */
+    /**
+     * @param string|int $id
+     * @param string $uri
+     *
+     * @return string
+     */
     protected function getGroupPath(string|int $id, string $uri): string
     {
         return 'groups/'.self::encodePath($id).'/'.$uri;

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -254,6 +254,16 @@ abstract class AbstractApi
     }
 
     /**
+     * @param $id
+     * @param string $uri
+     * @return string
+     */
+    protected function getGroupPath($id, string $uri): string
+    {
+        return 'groups/'.self::encodePath($id).'/'.$uri;
+    }
+
+    /**
      * Create a new OptionsResolver with page and per_page options.
      *
      * @return OptionsResolver

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -256,6 +256,7 @@ abstract class AbstractApi
     /**
      * @param $id
      * @param string $uri
+     *
      * @return string
      */
     protected function getGroupPath($id, string $uri): string

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -253,13 +253,13 @@ abstract class AbstractApi
         return 'projects/'.self::encodePath($id).'/'.$uri;
     }
 
-    /**
-     * @param $id
-     * @param string $uri
-     *
-     * @return string
-     */
-    protected function getGroupPath($id, string $uri): string
+	/**
+	 * @param string|int $id
+	 * @param string $uri
+	 *
+	 * @return string
+	 */
+    protected function getGroupPath(string|int $id, string $uri): string
     {
         return 'groups/'.self::encodePath($id).'/'.$uri;
     }

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -984,6 +984,7 @@ class Groups extends AbstractApi
 
     /**
      * @param $group_id
+     *
      * @return mixed
      */
     public function groupAccessTokens($group_id)
@@ -994,6 +995,7 @@ class Groups extends AbstractApi
     /**
      * @param $group_id
      * @param $token_id
+     *
      * @return mixed
      */
     public function groupAccessToken($group_id, $token_id)
@@ -1004,6 +1006,7 @@ class Groups extends AbstractApi
     /**
      * @param $group_id
      * @param array $parameters
+     *
      * @return mixed
      */
     public function createGroupAccessToken($group_id, array $parameters = [])
@@ -1044,6 +1047,7 @@ class Groups extends AbstractApi
     /**
      * @param $group_id
      * @param $token_id
+     *
      * @return mixed
      */
     public function deleteGroupAccessToken($group_id, $token_id)

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -1067,6 +1067,7 @@ class Groups extends AbstractApi
         $regex = '/(?:19|20)\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2]\d|3[01])/';
         if ('' !== $expiry && false !== \preg_match($regex, $expiry)) {
             $uri = 'access_tokens/'.self::encodePath($token_id).'/rotate?expires_at='.$expiry;
+
             return $this->post($this->getGroupPath($group_id, $uri));
         }
 

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -983,6 +983,75 @@ class Groups extends AbstractApi
     }
 
     /**
+     * @param $group_id
+     * @return mixed
+     */
+    public function groupAccessTokens($group_id)
+    {
+        return $this->get($this->getGroupPath($group_id, 'access_tokens'));
+    }
+
+    /**
+     * @param $group_id
+     * @param $token_id
+     * @return mixed
+     */
+    public function groupAccessToken($group_id, $token_id)
+    {
+        return $this->get($this->getGroupPath($group_id, 'access_tokens/'.self::encodePath($token_id)));
+    }
+
+    /**
+     * @param $group_id
+     * @param array $parameters
+     * @return mixed
+     */
+    public function createGroupAccessToken($group_id, array $parameters = [])
+    {
+        $resolver = $this->createOptionsResolver();
+        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
+            return $value->format('Y-m-d');
+        };
+
+        $resolver->define('name')
+            ->required();
+
+        $resolver->define('scopes')
+            ->required()
+            ->allowedTypes('array')
+            ->allowedValues(function ($scopes) {
+                $allowed = ['api', 'read_api', 'read_registry', 'write_registry', 'read_repository', 'write_repository'];
+                foreach ($scopes as $scope) {
+                    if (!\in_array($scope, $allowed, true)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            });
+
+        $resolver->setDefined('access_level')
+            ->setAllowedTypes('access_level', 'int')
+            ->setAllowedValues('access_level', [10, 20, 30, 40, 50]);
+
+        $resolver->setDefined('expires_at')
+            ->setAllowedTypes('expires_at', \DateTimeInterface::class)
+            ->setNormalizer('expires_at', $datetimeNormalizer);
+
+        return $this->post($this->getGroupPath($group_id, 'access_tokens'), $resolver->resolve($parameters));
+    }
+
+    /**
+     * @param $group_id
+     * @param $token_id
+     * @return mixed
+     */
+    public function deleteGroupAccessToken($group_id, $token_id)
+    {
+        return $this->delete($this->getGroupPath($group_id, 'access_tokens/'.self::encodePath($token_id)));
+    }
+
+    /**
      * @param int|string $id
      * @param array $parameters {
      *

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -982,35 +982,35 @@ class Groups extends AbstractApi
         return $this->delete('groups/'.self::encodePath($group_id).'/deploy_tokens/'.self::encodePath($token_id));
     }
 
-    /**
-     * @param $group_id
-     *
-     * @return mixed
-     */
-    public function groupAccessTokens($group_id)
-    {
+	/**
+	 * @param string|int $group_id
+	 *
+	 * @return mixed
+	 */
+    public function groupAccessTokens(string|int $group_id): mixed
+	{
         return $this->get($this->getGroupPath($group_id, 'access_tokens'));
     }
 
-    /**
-     * @param $group_id
-     * @param $token_id
-     *
-     * @return mixed
-     */
-    public function groupAccessToken($group_id, $token_id)
-    {
+	/**
+	 * @param string|int $group_id
+	 * @param string|int $token_id
+	 *
+	 * @return mixed
+	 */
+    public function groupAccessToken(string|int $group_id, string|int $token_id): mixed
+	{
         return $this->get($this->getGroupPath($group_id, 'access_tokens/'.self::encodePath($token_id)));
     }
 
-    /**
-     * @param $group_id
-     * @param array $parameters
-     *
-     * @return mixed
-     */
-    public function createGroupAccessToken($group_id, array $parameters = [])
-    {
+	/**
+	 * @param string|int $group_id
+	 * @param array $parameters
+	 *
+	 * @return mixed
+	 */
+    public function createGroupAccessToken(string|int $group_id, array $parameters = []): mixed
+	{
         $resolver = $this->createOptionsResolver();
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
             return $value->format('Y-m-d');
@@ -1044,14 +1044,14 @@ class Groups extends AbstractApi
         return $this->post($this->getGroupPath($group_id, 'access_tokens'), $resolver->resolve($parameters));
     }
 
-    /**
-     * @param $group_id
-     * @param $token_id
-     *
-     * @return mixed
-     */
-    public function deleteGroupAccessToken($group_id, $token_id)
-    {
+	/**
+	 * @param string|int $group_id
+	 * @param string|int $token_id
+	 *
+	 * @return mixed
+	 */
+    public function deleteGroupAccessToken(string|int $group_id, string|int $token_id): mixed
+	{
         return $this->delete($this->getGroupPath($group_id, 'access_tokens/'.self::encodePath($token_id)));
     }
 

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -1056,6 +1056,24 @@ class Groups extends AbstractApi
     }
 
     /**
+     * @param string|int $group_id
+     * @param string|int $token_id
+     * @param string $expiry
+     *
+     * @return mixed
+     */
+    public function rotateGroupAccessToken(string|int $group_id, string|int $token_id, string $expiry = ''): mixed
+    {
+        $regex = '/(?:19|20)\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2]\d|3[01])/';
+        if ($expiry !== '' && preg_match($regex, $expiry) !== false) {
+            $uri = 'access_tokens/'.self::encodePath($token_id).'/rotate?expires_at='.$expiry;
+            return $this->post($this->getGroupPath($group_id, $uri));
+        }
+
+        return $this->post($this->getGroupPath($group_id, 'access_tokens/'.self::encodePath($token_id).'/rotate'));
+    }
+
+    /**
      * @param int|string $id
      * @param array $parameters {
      *

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -982,35 +982,35 @@ class Groups extends AbstractApi
         return $this->delete('groups/'.self::encodePath($group_id).'/deploy_tokens/'.self::encodePath($token_id));
     }
 
-	/**
-	 * @param string|int $group_id
-	 *
-	 * @return mixed
-	 */
+    /**
+     * @param string|int $group_id
+     *
+     * @return mixed
+     */
     public function groupAccessTokens(string|int $group_id): mixed
-	{
+    {
         return $this->get($this->getGroupPath($group_id, 'access_tokens'));
     }
 
-	/**
-	 * @param string|int $group_id
-	 * @param string|int $token_id
-	 *
-	 * @return mixed
-	 */
+    /**
+     * @param string|int $group_id
+     * @param string|int $token_id
+     *
+     * @return mixed
+     */
     public function groupAccessToken(string|int $group_id, string|int $token_id): mixed
-	{
+    {
         return $this->get($this->getGroupPath($group_id, 'access_tokens/'.self::encodePath($token_id)));
     }
 
-	/**
-	 * @param string|int $group_id
-	 * @param array $parameters
-	 *
-	 * @return mixed
-	 */
+    /**
+     * @param string|int $group_id
+     * @param array $parameters
+     *
+     * @return mixed
+     */
     public function createGroupAccessToken(string|int $group_id, array $parameters = []): mixed
-	{
+    {
         $resolver = $this->createOptionsResolver();
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
             return $value->format('Y-m-d');
@@ -1044,14 +1044,14 @@ class Groups extends AbstractApi
         return $this->post($this->getGroupPath($group_id, 'access_tokens'), $resolver->resolve($parameters));
     }
 
-	/**
-	 * @param string|int $group_id
-	 * @param string|int $token_id
-	 *
-	 * @return mixed
-	 */
+    /**
+     * @param string|int $group_id
+     * @param string|int $token_id
+     *
+     * @return mixed
+     */
     public function deleteGroupAccessToken(string|int $group_id, string|int $token_id): mixed
-	{
+    {
         return $this->delete($this->getGroupPath($group_id, 'access_tokens/'.self::encodePath($token_id)));
     }
 

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -1065,7 +1065,7 @@ class Groups extends AbstractApi
     public function rotateGroupAccessToken(string|int $group_id, string|int $token_id, string $expiry = ''): mixed
     {
         $regex = '/(?:19|20)\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2]\d|3[01])/';
-        if ($expiry !== '' && preg_match($regex, $expiry) !== false) {
+        if ('' !== $expiry && false !== \preg_match($regex, $expiry)) {
             $uri = 'access_tokens/'.self::encodePath($token_id).'/rotate?expires_at='.$expiry;
             return $this->post($this->getGroupPath($group_id, $uri));
         }

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1715,6 +1715,24 @@ class Projects extends AbstractApi
         return $this->delete($this->getProjectPath($project_id, 'access_tokens/'.$token_id));
     }
 
+	/**
+	 * @param string|int $project_id
+	 * @param string|int $token_id
+	 * @param string $expiry
+	 *
+	 * @return mixed
+	 */
+	public function rotateProjectAccessToken(string|int $project_id, string|int $token_id, string $expiry = ''): mixed
+	{
+		$regex = '/(?:19|20)\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2]\d|3[01])/';
+		if ($expiry !== '' && preg_match($regex, $expiry) !== false) {
+			$uri = 'access_tokens/'.self::encodePath($token_id).'/rotate?expires_at='.$expiry;
+			return $this->post($this->getProjectPath($project_id, $uri));
+		}
+
+		return $this->post($this->getProjectPath($project_id, 'access_tokens/'.self::encodePath($token_id).'/rotate'));
+	}
+
     /**
      * @param int|string $project_id
      *

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1727,6 +1727,7 @@ class Projects extends AbstractApi
         $regex = '/(?:19|20)\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2]\d|3[01])/';
         if ('' !== $expiry && false !== \preg_match($regex, $expiry)) {
             $uri = 'access_tokens/'.self::encodePath($token_id).'/rotate?expires_at='.$expiry;
+
             return $this->post($this->getProjectPath($project_id, $uri));
         }
 

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1715,23 +1715,23 @@ class Projects extends AbstractApi
         return $this->delete($this->getProjectPath($project_id, 'access_tokens/'.$token_id));
     }
 
-	/**
-	 * @param string|int $project_id
-	 * @param string|int $token_id
-	 * @param string $expiry
-	 *
-	 * @return mixed
-	 */
-	public function rotateProjectAccessToken(string|int $project_id, string|int $token_id, string $expiry = ''): mixed
-	{
-		$regex = '/(?:19|20)\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2]\d|3[01])/';
-		if ($expiry !== '' && preg_match($regex, $expiry) !== false) {
-			$uri = 'access_tokens/'.self::encodePath($token_id).'/rotate?expires_at='.$expiry;
-			return $this->post($this->getProjectPath($project_id, $uri));
-		}
+    /**
+     * @param string|int $project_id
+     * @param string|int $token_id
+     * @param string $expiry
+     *
+     * @return mixed
+     */
+    public function rotateProjectAccessToken(string|int $project_id, string|int $token_id, string $expiry = ''): mixed
+    {
+        $regex = '/(?:19|20)\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2]\d|3[01])/';
+        if ('' !== $expiry && false !== \preg_match($regex, $expiry)) {
+            $uri = 'access_tokens/'.self::encodePath($token_id).'/rotate?expires_at='.$expiry;
+            return $this->post($this->getProjectPath($project_id, $uri));
+        }
 
-		return $this->post($this->getProjectPath($project_id, 'access_tokens/'.self::encodePath($token_id).'/rotate'));
-	}
+        return $this->post($this->getProjectPath($project_id, 'access_tokens/'.self::encodePath($token_id).'/rotate'));
+    }
 
     /**
      * @param int|string $project_id

--- a/src/HttpClient/Plugin/Authentication.php
+++ b/src/HttpClient/Plugin/Authentication.php
@@ -19,7 +19,6 @@ use Gitlab\Exception\RuntimeException;
 use Http\Client\Common\Plugin;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * Add authentication to the request.

--- a/src/HttpClient/Plugin/Authentication.php
+++ b/src/HttpClient/Plugin/Authentication.php
@@ -55,7 +55,7 @@ final class Authentication implements Plugin
      * @param callable         $next
      * @param callable         $first
      *
-     * @return Promise<ResponseInterface>
+     * @return Promise
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {

--- a/src/HttpClient/Plugin/ExceptionThrower.php
+++ b/src/HttpClient/Plugin/ExceptionThrower.php
@@ -39,10 +39,12 @@ final class ExceptionThrower implements Plugin
      * Handle the request and return the response coming from the next callable.
      *
      * @param RequestInterface $request
-     * @param callable         $next
-     * @param callable         $first
+     * @param callable $next
+     * @param callable $first
      *
-     * @return Promise<ResponseInterface>
+     * @return Promise
+     * @throws ErrorException
+     * @throws ExceptionInterface
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {

--- a/src/HttpClient/Plugin/ExceptionThrower.php
+++ b/src/HttpClient/Plugin/ExceptionThrower.php
@@ -42,9 +42,10 @@ final class ExceptionThrower implements Plugin
      * @param callable $next
      * @param callable $first
      *
-     * @return Promise
      * @throws ErrorException
      * @throws ExceptionInterface
+     *
+     * @return Promise
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -1063,6 +1063,34 @@ class GroupsTest extends TestCase
     /**
      * @test
      */
+    public function shouldRotateGroupAccessToken(): void
+    {
+        $expectedArray = [
+            'scopes' => [
+                'api',
+                'read_repository',
+            ],
+            'active' => true,
+            'name' => 'test',
+            'revoked' => false,
+            'created_at' => '2021-01-21T19:35:37.921Z',
+            'user_id' => 166,
+            'id' => 58,
+            'expires_at' => '2021-01-31',
+            'token' => 'D4y...Wzr',
+        ];
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('groups/1/access_tokens/2/rotate?expires_at=2021-01-31')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->rotateGroupAccessToken(1, 2, '2021-01-31'));
+    }
+
+    /**
+     * @test
+     */
     public function shouldSearchGroups(): void
     {
         $expectedArray = [

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -944,6 +944,125 @@ class GroupsTest extends TestCase
     /**
      * @test
      */
+    public function shouldGetGroupAccessTokens(): void
+    {
+        $expectedArray = [
+            [
+                'user_id' => 141,
+                'scopes' => [
+                    'api',
+                ],
+                'name' => 'token',
+                'expires_at' => '2021-01-31',
+                'id' => 42,
+                'active' => true,
+                'created_at' => '2021-01-20T22:11:48.151Z',
+                'revoked' => false,
+            ],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/access_tokens')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->groupAccessTokens(1));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetGroupAccessToken(): void
+    {
+        $expectedArray = [
+            'user_id' => 141,
+            'scopes' => [
+                'api',
+            ],
+            'name' => 'token',
+            'expires_at' => '2021-01-31',
+            'id' => 42,
+            'active' => true,
+            'created_at' => '2021-01-20T22:11:48.151Z',
+            'revoked' => false,
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/access_tokens/42')
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->groupAccessToken(1, 42));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateGroupAccessToken(): void
+    {
+        $expectedArray = [
+            'scopes' => [
+                'api',
+                'read_repository',
+            ],
+            'active' => true,
+            'name' => 'test',
+            'revoked' => false,
+            'created_at' => '2021-01-21T19:35:37.921Z',
+            'user_id' => 166,
+            'id' => 58,
+            'expires_at' => '2021-01-31',
+            'token' => 'D4y...Wzr',
+        ];
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with(
+                'groups/1/access_tokens',
+                [
+                    'name' => 'test_token',
+                    'scopes' => [
+                        'api',
+                        'read_repository',
+                    ],
+                    'access_level' => 30,
+                    'expires_at' => '2021-01-31',
+                ]
+            )
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->createGroupAccessToken(1, [
+            'name' => 'test_token',
+            'scopes' => [
+                'api',
+                'read_repository',
+            ],
+            'access_level' => 30,
+            'expires_at' => new DateTime('2021-01-31'),
+        ]));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldDeleteGroupAccessToken(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('groups/1/access_tokens/2')
+            ->will($this->returnValue($expectedBool));
+
+        $this->assertEquals($expectedBool, $api->deleteGroupAccessToken(1, 2));
+    }
+
+    /**
+     * @test
+     */
     public function shouldSearchGroups(): void
     {
         $expectedArray = [

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2975,7 +2975,7 @@ class ProjectsTest extends TestCase
         $api->expects($this->once())
             ->method('post')
             ->with(
-                'projects/1/access_tokens/2/rotate?expires_at=2021-01-31',)
+                'projects/1/access_tokens/2/rotate?expires_at=2021-01-31')
             ->will($this->returnValue($expectedArray));
 
         $this->assertEquals($expectedArray, $api->rotateProjectAccessToken(1, 2, '2021-01-31'));

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2955,6 +2955,35 @@ class ProjectsTest extends TestCase
     /**
      * @test
      */
+    public function shouldRotateProjectAccessToken(): void
+    {
+        $expectedArray = [
+            'scopes' => [
+                'api',
+                'read_repository',
+            ],
+            'active' => true,
+            'name' => 'test',
+            'revoked' => false,
+            'created_at' => '2021-01-21T19:35:37.921Z',
+            'user_id' => 166,
+            'id' => 58,
+            'expires_at' => '2021-01-31',
+            'token' => 'D4y...Wzr',
+        ];
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with(
+                'projects/1/access_tokens/2/rotate?expires_at=2021-01-31',)
+            ->will($this->returnValue($expectedArray));
+
+        $this->assertEquals($expectedArray, $api->rotateProjectAccessToken(1, 2, '2021-01-31'));
+    }
+
+    /**
+     * @test
+     */
     public function shouldUploadAvatar(): void
     {
         $emptyPNGContents = 'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAACYElEQVR42u3UMQEAAAjDMFCO9GEAByQSerQrmQJeagMAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwADAAAwADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMAAzAAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwADMAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAMAAZwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAOCybrx+H1CTHLYAAAAASUVORK5CYII=';


### PR DESCRIPTION
Closes #799 
Closes #798

This pull request includes:

- A new method in AbstractApi: getGroupPath (group equivalent to getProjectPath)
- New methods in Groups:
    - groupAccessTokens
    - groupAccessToken
    - createGroupAccessToken
    - deleteGroupAccessToken
    - rotateGroupAccessToken
- New methods in Projects
    - rotateProjectAccessToken
- Tests for above methods

The above methods are almost 1:1 to the same functionality available for project access tokens, making this pull request super easy to make. Tested with the available test tools seen in this project (albeit locally) and against my company's private group (with Premium). Works as expected in that regard.

The rotate methods simply rotate the specified access token, and returns the resulting array, containing also the token itself; this is handy for automatically updating variables in Gitlab containing these tokens.