### PR TITLE
[12.1] Add permanent removal and restore functionality for projects

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -194,9 +194,21 @@ class Projects extends AbstractApi
         return $this->put('projects/'.self::encodePath($project_id), $parameters);
     }
 
-    public function remove(int|string $project_id): mixed
+    public function remove(int|string $project_id, bool $permanent = false, string $fullPath = ""): mixed
     {
-        return $this->delete('projects/'.self::encodePath($project_id));
+        $params = [];
+        if ($permanent) {
+            $params = [
+                'permanently_remove' => true,
+                'full_path' => $fullPath
+            ];
+        }
+        return $this->delete('projects/'.self::encodePath($project_id), $params);
+    }
+
+    public function restore(int|string $project_id): mixed
+    {
+        return $this->post('projects/'.self::encodePath($project_id).'/restore');
     }
 
     public function archive(int|string $project_id): mixed

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -203,6 +203,7 @@ class Projects extends AbstractApi
                 'full_path' => $fullPath,
             ];
         }
+
         return $this->delete('projects/'.self::encodePath($project_id), $params);
     }
 

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -194,13 +194,13 @@ class Projects extends AbstractApi
         return $this->put('projects/'.self::encodePath($project_id), $parameters);
     }
 
-    public function remove(int|string $project_id, bool $permanent = false, string $fullPath = ""): mixed
+    public function remove(int|string $project_id, bool $permanent = false, string $fullPath = ''): mixed
     {
         $params = [];
         if ($permanent) {
             $params = [
                 'permanently_remove' => true,
-                'full_path' => $fullPath
+                'full_path' => $fullPath,
             ];
         }
         return $this->delete('projects/'.self::encodePath($project_id), $params);

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -194,17 +194,9 @@ class Projects extends AbstractApi
         return $this->put('projects/'.self::encodePath($project_id), $parameters);
     }
 
-    public function remove(int|string $project_id, bool $permanent = false, string $fullPath = ''): mixed
+    public function remove(int|string $project_id, array $parameters = []): mixed
     {
-        $params = [];
-        if ($permanent) {
-            $params = [
-                'permanently_remove' => true,
-                'full_path' => $fullPath,
-            ];
-        }
-
-        return $this->delete('projects/'.self::encodePath($project_id), $params);
+        return $this->delete('projects/'.self::encodePath($project_id), $parameters);
     }
 
     public function restore(int|string $project_id): mixed

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -346,6 +346,35 @@ class ProjectsTest extends TestCase
     }
 
     #[Test]
+    public function shouldRemoveProjectPermanently(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1', ['permanently_remove' => true, 'full_path' => 'full/path/to/project'])
+            ->willReturn(true);
+
+        $this->assertEquals($expectedBool, $api->remove(1, true, 'full/path/to/project'));
+
+    }
+
+    #[Test]
+    public function shouldRestoreDeletedProject(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/restore')
+            ->willReturn(true);
+
+        $this->assertEquals($expectedBool, $api->restore(1));
+    }
+
+    #[Test]
     public function shouldGetPipelines(): void
     {
         $expectedArray = [

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -357,7 +357,6 @@ class ProjectsTest extends TestCase
             ->willReturn(true);
 
         $this->assertEquals($expectedBool, $api->remove(1, true, 'full/path/to/project'));
-
     }
 
     #[Test]

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -356,7 +356,10 @@ class ProjectsTest extends TestCase
             ->with('projects/1', ['permanently_remove' => true, 'full_path' => 'full/path/to/project'])
             ->willReturn(true);
 
-        $this->assertEquals($expectedBool, $api->remove(1, true, 'full/path/to/project'));
+        $this->assertEquals($expectedBool, $api->remove(1, [
+            'permanently_remove' => true,
+            'full_path' => 'full/path/to/project',
+        ]));
     }
 
     #[Test]


### PR DESCRIPTION
Permanent project removal and restore was added to Gitlab Free in 18.0.