### PR TITLE
[12.0] Support merge request dependency endpoint

### DIFF
--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -368,4 +368,26 @@ class MergeRequests extends AbstractApi
     {
         return $this->delete($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/approval_rules/'.self::encodePath($approval_rule_id)));
     }
+
+    public function createDependency(int|string $project_id, int $mr_iid, int $blocking_merge_request_id): mixed
+    {
+        return $this->post($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/blocks'), [
+            'blocking_merge_request_id' => $blocking_merge_request_id,
+        ]);
+    }
+
+    public function dependencies(int|string $project_id, int $mr_iid): mixed
+    {
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/blocks'));
+    }
+
+    public function deleteDependency(int|string $project_id, int $mr_iid, int $block_id): mixed
+    {
+        return $this->delete($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/blocks/'.self::encodePath($block_id)));
+    }
+
+    public function blockedMrs(int|string $project_id, int $mr_iid): mixed
+    {
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/blockees'));
+    }
 }

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -822,4 +822,69 @@ class MergeRequestsTest extends TestCase
             'skip_ci' => true,
         ]));
     }
+
+    #[Test]
+    public function shouldCreateDependency(): void
+    {
+        $expectedArray = ['id' => 1, 'blocking_merge_request_id' => 3];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/merge_requests/2/blocks/3')
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->createDependency(1, 2, 3));
+    }
+
+    #[Test]
+    public function shouldGetDependencies(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'blocking_merge_request_id' => 3],
+            ['id' => 2, 'blocking_merge_request_id' => 4],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/merge_requests/2/blocks')
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->dependencies(1, 2));
+    }
+
+    #[Test]
+    public function shouldDeleteDependency(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/merge_requests/2/blocks/3')
+            ->willReturn($expectedBool);
+
+        $this->assertEquals($expectedBool, $api->deleteDependency(1, 2, 3));
+    }
+
+    #[Test]
+    public function shouldGetBlockedMergeRequests(): void
+    {
+        $expectedArray = [
+            ['id' => 3, 'project_id' => 1, 'blocking_merge_request' => [], 'blocked_merge_request' => []],
+            ['id' => 4, 'project_id' => 1, 'blocking_merge_request' => [], 'blocked_merge_request' => []],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/merge_requests/2/blockees')
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->blockedMrs(1, 2));
+    }
 }


### PR DESCRIPTION
# Support Merge Request Dependencies API

## 🎯 Overview

Add comprehensive support for GitLab's Merge Request Dependencies API, enabling developers to manage blocking relationships between merge requests programmatically.

## ✨ Features Added

### New API Methods
- **`createDependency()`** - Create dependency between merge requests
- **`dependencies()`** - List all dependencies for a merge request  
- **`deleteDependency()`** - Remove dependency relationship
- **`blockedMrs()`** - Get merge requests blocked by current MR

### API Endpoints Covered
```
POST   /projects/:id/merge_requests/:merge_request_iid/blocks (The example in the official document is wrong.)
GET    /projects/:id/merge_requests/:merge_request_iid/blocks
DELETE /projects/:id/merge_requests/:merge_request_iid/blocks/:block_id
GET    /projects/:id/merge_requests/:merge_request_iid/blockees
```

**Related**: GitLab Merge Request Dependencies  [API Documentation](https://docs.gitlab.com/api/merge_requests/#get-merge-request-dependenciesl)