### PR TITLE
Handle project push rule REST API.

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -647,6 +647,130 @@ class Projects extends AbstractApi
         return $this->delete($this->getProjectPath($project_id, 'deploy_tokens/'.self::encodePath($token_id)));
     }
 
+    public function pushRule(int|string $project_id): mixed
+    {
+        return $this->get($this->getProjectPath($project_id, 'push_rule'));
+    }
+
+    public function createPushRule(int|string $project_id, array $parameters = []): mixed
+    {
+        $resolver = $this->createOptionsResolver();
+        $booleanNormalizer = function (Options $resolver, $value): string {
+            return $value ? 'true' : 'false';
+        };
+
+        $resolver->setDefined('author_email_regex')
+            ->setAllowedTypes('author_email_regex', 'string')
+        ;
+        $resolver->setDefined('branch_name_regex')
+            ->setAllowedTypes('branch_name_regex', 'string')
+        ;
+        $resolver->setDefined('commit_message_negative_regex')
+            ->setAllowedTypes('commit_message_negative_regex', 'string')
+        ;
+        $resolver->setDefined('commit_message_regex')
+            ->setAllowedTypes('commit_message_regex', 'string')
+        ;
+        $resolver->setDefined('deny_delete_tag')
+            ->setAllowedTypes('deny_delete_tag', 'bool')
+            ->setNormalizer('deny_delete_tag', $booleanNormalizer)
+        ;
+        $resolver->setDefined('file_name_regex')
+            ->setAllowedTypes('file_name_regex', 'string')
+        ;
+        $resolver->setDefined('max_file_size')
+            ->setAllowedTypes('max_file_size', 'string')
+        ;
+        $resolver->setDefined('member_check')
+            ->setAllowedTypes('member_check', 'bool')
+            ->setNormalizer('member_check', $booleanNormalizer)
+        ;
+        $resolver->setDefined('prevent_secrets')
+            ->setAllowedTypes('prevent_secrets', 'bool')
+            ->setNormalizer('prevent_secrets', $booleanNormalizer)
+        ;
+        $resolver->setDefined('commit_committer_check')
+            ->setAllowedTypes('commit_committer_check', 'bool')
+            ->setNormalizer('commit_committer_check', $booleanNormalizer)
+        ;
+        $resolver->setDefined('commit_committer_name_check')
+            ->setAllowedTypes('commit_committer_name_check', 'bool')
+            ->setNormalizer('commit_committer_name_check', $booleanNormalizer)
+        ;
+        $resolver->setDefined('reject_unsigned_commits')
+            ->setAllowedTypes('reject_unsigned_commits', 'bool')
+            ->setNormalizer('reject_unsigned_commits', $booleanNormalizer)
+        ;
+        $resolver->setDefined('reject_non_dco_commits')
+            ->setAllowedTypes('reject_non_dco_commits', 'bool')
+            ->setNormalizer('reject_non_dco_commits', $booleanNormalizer)
+        ;
+
+        return $this->post($this->getProjectPath($project_id, 'push_rule'), $resolver->resolve($parameters));
+    }
+
+    public function updatePushRule(int|string $project_id, array $parameters = []): mixed
+    {
+        $resolver = $this->createOptionsResolver();
+        $booleanNormalizer = function (Options $resolver, $value): string {
+            return $value ? 'true' : 'false';
+        };
+
+        $resolver->setDefined('author_email_regex')
+            ->setAllowedTypes('author_email_regex', 'string')
+        ;
+        $resolver->setDefined('branch_name_regex')
+            ->setAllowedTypes('branch_name_regex', 'string')
+        ;
+        $resolver->setDefined('commit_message_negative_regex')
+            ->setAllowedTypes('commit_message_negative_regex', 'string')
+        ;
+        $resolver->setDefined('commit_message_regex')
+            ->setAllowedTypes('commit_message_regex', 'string')
+        ;
+        $resolver->setDefined('deny_delete_tag')
+            ->setAllowedTypes('deny_delete_tag', 'bool')
+            ->setNormalizer('deny_delete_tag', $booleanNormalizer)
+        ;
+        $resolver->setDefined('file_name_regex')
+            ->setAllowedTypes('file_name_regex', 'string')
+        ;
+        $resolver->setDefined('max_file_size')
+            ->setAllowedTypes('max_file_size', 'string')
+        ;
+        $resolver->setDefined('member_check')
+            ->setAllowedTypes('member_check', 'bool')
+            ->setNormalizer('member_check', $booleanNormalizer)
+        ;
+        $resolver->setDefined('prevent_secrets')
+            ->setAllowedTypes('prevent_secrets', 'bool')
+            ->setNormalizer('prevent_secrets', $booleanNormalizer)
+        ;
+        $resolver->setDefined('commit_committer_check')
+            ->setAllowedTypes('commit_committer_check', 'bool')
+            ->setNormalizer('commit_committer_check', $booleanNormalizer)
+        ;
+        $resolver->setDefined('commit_committer_name_check')
+            ->setAllowedTypes('commit_committer_name_check', 'bool')
+            ->setNormalizer('commit_committer_name_check', $booleanNormalizer)
+        ;
+        $resolver->setDefined('reject_unsigned_commits')
+            ->setAllowedTypes('reject_unsigned_commits', 'bool')
+            ->setNormalizer('reject_unsigned_commits', $booleanNormalizer)
+        ;
+        $resolver->setDefined('reject_non_dco_commits')
+            ->setAllowedTypes('reject_non_dco_commits', 'bool')
+            ->setNormalizer('reject_non_dco_commits', $booleanNormalizer)
+        ;
+
+        return $this->put($this->getProjectPath($project_id, 'push_rule'), $resolver->resolve($parameters));
+    }
+
+    public function deletePushRule(int|string $project_id): mixed
+    {
+        return $this->delete($this->getProjectPath($project_id, 'push_rule'));
+    }
+
     /**
      * @param array      $parameters {
      *

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -1491,6 +1491,78 @@ class ProjectsTest extends TestCase
     }
 
     #[Test]
+    public function shouldGetPushRule(): void
+    {
+        $expectedArray = [
+            'id' => 1,
+            'project_id' => 3,
+            'commit_message_regex' => '.*',
+            'branch_name_regex' => '.*',
+            'author_email_regex' => '.*',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/3/push_rule')
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->pushRule(3));
+    }
+
+    #[Test]
+    public function shouldCreatePushRule(): void
+    {
+        $expectedBool = true;
+        $params = [
+            'commit_message_regex' => '.*',
+            'branch_name_regex' => '.*',
+            'author_email_regex' => '.*',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/3/push_rule', $params)
+            ->willReturn($expectedBool);
+
+        $this->assertEquals($expectedBool, $api->createPushRule(3, $params));
+    }
+
+    #[Test]
+    public function shouldUpdatePushRule(): void
+    {
+        $expectedBool = true;
+        $params = [
+            'commit_message_regex' => '.*',
+            'branch_name_regex' => '.*',
+            'author_email_regex' => '.*',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('projects/3/push_rule', $params)
+            ->willReturn($expectedBool);
+
+        $this->assertEquals($expectedBool, $api->updatePushRule(3, $params));
+    }
+
+    #[Test]
+    public function shouldDeletePushRule(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/3/push_rule')
+            ->willReturn($expectedBool);
+
+        $this->assertEquals($expectedBool, $api->deletePushRule(3));
+    }
+
+    #[Test]
     public function shouldGetEvents(): void
     {
         $expectedArray = [


### PR DESCRIPTION
This pull request propose you to add the missing REST API client proxy for project push rule.

Related documentation: https://docs.gitlab.com/api/project_push_rules/