### PR TITLE
Add the job_variables_attributes as additional parameters to the job …

### DIFF
--- a/src/Api/Jobs.php
+++ b/src/Api/Jobs.php
@@ -240,12 +240,16 @@ class Jobs extends AbstractApi
     /**
      * @param int|string $project_id
      * @param int        $job_id
+     * @param array     $parameters
      *
      * @return mixed
      */
-    public function play($project_id, int $job_id)
+    public function play($project_id, int $job_id, array $parameters = [])
     {
-        return $this->post('projects/'.self::encodePath($project_id).'/jobs/'.self::encodePath($job_id).'/play');
+        $resolver = new OptionsResolver();
+        $resolver->setDefined('job_variables_attributes');
+
+        return $this->post('projects/'.self::encodePath($project_id).'/jobs/'.self::encodePath($job_id).'/play', $resolver->resolve($parameters));
     }
 
     /**

--- a/tests/Api/JobsTest.php
+++ b/tests/Api/JobsTest.php
@@ -298,6 +298,36 @@ class JobsTest extends TestCase
         $this->assertEquals($expectedArray, $api->play(1, 3));
     }
 
+    /**
+     * @test
+     */
+    public function shouldPlayWithVariables(): void
+    {
+        $expectedArray = ['id' => 3, 'name' => 'A job'];
+
+        $jobVariables = [
+            'job_variables_attributes' => [
+                [
+                    'key' => 'TEST_VAR_1',
+                    'value' => 'test1',
+                ],
+                [
+                    'key' => 'TEST_VAR_2',
+                    'value' => 'test2',
+                ],
+            ],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/jobs/3/play', $jobVariables)
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->play(1, 3, $jobVariables));
+    }
+
     protected function getApiClass()
     {
         return Jobs::class;


### PR DESCRIPTION
Add the `job_variables_attributes` as additional parameters to the job play call.

This gives the option to add custom variables to a job.

See: https://docs.gitlab.com/ee/api/jobs.html#run-a-job

I don't know if it is possible to have more validation on the array in the provided options. If that is possible I'm happy to add it.

I didn't see a place with documentation where I need to add something, let me know if I missed it.  
If there is anything else that I can/need to change please say it.