### PR TITLE
[12.1] Add missing award emoji methods to MergeRequests

### DIFF
--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -308,9 +308,29 @@ class MergeRequests extends AbstractApi
         return $this->get($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/award_emoji'));
     }
 
+    public function addAwardEmoji(int|string $project_id, int $mr_iid, string $name): mixed
+    {
+        return $this->post($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/award_emoji'), ['name' => $name]);
+    }
+
     public function removeAwardEmoji(int|string $project_id, int $mr_iid, int $award_id): mixed
     {
         return $this->delete($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/award_emoji/'.self::encodePath($award_id)));
+    }
+
+    public function showNoteAwardEmoji(int|string $project_id, int $mr_iid, int $note_id): mixed
+    {
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/notes/'.self::encodePath($note_id).'/award_emoji'));
+    }
+
+    public function addNoteAwardEmoji(int|string $project_id, int $mr_iid, int $note_id, string $name): mixed
+    {
+        return $this->post($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/notes/'.self::encodePath($note_id).'/award_emoji'), ['name' => $name]);
+    }
+
+    public function removeNoteAwardEmoji(int|string $project_id, int $mr_iid, int $note_id, int $award_id): mixed
+    {
+        return $this->delete($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/notes/'.self::encodePath($note_id).'/award_emoji/'.self::encodePath($award_id)));
     }
 
     public function rebase(int|string $project_id, int $mr_iid, array $params = []): mixed

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -583,6 +583,21 @@ class MergeRequestsTest extends TestCase
     }
 
     #[Test]
+    public function shouldAddMergeRequestAwardEmoji(): void
+    {
+        $expectedArray = ['id' => 1, 'name' => 'sparkles'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/merge_requests/2/award_emoji', ['name' => 'sparkles'])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->addAwardEmoji(1, 2, 'sparkles'));
+    }
+
+    #[Test]
     public function shouldRevokeMergeRequestAwardEmoji(): void
     {
         $expectedBool = true;
@@ -594,6 +609,53 @@ class MergeRequestsTest extends TestCase
             ->willReturn($expectedBool);
 
         $this->assertEquals(true, $api->removeAwardEmoji(1, 2, 3));
+    }
+
+    #[Test]
+    public function shouldShowMergeRequestNoteAwardEmoji(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'sparkles'],
+            ['id' => 2, 'name' => 'heart_eyes'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/merge_requests/2/notes/3/award_emoji')
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->showNoteAwardEmoji(1, 2, 3));
+    }
+
+    #[Test]
+    public function shouldAddMergeRequestNoteAwardEmoji(): void
+    {
+        $expectedArray = ['id' => 1, 'name' => 'sparkles'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/merge_requests/2/notes/3/award_emoji', ['name' => 'sparkles'])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->addNoteAwardEmoji(1, 2, 3, 'sparkles'));
+    }
+
+    #[Test]
+    public function shouldRevokeMergeRequestNoteAwardEmoji(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/merge_requests/2/notes/3/award_emoji/4')
+            ->willReturn($expectedBool);
+
+        $this->assertEquals(true, $api->removeNoteAwardEmoji(1, 2, 3, 4));
     }
 
     #[Test]


### PR DESCRIPTION
Adds the missing `award_emoji` write/read endpoints to
`Gitlab\Api\MergeRequests` — both for the merge request itself
and for its notes:

| Method                   | Verb   | Path                                                         |
|--------------------------|--------|--------------------------------------------------------------|
| `addAwardEmoji()`        | POST   | `.../merge_requests/:iid/award_emoji`                        |
| `showNoteAwardEmoji()`   | GET    | `.../merge_requests/:iid/notes/:note_id/award_emoji`         |
| `addNoteAwardEmoji()`    | POST   | `.../merge_requests/:iid/notes/:note_id/award_emoji`         |
| `removeNoteAwardEmoji()` | DELETE | `.../merge_requests/:iid/notes/:note_id/award_emoji/:award_id` |

Existing `awardEmoji()` (GET list) and `removeAwardEmoji()` (DELETE)
already covered the read/remove side for the MR itself, but there
was no way to actually add an emoji — and nothing at all for notes.

Naming follows the existing conventions on this class:
- `show*` for single-resource reads (`showNote()`, `showDiscussion()`)
- `add*` / `remove*` for writes (`addNote()`, `removeNote()`)

GitLab uses a flat `/notes/:note_id/award_emoji` path, so the note
methods also cover reactions on discussion thread comments —
callers just pass the `note_id` of the discussion note.

Reference: https://docs.gitlab.com/api/emoji_reactions/

Resurrects #794 (closed as stale after a request for test coverage);
this PR adds the missing tests and `removeNoteAwardEmoji()` for
symmetry.
