### PR TITLE
Added more options for deployments endpoint

### DIFF
--- a/src/Api/Deployments.php
+++ b/src/Api/Deployments.php
@@ -14,12 +14,14 @@ declare(strict_types=1);
 
 namespace Gitlab\Api;
 
+use Symfony\Component\OptionsResolver\Options;
+
 class Deployments extends AbstractApi
 {
     /**
      * @param array      $parameters {
      *
-     *     @var string $order_by                    Return deployments ordered by id, iid, created_at, updated_at,
+     *     @var string $order_by                    Return deployments ordered by id, iid, created_at, updated_at, finished_at,
      *                                              or ref fields (default is id)
      *     @var string $sort                        Return deployments sorted in asc or desc order (default is desc)
      *     @var string $status                      Return deployments filtered by status of deployment allowed
@@ -31,17 +33,51 @@ class Deployments extends AbstractApi
     public function all(int|string $project_id, array $parameters = []): mixed
     {
         $resolver = $this->createOptionsResolver();
+
+        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
+            $utc = (new \DateTimeImmutable($value->format(\DateTimeImmutable::RFC3339_EXTENDED)))->setTimezone(new \DateTimeZone('UTC'));
+
+            return $utc->format('Y-m-d\TH:i:s.v\Z');
+        };
+
         $resolver->setDefined('order_by')
             ->setAllowedTypes('order_by', 'string')
-            ->setAllowedValues('order_by', ['id', 'iid', 'created_at', 'updated_at', 'ref']);
+            ->setAllowedValues('order_by', ['id', 'iid', 'created_at', 'updated_at', 'finished_at', 'ref'])
+        ;
+
         $resolver->setDefined('sort')
             ->setAllowedTypes('sort', 'string')
-            ->setAllowedValues('sort', ['desc', 'asc']);
+            ->setAllowedValues('sort', ['asc', 'desc'])
+        ;
+
+        $resolver->setDefined('updated_after')
+            ->setAllowedTypes('updated_after', \DateTimeInterface::class)
+            ->setNormalizer('updated_after', $datetimeNormalizer)
+        ;
+
+        $resolver->setDefined('updated_before')
+            ->setAllowedTypes('updated_before', \DateTimeInterface::class)
+            ->setNormalizer('updated_before', $datetimeNormalizer)
+        ;
+
+        $resolver->setDefined('finished_after')
+            ->setAllowedTypes('finished_after', \DateTimeInterface::class)
+            ->setNormalizer('finished_after', $datetimeNormalizer)
+        ;
+
+        $resolver->setDefined('finished_before')
+            ->setAllowedTypes('finished_before', \DateTimeInterface::class)
+            ->setNormalizer('finished_before', $datetimeNormalizer)
+        ;
+
+        $resolver->setDefined('environment')
+            ->setAllowedTypes('environment', 'string')
+        ;
+
         $resolver->setDefined('status')
             ->setAllowedTypes('status', 'string')
-            ->setAllowedValues('status', ['created', 'running', 'success', 'failed', 'canceled', 'blocked']);
-        $resolver->setDefined('environment')
-            ->setAllowedTypes('environment', 'string');
+            ->setAllowedValues('status', ['created', 'running', 'success', 'failed', 'canceled', 'blocked'])
+        ;
 
         return $this->get($this->getProjectPath($project_id, 'deployments'), $resolver->resolve($parameters));
     }

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -968,7 +968,9 @@ class Projects extends AbstractApi
         $resolver = $this->createOptionsResolver();
 
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
-            return $value->format('c');
+            $utc = (new \DateTimeImmutable($value->format(\DateTimeImmutable::RFC3339_EXTENDED)))->setTimezone(new \DateTimeZone('UTC'));
+
+            return $utc->format('Y-m-d\TH:i:s.v\Z');
         };
 
         $resolver->setDefined('order_by')

--- a/tests/Api/DeploymentsTest.php
+++ b/tests/Api/DeploymentsTest.php
@@ -323,4 +323,25 @@ See merge request !2',
         $this->assertEquals([], $api->all(1, ['environment' => 'test'])
         );
     }
+
+    #[Test]
+    public function shouldAllowFilterByUpdateAfter(): void
+    {
+        $expectedArray = $this->getMultipleDeploymentsData();
+
+        $dateTime = new \DateTime();
+        $utc = (new \DateTimeImmutable($dateTime->format(\DateTimeImmutable::RFC3339_EXTENDED)))
+            ->setTimezone(new \DateTimeZone('UTC'));
+
+        $api = $this->getMultipleDeploymentsRequestMock(
+            'projects/1/deployments',
+            $expectedArray,
+            ['updated_after' => $utc->format('Y-m-d\TH:i:s.v\Z')]
+        );
+
+        $this->assertEquals(
+            $expectedArray,
+            $api->all(1, ['updated_after' => $dateTime])
+        );
+    }
 }

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2225,17 +2225,19 @@ class ProjectsTest extends TestCase
             ['id' => 3, 'sha' => '0000003'],
         ];
 
-        $time = new DateTime('now');
+        $dateTime = new DateTime();
+        $utc = (new \DateTimeImmutable($dateTime->format(\DateTimeImmutable::RFC3339_EXTENDED)))
+                ->setTimezone(new \DateTimeZone('UTC'));
 
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
             ->with('projects/1/deployments', [
-                'updated_after' => $time->format('c'),
+                'updated_after' => $utc->format('Y-m-d\TH:i:s.v\Z')
             ])
             ->willReturn($expectedArray);
 
-        $this->assertEquals($expectedArray, $api->deployments(1, ['updated_after' => $time]));
+        $this->assertEquals($expectedArray, $api->deployments(1, ['updated_after' => $dateTime]));
     }
 
     protected function getMultipleProjectsData(): array

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2233,7 +2233,7 @@ class ProjectsTest extends TestCase
         $api->expects($this->once())
             ->method('get')
             ->with('projects/1/deployments', [
-                'updated_after' => $utc->format('Y-m-d\TH:i:s.v\Z')
+                'updated_after' => $utc->format('Y-m-d\TH:i:s.v\Z'),
             ])
             ->willReturn($expectedArray);
 


### PR DESCRIPTION
As per the docs: https://docs.gitlab.com/api/deployments/#list-project-deployments
I have added the following options for filtering:

- `updated_after`
- `updated_before`
- `finished_after`
- `finished_before`

I have also added the sort mode `finished_at` which needs to be set when filtering by `finished_after` and `finished_before`

When looking at the existing test I noticed the tests for project deployments was formatting the date incorrectly. I have updated this and updated the tests.