### PR TITLE
Collection of missing/incorrect parameters

### DIFF
--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -310,6 +310,7 @@ class Groups extends AbstractApi
      *     @var bool   $with_shared                 Include projects shared to this group (default is true)
      *     @var bool   $include_subgroups           Include projects in subgroups of this group (default is false)
      *     @var bool   $with_custom_attributes      Include custom attributes in response (admins only).
+     *     @var \DateTimeInterface $last_activity_after Limit by projects with last_activity after specified time
      * }
      *
      * @return mixed

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -320,6 +320,9 @@ class Groups extends AbstractApi
         $booleanNormalizer = function (Options $resolver, $value): string {
             return $value ? 'true' : 'false';
         };
+        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
+            return $value->format('c');
+        };
 
         $resolver->setDefined('archived')
             ->setAllowedTypes('archived', 'bool')
@@ -366,6 +369,10 @@ class Groups extends AbstractApi
         $resolver->setDefined('with_custom_attributes')
             ->setAllowedTypes('with_custom_attributes', 'bool')
             ->setNormalizer('with_custom_attributes', $booleanNormalizer)
+        ;
+        $resolver->setDefined('last_activity_after')
+            ->setAllowedTypes('last_activity_after', \DateTimeInterface::class)
+            ->setNormalizer('last_activity_after', $datetimeNormalizer)
         ;
 
         return $this->get('groups/'.self::encodePath($id).'/projects', $resolver->resolve($parameters));

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -309,7 +309,7 @@ class Groups extends AbstractApi
      *     @var bool   $with_merge_requests_enabled Limit by projects with merge requests feature enabled (default is false)
      *     @var bool   $with_shared                 Include projects shared to this group (default is true)
      *     @var bool   $include_subgroups           Include projects in subgroups of this group (default is false)
-     *     @var bool   $with_custom_attributes      Include custom attributes in response (admins only).
+     *     @var bool   $with_custom_attributes      Include custom attributes in response (admins only)
      *     @var \DateTimeInterface $last_activity_after Limit by projects with last_activity after specified time
      * }
      *

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -348,11 +348,12 @@ class Projects extends AbstractApi
      *     @var string $name        the name of the user who triggered pipelines
      *     @var string $username    the username of the user who triggered pipelines
      *     @var string $order_by    order pipelines by id, status, ref, updated_at, or user_id (default: id)
-     *     @var string $order       sort pipelines in asc or desc order (default: desc)
+     *     @var string $sort        sort pipelines in asc or desc order (default: desc)
      *     @var string $source      the source of the pipeline
+     *     @var \DateTimeInterface $updated_after Return pipelines updated on or after the given date and time.
+     *     @var \DateTimeInterface $updated_before Return pipelines updated on or before the given date and time.
      * }
      *
-     * @return mixed
      */
     public function pipelines($project_id, array $parameters = [])
     {
@@ -361,7 +362,7 @@ class Projects extends AbstractApi
             return $value ? 'true' : 'false';
         };
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
-            return $value->format('Y-m-d');
+            return $value->format('c');
         };
 
         $resolver->setDefined('scope')

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -350,10 +350,9 @@ class Projects extends AbstractApi
      *     @var string $order_by    order pipelines by id, status, ref, updated_at, or user_id (default: id)
      *     @var string $sort        sort pipelines in asc or desc order (default: desc)
      *     @var string $source      the source of the pipeline
-     *     @var \DateTimeInterface $updated_after Return pipelines updated on or after the given date and time.
+     *     @var \DateTimeInterface $updated_after Return pipelines updated on or after the given date and time
      *     @var \DateTimeInterface $updated_before Return pipelines updated on or before the given date and time.
      * }
-     *
      */
     public function pipelines($project_id, array $parameters = [])
     {


### PR DESCRIPTION
- `\Gitlab\Api\Groups::projects` can accept a last_activity_after date arg
- `\Gitlab\Api\Projects::pipelines` $order -> $sort rename
- `\Gitlab\Api\Projects::pipelines` can accept an updated_before date arg
- `\Gitlab\Api\Projects::pipelines` can accept an updated_after date arg
- wider date required for projects date, needs time