### PR TITLE
[12.1] Add Symfony OptionsResolver 8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [12.1.0] - UPCOMING
 
 * Add PHP 8.5 support
+* Add support for `symfony/options-resolver:^8.0`
 
 
 ## [12.0.0] - 2025-02-23

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
         "psr/http-message": "^1.1 || ^2.0",
-        "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0"
+        "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",


### PR DESCRIPTION
Adds support for `symfony/options-resolver:^8.0` and updates the changelog.