### PR TITLE
[12.1] Add without project bots user filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for `job_inputs` and `job_variables_attributes` in `Jobs::play`
 * Add support for filters in `Projects::projectAccessTokens`
 * Add support for listing merge requests associated with a commit
+* Add support for `without_project_bots` in `Users::all`
 
 
 ## [12.0.0] - 2025-02-23

--- a/src/Api/Users.php
+++ b/src/Api/Users.php
@@ -21,15 +21,16 @@ class Users extends AbstractApi
     /**
      * @param array $parameters {
      *
-     *     @var string             $search         search for user by email or username
-     *     @var string             $username       lookup for user by username
-     *     @var bool               $external       search for external users only
-     *     @var string             $extern_uid     lookup for users by external uid
-     *     @var string             $provider       lookup for users by provider
-     *     @var \DateTimeInterface $created_before return users created before the given time (inclusive)
-     *     @var \DateTimeInterface $created_after  return users created after the given time (inclusive)
-     *     @var bool               $active         Return only active users. It does not support filtering inactive users.
-     *     @var bool               $blocked        Return only blocked users. It does not support filtering non-blocked users.
+     *     @var string             $search               search for user by email or username
+     *     @var string             $username             lookup for user by username
+     *     @var bool               $external             search for external users only
+     *     @var string             $extern_uid           lookup for users by external uid
+     *     @var string             $provider             lookup for users by provider
+     *     @var \DateTimeInterface $created_before       return users created before the given time (inclusive)
+     *     @var \DateTimeInterface $created_after        return users created after the given time (inclusive)
+     *     @var bool               $active               Return only active users. It does not support filtering inactive users.
+     *     @var bool               $blocked              Return only blocked users. It does not support filtering non-blocked users.
+     *     @var bool               $without_project_bots Exclude project and group bot users.
      * }
      */
     public function all(array $parameters = []): mixed
@@ -61,6 +62,10 @@ class Users extends AbstractApi
         $resolver->setDefined('blocked')
             ->setAllowedTypes('blocked', 'bool')
             ->setAllowedValues('blocked', true)
+        ;
+        $resolver->setDefined('without_project_bots')
+            ->setAllowedTypes('without_project_bots', 'bool')
+            ->setAllowedValues('without_project_bots', true)
         ;
 
         return $this->get('users', $resolver->resolve($parameters));

--- a/tests/Api/UsersTest.php
+++ b/tests/Api/UsersTest.php
@@ -58,6 +58,24 @@ class UsersTest extends TestCase
     }
 
     #[Test]
+    public function shouldGetAllUsersWithoutProjectBots(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'Matt'],
+            ['id' => 2, 'name' => 'John'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('users', ['without_project_bots' => true])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->all(['without_project_bots' => true]));
+    }
+
+    #[Test]
     public function shouldGetUsersWithDateTimeParams(): void
     {
         $expectedArray = [


### PR DESCRIPTION
Adds `without_project_bots` to `Users::all`. Replaces #845.