### PR TITLE
[12.1] Add repository branch listing parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for `with_custom_attributes` and `with_projects` in `Groups::show`
 * Add support for project remote mirror read endpoints
 * Add support for permanent project removal and project restoration
+* Add support for `regex`, `sort`, and `page_token` in `Repositories::branches`
 
 
 ## [12.0.0] - 2025-02-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for `with_custom_attributes` and `with_projects` in `Groups::show`
 * Add support for project remote mirror read endpoints
 * Add support for permanent project removal and project restoration
-* Add support for `regex`, `sort`, and `page_token` in `Repositories::branches`
+* Add support for `regex` and `sort` in `Repositories::branches`
 
 
 ## [12.0.0] - 2025-02-23

--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -32,9 +32,9 @@ class Repositories extends AbstractApi
     /**
      * @param array      $parameters {
      *
-     *     @var string $search     Return branches matching the search string.
-     *     @var string $regex      Return branches matching an RE2 regex.
-     *     @var string $sort       Return branches sorted by name_asc, updated_asc, or updated_desc.
+     *     @var string $search     return branches matching the search string
+     *     @var string $regex      return branches matching an RE2 regex
+     *     @var string $sort       return branches sorted by name_asc, updated_asc, or updated_desc
      *     @var string $page_token Name of the branch to start pagination from.
      * }
      */

--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -35,7 +35,6 @@ class Repositories extends AbstractApi
      *     @var string $search     return branches matching the search string
      *     @var string $regex      return branches matching an RE2 regex
      *     @var string $sort       return branches sorted by name_asc, updated_asc, or updated_desc
-     *     @var string $page_token Name of the branch to start pagination from.
      * }
      */
     public function branches(int|string $project_id, array $parameters = []): mixed
@@ -50,9 +49,6 @@ class Repositories extends AbstractApi
         $resolver->setDefined('sort')
             ->setAllowedTypes('sort', 'string')
             ->setAllowedValues('sort', ['name_asc', 'updated_asc', 'updated_desc'])
-        ;
-        $resolver->setDefined('page_token')
-            ->setAllowedTypes('page_token', 'string')
         ;
 
         return $this->get($this->getProjectPath($project_id, 'repository/branches'), $resolver->resolve($parameters));

--- a/src/Api/Repositories.php
+++ b/src/Api/Repositories.php
@@ -32,14 +32,28 @@ class Repositories extends AbstractApi
     /**
      * @param array      $parameters {
      *
-     *     @var string $search
+     *     @var string $search     Return branches matching the search string.
+     *     @var string $regex      Return branches matching an RE2 regex.
+     *     @var string $sort       Return branches sorted by name_asc, updated_asc, or updated_desc.
+     *     @var string $page_token Name of the branch to start pagination from.
      * }
      */
     public function branches(int|string $project_id, array $parameters = []): mixed
     {
         $resolver = $this->createOptionsResolver();
         $resolver->setDefined('search')
-            ->setAllowedTypes('search', 'string');
+            ->setAllowedTypes('search', 'string')
+        ;
+        $resolver->setDefined('regex')
+            ->setAllowedTypes('regex', 'string')
+        ;
+        $resolver->setDefined('sort')
+            ->setAllowedTypes('sort', 'string')
+            ->setAllowedValues('sort', ['name_asc', 'updated_asc', 'updated_desc'])
+        ;
+        $resolver->setDefined('page_token')
+            ->setAllowedTypes('page_token', 'string')
+        ;
 
         return $this->get($this->getProjectPath($project_id, 'repository/branches'), $resolver->resolve($parameters));
     }

--- a/tests/Api/RepositoriesTest.php
+++ b/tests/Api/RepositoriesTest.php
@@ -39,6 +39,29 @@ class RepositoriesTest extends TestCase
     }
 
     #[Test]
+    public function shouldGetBranchesWithAdditionalParameters(): void
+    {
+        $expectedArray = [
+            ['name' => 'release/1.0'],
+            ['name' => 'release/1.1'],
+        ];
+        $parameters = [
+            'regex' => '^release/.*',
+            'sort' => 'updated_desc',
+            'page_token' => 'release/1.0',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/repository/branches', $parameters)
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->branches(1, $parameters));
+    }
+
+    #[Test]
     public function shouldGetBranch(): void
     {
         $expectedArray = ['name' => 'master'];

--- a/tests/Api/RepositoriesTest.php
+++ b/tests/Api/RepositoriesTest.php
@@ -48,7 +48,6 @@ class RepositoriesTest extends TestCase
         $parameters = [
             'regex' => '^release/.*',
             'sort' => 'updated_desc',
-            'page_token' => 'release/1.0',
         ];
 
         $api = $this->getApiMock();


### PR DESCRIPTION
Adds support for `regex` and `sort` in `Repositories::branches`. Replaces #848.