### PR TITLE
[12.1] Add personal access tokens API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add PHP 8.5 support
 * Add support for `symfony/options-resolver:^8.0`
 * Add support for `visibility` in `Groups::all`
+* Add support for personal access tokens
 
 
 ## [12.0.0] - 2025-02-23

--- a/src/Api/PersonalAccessTokens.php
+++ b/src/Api/PersonalAccessTokens.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Api;
+
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PersonalAccessTokens extends AbstractApi
+{
+    /**
+     * @param array $parameters {
+     *
+     *     @var string             $search            search text
+     *     @var string             $state             state of the token
+     *     @var int|string         $user_id           tokens belonging to the given user
+     *     @var bool               $revoked           whether the token is revoked or not
+     *     @var \DateTimeInterface $created_after     return tokens created after the given time
+     *     @var \DateTimeInterface $created_before    return tokens created before the given time
+     *     @var \DateTimeInterface $expires_after     return tokens that expire after the given date
+     *     @var \DateTimeInterface $expires_before    return tokens that expire before the given date
+     *     @var \DateTimeInterface $last_used_after   return tokens last used after the given time
+     *     @var \DateTimeInterface $last_used_before  return tokens last used before the given time
+     *     @var string             $sort              sort by created, expires, last_used, or name
+     * }
+     */
+    public function all(array $parameters = []): mixed
+    {
+        $resolver = $this->createOptionsResolver();
+        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
+            return $value->format('c');
+        };
+        $dateNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
+            return $value->format('Y-m-d');
+        };
+        $booleanNormalizer = function (Options $resolver, $value): string {
+            return $value ? 'true' : 'false';
+        };
+
+        $resolver->setDefined('search')
+            ->setAllowedTypes('search', 'string')
+        ;
+        $resolver->setDefined('state')
+            ->setAllowedValues('state', ['active', 'inactive'])
+        ;
+        $resolver->setDefined('user_id')
+            ->setAllowedTypes('user_id', ['int', 'string'])
+            ->setAllowedValues('user_id', function ($value): bool {
+                return \is_int($value) ? $value > 0 : '' !== $value;
+            })
+        ;
+        $resolver->setDefined('revoked')
+            ->setAllowedTypes('revoked', 'bool')
+            ->setNormalizer('revoked', $booleanNormalizer)
+        ;
+        $resolver->setDefined('created_after')
+            ->setAllowedTypes('created_after', \DateTimeInterface::class)
+            ->setNormalizer('created_after', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('created_before')
+            ->setAllowedTypes('created_before', \DateTimeInterface::class)
+            ->setNormalizer('created_before', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('expires_after')
+            ->setAllowedTypes('expires_after', \DateTimeInterface::class)
+            ->setNormalizer('expires_after', $dateNormalizer)
+        ;
+        $resolver->setDefined('expires_before')
+            ->setAllowedTypes('expires_before', \DateTimeInterface::class)
+            ->setNormalizer('expires_before', $dateNormalizer)
+        ;
+        $resolver->setDefined('last_used_after')
+            ->setAllowedTypes('last_used_after', \DateTimeInterface::class)
+            ->setNormalizer('last_used_after', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('last_used_before')
+            ->setAllowedTypes('last_used_before', \DateTimeInterface::class)
+            ->setNormalizer('last_used_before', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['created_asc', 'created_desc', 'expires_asc', 'expires_desc', 'last_used_asc', 'last_used_desc', 'name_asc', 'name_desc'])
+        ;
+
+        return $this->get('personal_access_tokens', $resolver->resolve($parameters));
+    }
+
+    public function show(int|string $id): mixed
+    {
+        return $this->get('personal_access_tokens/'.self::encodePath($id));
+    }
+
+    public function current(): mixed
+    {
+        return $this->get('personal_access_tokens/self');
+    }
+
+    /**
+     * @param array $parameters {
+     *
+     *     @var \DateTimeInterface $expires_at expiration date of the access token
+     * }
+     */
+    public function rotate(int|string $id, array $parameters = []): mixed
+    {
+        $resolver = new OptionsResolver();
+        $dateNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
+            return $value->format('Y-m-d');
+        };
+        $resolver->setDefined('expires_at')
+            ->setAllowedTypes('expires_at', \DateTimeInterface::class)
+            ->setNormalizer('expires_at', $dateNormalizer)
+        ;
+
+        return $this->post('personal_access_tokens/'.self::encodePath($id).'/rotate', $resolver->resolve($parameters));
+    }
+
+    /**
+     * @param array $parameters {
+     *
+     *     @var \DateTimeInterface $expires_at expiration date of the access token
+     * }
+     */
+    public function rotateCurrent(array $parameters = []): mixed
+    {
+        $resolver = new OptionsResolver();
+        $dateNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
+            return $value->format('Y-m-d');
+        };
+        $resolver->setDefined('expires_at')
+            ->setAllowedTypes('expires_at', \DateTimeInterface::class)
+            ->setNormalizer('expires_at', $dateNormalizer)
+        ;
+
+        return $this->post('personal_access_tokens/self/rotate', $resolver->resolve($parameters));
+    }
+
+    public function remove(int|string $id): mixed
+    {
+        return $this->delete('personal_access_tokens/'.self::encodePath($id));
+    }
+
+    public function removeCurrent(): mixed
+    {
+        return $this->delete('personal_access_tokens/self');
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -30,6 +30,7 @@ use Gitlab\Api\Jobs;
 use Gitlab\Api\Keys;
 use Gitlab\Api\MergeRequests;
 use Gitlab\Api\Milestones;
+use Gitlab\Api\PersonalAccessTokens;
 use Gitlab\Api\ProjectNamespaces;
 use Gitlab\Api\Projects;
 use Gitlab\Api\Repositories;
@@ -233,6 +234,11 @@ class Client
     public function milestones(): Milestones
     {
         return new Milestones($this);
+    }
+
+    public function personalAccessTokens(): PersonalAccessTokens
+    {
+        return new PersonalAccessTokens($this);
     }
 
     public function namespaces(): ProjectNamespaces

--- a/tests/Api/PersonalAccessTokensTest.php
+++ b/tests/Api/PersonalAccessTokensTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Tests\Api;
+
+use Gitlab\Api\PersonalAccessTokens;
+use PHPUnit\Framework\Attributes\Test;
+
+class PersonalAccessTokensTest extends TestCase
+{
+    #[Test]
+    public function shouldGetAllTokens(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'Token 1', 'state' => 'active'],
+            ['id' => 2, 'name' => 'Token 2', 'state' => 'inactive'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('personal_access_tokens', [])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->all());
+    }
+
+    #[Test]
+    public function shouldGetAllTokensWithFilters(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'Token 1', 'state' => 'active'],
+        ];
+        $createdAfter = new \DateTimeImmutable('2025-01-01 00:00:00');
+        $createdBefore = new \DateTimeImmutable('2025-02-01 00:00:00');
+        $expiresAfter = new \DateTimeImmutable('2025-03-01 00:00:00');
+        $expiresBefore = new \DateTimeImmutable('2025-04-01 00:00:00');
+        $lastUsedAfter = new \DateTimeImmutable('2025-05-01 00:00:00');
+        $lastUsedBefore = new \DateTimeImmutable('2025-06-01 00:00:00');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('personal_access_tokens', [
+                'search' => 'Token',
+                'state' => 'active',
+                'user_id' => 1,
+                'revoked' => 'false',
+                'created_after' => $createdAfter->format('c'),
+                'created_before' => $createdBefore->format('c'),
+                'expires_after' => $expiresAfter->format('Y-m-d'),
+                'expires_before' => $expiresBefore->format('Y-m-d'),
+                'last_used_after' => $lastUsedAfter->format('c'),
+                'last_used_before' => $lastUsedBefore->format('c'),
+                'sort' => 'name_desc',
+                'page' => 1,
+                'per_page' => 10,
+            ])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->all([
+            'search' => 'Token',
+            'state' => 'active',
+            'user_id' => 1,
+            'revoked' => false,
+            'created_after' => $createdAfter,
+            'created_before' => $createdBefore,
+            'expires_after' => $expiresAfter,
+            'expires_before' => $expiresBefore,
+            'last_used_after' => $lastUsedAfter,
+            'last_used_before' => $lastUsedBefore,
+            'sort' => 'name_desc',
+            'page' => 1,
+            'per_page' => 10,
+        ]));
+    }
+
+    #[Test]
+    public function shouldShowToken(): void
+    {
+        $expectedArray = ['id' => 1, 'name' => 'Token 1', 'state' => 'active'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('personal_access_tokens/1')
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->show(1));
+    }
+
+    #[Test]
+    public function shouldShowCurrentToken(): void
+    {
+        $expectedArray = ['id' => 1, 'name' => 'Token 1', 'state' => 'active'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('personal_access_tokens/self')
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->current());
+    }
+
+    #[Test]
+    public function shouldRotateToken(): void
+    {
+        $expectedArray = ['id' => 4, 'name' => 'Token 4'];
+        $expiresAt = new \DateTimeImmutable('2025-07-01 00:00:00');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('personal_access_tokens/3/rotate', ['expires_at' => $expiresAt->format('Y-m-d')])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->rotate(3, ['expires_at' => $expiresAt]));
+    }
+
+    #[Test]
+    public function shouldRotateCurrentToken(): void
+    {
+        $expectedArray = ['id' => 4, 'name' => 'Token 4'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('personal_access_tokens/self/rotate', [])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->rotateCurrent());
+    }
+
+    #[Test]
+    public function shouldRemoveToken(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('personal_access_tokens/1')
+            ->willReturn($expectedBool)
+        ;
+
+        $this->assertEquals($expectedBool, $api->remove(1));
+    }
+
+    #[Test]
+    public function shouldRemoveCurrentToken(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('personal_access_tokens/self')
+            ->willReturn($expectedBool)
+        ;
+
+        $this->assertEquals($expectedBool, $api->removeCurrent());
+    }
+
+    protected function getApiClass(): string
+    {
+        return PersonalAccessTokens::class;
+    }
+}


### PR DESCRIPTION
Adds a PersonalAccessTokens API for listing, retrieving, rotating, and revoking personal access tokens, with a client accessor, tests, and a changelog entry. Replaces #827.