### PR TITLE
Added support for merge_train endpoint

### DIFF
--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -204,7 +204,7 @@ class MergeRequests extends AbstractApi
 
     public function mergeTrain($project_id, int $mr_iid, array $parameters = [])
     {
-        return $this->put($this->getProjectPath($project_id, 'merge_trains/merge_requests/'.self::encodePath($mr_iid)), $parameters);
+        return $this->post($this->getProjectPath($project_id, 'merge_trains/merge_requests/'.self::encodePath($mr_iid)), $parameters);
     }
 
     public function showNotes(int|string $project_id, int $mr_iid): mixed

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -206,7 +206,7 @@ class MergeRequests extends AbstractApi
     {
         return $this->put($this->getProjectPath($project_id, 'merge_trains/merge_requests/'.self::encodePath($mr_iid)), $parameters);
     }
-    
+
     public function showNotes(int|string $project_id, int $mr_iid): mixed
     {
         return $this->get($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/notes'));

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -202,6 +202,11 @@ class MergeRequests extends AbstractApi
         return $this->put($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/merge'), $parameters);
     }
 
+    public function mergeTrain($project_id, int $mr_iid, array $parameters = [])
+    {
+        return $this->put($this->getProjectPath($project_id, 'merge_trains/merge_requests/'.self::encodePath($mr_iid)), $parameters);
+    }
+    
     public function showNotes(int|string $project_id, int $mr_iid): mixed
     {
         return $this->get($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/notes'));


### PR DESCRIPTION
The merge_train endpoint allows a merge/pull request to be added to a merge train, rather than merging directly.§

See the documentation here: https://docs.gitlab.com/api/merge_trains/#add-a-merge-request-to-a-merge-train