### PR TITLE
[12.1] Add Jobs play parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for `symfony/options-resolver:^8.0`
 * Add support for `visibility` in `Groups::all`
 * Add support for personal access tokens
+* Add support for `job_inputs` and `job_variables_attributes` in `Jobs::play`
 
 
 ## [12.0.0] - 2025-02-23

--- a/src/Api/Jobs.php
+++ b/src/Api/Jobs.php
@@ -162,9 +162,37 @@ class Jobs extends AbstractApi
         return $this->post('projects/'.self::encodePath($project_id).'/jobs/'.self::encodePath($job_id).'/artifacts/keep');
     }
 
-    public function play(int|string $project_id, int $job_id): mixed
+    /**
+     * @param array $parameters {
+     *
+     *     @var array $job_inputs               job input values to use when playing the job
+     *     @var array $job_variables_attributes custom variables available to the job
+     * }
+     */
+    public function play(int|string $project_id, int $job_id, array $parameters = []): mixed
     {
-        return $this->post('projects/'.self::encodePath($project_id).'/jobs/'.self::encodePath($job_id).'/play');
+        $resolver = new OptionsResolver();
+        $resolver->setDefined('job_inputs')
+            ->setAllowedTypes('job_inputs', 'array')
+        ;
+        $resolver->setDefined('job_variables_attributes')
+            ->setAllowedTypes('job_variables_attributes', 'array')
+            ->setAllowedValues('job_variables_attributes', function (array $variables): bool {
+                foreach ($variables as $variable) {
+                    if (!\is_array($variable) || !isset($variable['key'], $variable['value'])) {
+                        return false;
+                    }
+
+                    if (!\is_string($variable['key']) || !\is_string($variable['value'])) {
+                        return false;
+                    }
+                }
+
+                return true;
+            })
+        ;
+
+        return $this->post('projects/'.self::encodePath($project_id).'/jobs/'.self::encodePath($job_id).'/play', $resolver->resolve($parameters));
     }
 
     protected function createOptionsResolver(): OptionsResolver

--- a/tests/Api/JobsTest.php
+++ b/tests/Api/JobsTest.php
@@ -258,11 +258,41 @@ class JobsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('post')
-            ->with('projects/1/jobs/3/play')
+            ->with('projects/1/jobs/3/play', [])
             ->willReturn($expectedArray)
         ;
 
         $this->assertEquals($expectedArray, $api->play(1, 3));
+    }
+
+    #[Test]
+    public function shouldPlayWithParameters(): void
+    {
+        $expectedArray = ['id' => 3, 'name' => 'A job'];
+        $parameters = [
+            'job_inputs' => [
+                'environment' => 'staging',
+            ],
+            'job_variables_attributes' => [
+                [
+                    'key' => 'TEST_VAR_1',
+                    'value' => 'test1',
+                ],
+                [
+                    'key' => 'TEST_VAR_2',
+                    'value' => 'test2',
+                ],
+            ],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/jobs/3/play', $parameters)
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->play(1, 3, $parameters));
     }
 
     protected function getApiClass(): string


### PR DESCRIPTION
Adds support for `job_inputs` and `job_variables_attributes` in `Jobs::play`, matching the GitLab Jobs API documentation. Replaces #802.