### PR TITLE
Add support for fetching remote mirror(s) for projects

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1280,4 +1280,14 @@ class Projects extends AbstractApi
 
         return $this->get('projects/'.self::encodePath($id).'/search', $resolver->resolve($parameters));
     }
+
+    public function remoteMirrors(int|string $project_id): mixed
+    {
+        return $this->get('projects/'.self::encodePath($project_id).'/remote_mirrors');
+    }
+
+    public function remoteMirror(int|string $project_id, int $mirror_id): mixed
+    {
+        return $this->get('projects/'.self::encodePath($project_id).'/remote_mirrors/'.self::encodePath($mirror_id));
+    }
 }


### PR DESCRIPTION
There is no way to fetch the remote mirror(s) for a project. This PR will add it. I based myself on the protected tags, that also didn't have a test for it.

API specs: https://docs.gitlab.com/api/remote_mirrors/#list-a-projects-remote-mirrors