### PR TITLE
Add missing option "visibility" to groups API

### DIFF
--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -866,6 +866,10 @@ class Groups extends AbstractApi
             ->setNormalizer('top_level_only', $booleanNormalizer)
         ;
 
+        $resolver->setDefined('visibility')
+            ->setAllowedValues('visibility', ['public', 'internal', 'private'])
+        ;
+
         return $resolver;
     }
 


### PR DESCRIPTION
Visibility is also available as filter for groups, not only for projects.