### PR TITLE
Group: add parameters to show API call

### DIFF
--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -67,9 +67,16 @@ class Groups extends AbstractApi
         return $this->get('groups', $resolver->resolve($parameters));
     }
 
-    public function show(int|string $id): mixed
+    public function show(int|string $id, array $parameters = []): mixed
     {
-        return $this->get('groups/'.self::encodePath($id));
+        $resolver = $this->createOptionsResolver()
+            ->setDefined('with_custom_attributes')
+            ->setAllowedTypes('with_custom_attributes', 'bool')
+            ->setDefined('with_projects')
+            ->setAllowedTypes('with_projects', 'bool')
+        ;
+
+        return $this->get('groups/'.self::encodePath($id), $resolver->resolve($parameters));
     }
 
     public function create(string $name, string $path, ?string $description = null, string $visibility = 'private', ?bool $lfs_enabled = null, ?bool $request_access_enabled = null, ?int $parent_id = null, ?int $shared_runners_minutes_limit = null): mixed

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -126,6 +126,22 @@ class GroupsTest extends TestCase
     }
 
     #[Test]
+    public function shouldShowGroupWithAdditionalParameters(): void
+    {
+        $expectedArray = ['id' => 1, 'name' => 'A group'];
+        $parameters = ['with_custom_attributes' => false, 'with_projects' => false];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1', $parameters)
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->show(1, $parameters));
+    }
+
+    #[Test]
     public function shouldCreateGroup(): void
     {
         $expectedArray = ['id' => 1, 'name' => 'A new group'];


### PR DESCRIPTION
Add all parameters defined in the GitLab docs to the show group API call.
See docs: https://docs.gitlab.com/api/groups/#get-a-single-group