### PR TITLE
Add support for listing merge requests associated with a commit

### DIFF
--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -185,6 +185,13 @@ class Repositories extends AbstractApi
         );
     }
 
+    public function commitMergeRequests(int|string $project_id, string $sha): mixed
+    {
+        return $this->get(
+            $this->getProjectPath($project_id, 'repository/commits/'.self::encodePath($sha).'/merge_requests'),
+        );
+    }
+
     /**
      * @param array      $parameters {
      *

--- a/tests/Api/RepositoriesTest.php
+++ b/tests/Api/RepositoriesTest.php
@@ -329,6 +329,24 @@ class RepositoriesTest extends TestCase
     }
 
     #[Test]
+    public function shouldGetCommitMergeRequests(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'title' => 'A merge request'],
+            ['id' => 2, 'title' => 'Another merge request'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/repository/commits/abcd1234/merge_requests')
+            ->will($this->returnValue($expectedArray))
+        ;
+
+        $this->assertEquals($expectedArray, $api->commitMergeRequests(1, 'abcd1234'));
+    }
+
+    #[Test]
     #[DataProvider('dataGetCommitRefsWithParams')]
     public function shouldGetCommitRefsWithParams(string $type, array $expectedArray): void
     {


### PR DESCRIPTION
Api specification: https://docs.gitlab.com/ee/api/commits.html#list-merge-requests-associated-with-a-commit