### PR TITLE
[12.1] Add visibility filter to groups API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add PHP 8.5 support
 * Add support for `symfony/options-resolver:^8.0`
+* Add support for `visibility` in `Groups::all`
 
 
 ## [12.0.0] - 2025-02-23

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -58,6 +58,7 @@ class Groups extends AbstractApi
      *     @var bool   $owned            limit by groups owned by the current user
      *     @var int    $min_access_level limit by groups in which the current user has at least this access level
      *     @var bool   $top_level_only   limit to top level groups, excluding all subgroups
+     *     @var string $visibility       limit by visibility public, internal, or private
      * }
      */
     public function all(array $parameters = []): mixed
@@ -708,6 +709,9 @@ class Groups extends AbstractApi
         $resolver->setDefined('top_level_only')
             ->setAllowedTypes('top_level_only', 'bool')
             ->setNormalizer('top_level_only', $booleanNormalizer)
+        ;
+        $resolver->setDefined('visibility')
+            ->setAllowedValues('visibility', ['public', 'internal', 'private'])
         ;
 
         return $resolver;

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -75,6 +75,24 @@ class GroupsTest extends TestCase
     }
 
     #[Test]
+    public function shouldGetAllGroupsWithVisibilityParam(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'A group'],
+            ['id' => 2, 'name' => 'Another group'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups', ['visibility' => 'public'])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->all(['visibility' => 'public']));
+    }
+
+    #[Test]
     public function shouldGetAllGroupProjectsWithBooleanParam(): void
     {
         $expectedArray = [


### PR DESCRIPTION
Adds support for the `visibility` filter in `Groups::all`, with PHPDoc, test coverage, and changelog updates. Replaces #824.