### PR TITLE
[12.1] Add project access token filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for `visibility` in `Groups::all`
 * Add support for personal access tokens
 * Add support for `job_inputs` and `job_variables_attributes` in `Jobs::play`
+* Add support for filters in `Projects::projectAccessTokens`
 
 
 ## [12.0.0] - 2025-02-23

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1126,9 +1126,73 @@ class Projects extends AbstractApi
         return $this->delete($this->getProjectPath($project_id, 'repository/merged_branches'));
     }
 
-    public function projectAccessTokens(int|string $project_id): mixed
+    /**
+     * @param array $parameters {
+     *
+     *     @var string             $search             search text
+     *     @var string             $state              state of the token
+     *     @var bool               $revoked            whether the token is revoked or not
+     *     @var \DateTimeInterface $created_after      return tokens created after the given time
+     *     @var \DateTimeInterface $created_before     return tokens created before the given time
+     *     @var \DateTimeInterface $expires_after      return tokens that expire after the given date
+     *     @var \DateTimeInterface $expires_before     return tokens that expire before the given date
+     *     @var \DateTimeInterface $last_used_after    return tokens last used after the given time
+     *     @var \DateTimeInterface $last_used_before   return tokens last used before the given time
+     *     @var string             $sort               sort by created, expires, last_used, or name
+     * }
+     */
+    public function projectAccessTokens(int|string $project_id, array $parameters = []): mixed
     {
-        return $this->get($this->getProjectPath($project_id, 'access_tokens'));
+        $resolver = $this->createOptionsResolver();
+        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
+            return $value->format('c');
+        };
+        $dateNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
+            return $value->format('Y-m-d');
+        };
+        $booleanNormalizer = function (Options $resolver, $value): string {
+            return $value ? 'true' : 'false';
+        };
+
+        $resolver->setDefined('search')
+            ->setAllowedTypes('search', 'string')
+        ;
+        $resolver->setDefined('state')
+            ->setAllowedValues('state', ['active', 'inactive'])
+        ;
+        $resolver->setDefined('revoked')
+            ->setAllowedTypes('revoked', 'bool')
+            ->setNormalizer('revoked', $booleanNormalizer)
+        ;
+        $resolver->setDefined('created_after')
+            ->setAllowedTypes('created_after', \DateTimeInterface::class)
+            ->setNormalizer('created_after', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('created_before')
+            ->setAllowedTypes('created_before', \DateTimeInterface::class)
+            ->setNormalizer('created_before', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('expires_after')
+            ->setAllowedTypes('expires_after', \DateTimeInterface::class)
+            ->setNormalizer('expires_after', $dateNormalizer)
+        ;
+        $resolver->setDefined('expires_before')
+            ->setAllowedTypes('expires_before', \DateTimeInterface::class)
+            ->setNormalizer('expires_before', $dateNormalizer)
+        ;
+        $resolver->setDefined('last_used_after')
+            ->setAllowedTypes('last_used_after', \DateTimeInterface::class)
+            ->setNormalizer('last_used_after', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('last_used_before')
+            ->setAllowedTypes('last_used_before', \DateTimeInterface::class)
+            ->setNormalizer('last_used_before', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('sort')
+            ->setAllowedValues('sort', ['created_asc', 'created_desc', 'expires_asc', 'expires_desc', 'last_used_asc', 'last_used_desc', 'name_asc', 'name_desc'])
+        ;
+
+        return $this->get($this->getProjectPath($project_id, 'access_tokens'), $resolver->resolve($parameters));
     }
 
     public function projectAccessToken(int|string $project_id, int|string $token_id): mixed

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2586,10 +2586,69 @@ class ProjectsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/access_tokens')
+            ->with('projects/1/access_tokens', [])
             ->willReturn($expectedArray);
 
         $this->assertEquals($expectedArray, $api->projectAccessTokens(1));
+    }
+
+    #[Test]
+    public function shouldGetProjectAccessTokensWithFilters(): void
+    {
+        $expectedArray = [
+            [
+                'user_id' => 141,
+                'scopes' => [
+                    'api',
+                ],
+                'name' => 'token',
+                'expires_at' => '2021-01-31',
+                'id' => 42,
+                'active' => true,
+                'created_at' => '2021-01-20T22:11:48.151Z',
+                'revoked' => false,
+            ],
+        ];
+        $createdAfter = new DateTime('2025-01-01 00:00:00');
+        $createdBefore = new DateTime('2025-02-01 00:00:00');
+        $expiresAfter = new DateTime('2025-03-01 00:00:00');
+        $expiresBefore = new DateTime('2025-04-01 00:00:00');
+        $lastUsedAfter = new DateTime('2025-05-01 00:00:00');
+        $lastUsedBefore = new DateTime('2025-06-01 00:00:00');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/access_tokens', [
+                'search' => 'token',
+                'state' => 'active',
+                'revoked' => 'false',
+                'created_after' => $createdAfter->format('c'),
+                'created_before' => $createdBefore->format('c'),
+                'expires_after' => $expiresAfter->format('Y-m-d'),
+                'expires_before' => $expiresBefore->format('Y-m-d'),
+                'last_used_after' => $lastUsedAfter->format('c'),
+                'last_used_before' => $lastUsedBefore->format('c'),
+                'sort' => 'name_desc',
+                'page' => 1,
+                'per_page' => 10,
+            ])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->projectAccessTokens(1, [
+            'search' => 'token',
+            'state' => 'active',
+            'revoked' => false,
+            'created_after' => $createdAfter,
+            'created_before' => $createdBefore,
+            'expires_after' => $expiresAfter,
+            'expires_before' => $expiresBefore,
+            'last_used_after' => $lastUsedAfter,
+            'last_used_before' => $lastUsedBefore,
+            'sort' => 'name_desc',
+            'page' => 1,
+            'per_page' => 10,
+        ]));
     }
 
     #[Test]


### PR DESCRIPTION
Adds documented list filters to `Projects::projectAccessTokens`, with resolver validation, PHPDoc, test coverage, and a changelog entry. Replaces #830.