### PR TITLE
Add way to update a deploy key on a project.

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -591,6 +591,11 @@ class Projects extends AbstractApi
         return $this->post($this->getProjectPath($project_id, 'deploy_keys/'.self::encodePath($key_id).'/enable'));
     }
 
+    public function updateDeployKey(int|string $project_id, int $key_id, array $parameters): mixed
+    {
+        return $this->put($this->getProjectPath($project_id, 'deploy_keys/'.self::encodePath($key_id)), $parameters);
+    }
+
     public function deployTokens(int|string $project_id, ?bool $active = null): mixed
     {
         return $this->get($this->getProjectPath($project_id, 'deploy_tokens'), (null !== $active) ? ['active' => $active] : []);

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -1353,6 +1353,20 @@ class ProjectsTest extends TestCase
     }
 
     #[Test]
+    public function shouldUpdateDeployKey(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('projects/1/deploy_keys/3', ['title' => 'new-title', 'can_push' => true])
+            ->willReturn($expectedBool);
+
+        $this->assertEquals($expectedBool, $api->updateDeployKey(1, 3, ['title' => 'new-title', 'can_push' => true]));
+    }
+
+    #[Test]
     public function shouldGetDeployTokens(): void
     {
         $expectedArray = [


### PR DESCRIPTION
This pull request propose you to add a way to update a deploy key assigned to a project.

Current methods can be used to list, add, enable, disable or delete a deploy key, but no method was designed to update a deploy key, which makes sense when the deploy key is already created and one wants to change its name or grant access to push.

Related documentation: https://docs.gitlab.com/api/deploy_keys/#update-deploy-key