### PR TITLE
[12.1] Add commit merge request listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for personal access tokens
 * Add support for `job_inputs` and `job_variables_attributes` in `Jobs::play`
 * Add support for filters in `Projects::projectAccessTokens`
+* Add support for listing merge requests associated with a commit
 
 
 ## [12.0.0] - 2025-02-23

--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -186,6 +186,25 @@ class Repositories extends AbstractApi
     }
 
     /**
+     * @param array $parameters {
+     *
+     *     @var string $state Returns merge requests with the specified state: opened, closed, locked, or merged.
+     * }
+     */
+    public function commitMergeRequests(int|string $project_id, string $sha, array $parameters = []): mixed
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefined('state')
+            ->setAllowedValues('state', ['opened', 'closed', 'locked', 'merged'])
+        ;
+
+        return $this->get(
+            $this->getProjectPath($project_id, 'repository/commits/'.self::encodePath($sha).'/merge_requests'),
+            $resolver->resolve($parameters)
+        );
+    }
+
+    /**
      * @param array      $parameters {
      *
      *     @var string $branch         Name of the branch to commit into. To create a new branch, also provide start_branch.

--- a/tests/Api/RepositoriesTest.php
+++ b/tests/Api/RepositoriesTest.php
@@ -329,6 +329,41 @@ class RepositoriesTest extends TestCase
     }
 
     #[Test]
+    public function shouldGetCommitMergeRequests(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'title' => 'A merge request'],
+            ['id' => 2, 'title' => 'Another merge request'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/repository/commits/abcd1234/merge_requests', [])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->commitMergeRequests(1, 'abcd1234'));
+    }
+
+    #[Test]
+    public function shouldGetCommitMergeRequestsWithState(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'title' => 'A merge request', 'state' => 'opened'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/repository/commits/abcd1234/merge_requests', ['state' => 'opened'])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->commitMergeRequests(1, 'abcd1234', ['state' => 'opened']));
+    }
+
+    #[Test]
     #[DataProvider('dataGetCommitRefsWithParams')]
     public function shouldGetCommitRefsWithParams(string $type, array $expectedArray): void
     {


### PR DESCRIPTION
Adds `Repositories::commitMergeRequests` with the documented `state` filter. Replaces #843.