### PR TITLE
[12.1] Add project job token scope API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for `regex` and `sort` in `Repositories::branches`
 * Add support for `Users::usersContributedProjects`
 * Add support for additional filters and ordering options in `MergeRequests::all`
+* Add support for project CI/CD job token scope endpoints
 
 
 ## [12.0.0] - 2025-02-23

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1273,6 +1273,56 @@ class Projects extends AbstractApi
         return $this->delete($this->getProjectPath($project_id, 'access_tokens/'.$token_id));
     }
 
+    public function jobTokenScope(int|string $project_id): mixed
+    {
+        return $this->get($this->getProjectPath($project_id, 'job_token_scope'));
+    }
+
+    public function updateJobTokenScope(int|string $project_id, bool $enabled): mixed
+    {
+        return $this->patch($this->getProjectPath($project_id, 'job_token_scope'), ['enabled' => $enabled]);
+    }
+
+    public function jobTokenScopeAllowlistProjects(int|string $project_id, array $parameters = []): mixed
+    {
+        $resolver = $this->createOptionsResolver();
+
+        return $this->get($this->getProjectPath($project_id, 'job_token_scope/allowlist'), $resolver->resolve($parameters));
+    }
+
+    public function addJobTokenScopeAllowlistProject(int|string $project_id, int $target_project_id): mixed
+    {
+        return $this->post(
+            $this->getProjectPath($project_id, 'job_token_scope/allowlist'),
+            ['target_project_id' => $target_project_id]
+        );
+    }
+
+    public function removeJobTokenScopeAllowlistProject(int|string $project_id, int $target_project_id): mixed
+    {
+        return $this->delete($this->getProjectPath($project_id, 'job_token_scope/allowlist/'.self::encodePath($target_project_id)));
+    }
+
+    public function jobTokenScopeAllowlistGroups(int|string $project_id, array $parameters = []): mixed
+    {
+        $resolver = $this->createOptionsResolver();
+
+        return $this->get($this->getProjectPath($project_id, 'job_token_scope/groups_allowlist'), $resolver->resolve($parameters));
+    }
+
+    public function addJobTokenScopeAllowlistGroup(int|string $project_id, int $target_group_id): mixed
+    {
+        return $this->post(
+            $this->getProjectPath($project_id, 'job_token_scope/groups_allowlist'),
+            ['target_group_id' => $target_group_id]
+        );
+    }
+
+    public function removeJobTokenScopeAllowlistGroup(int|string $project_id, int $target_group_id): mixed
+    {
+        return $this->delete($this->getProjectPath($project_id, 'job_token_scope/groups_allowlist/'.self::encodePath($target_group_id)));
+    }
+
     public function protectedTags(int|string $project_id): mixed
     {
         return $this->get('projects/'.self::encodePath($project_id).'/protected_tags');

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2784,6 +2784,168 @@ class ProjectsTest extends TestCase
     }
 
     #[Test]
+    public function shouldGetJobTokenScope(): void
+    {
+        $expectedArray = ['inbound_enabled' => true, 'outbound_enabled' => false];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/job_token_scope')
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->jobTokenScope(1));
+    }
+
+    #[Test]
+    public function shouldUpdateJobTokenScope(): void
+    {
+        $expectedString = '';
+
+        $api = $this->getApiMock(['patch']);
+        $api->expects($this->once())
+            ->method('patch')
+            ->with('projects/1/job_token_scope', ['enabled' => false])
+            ->willReturn($expectedString);
+
+        $this->assertEquals($expectedString, $api->updateJobTokenScope(1, false));
+    }
+
+    #[Test]
+    public function shouldGetJobTokenScopeAllowlistProjects(): void
+    {
+        $expectedArray = [[
+            'id' => 4,
+            'name' => 'Diaspora Client',
+            'web_url' => 'https://gitlab.example.com/diaspora/diaspora-client',
+        ]];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/job_token_scope/allowlist', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->jobTokenScopeAllowlistProjects(1));
+    }
+
+    #[Test]
+    public function shouldGetJobTokenScopeAllowlistProjectsWithPagination(): void
+    {
+        $expectedArray = [[
+            'id' => 4,
+            'name' => 'Diaspora Client',
+            'web_url' => 'https://gitlab.example.com/diaspora/diaspora-client',
+        ]];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/job_token_scope/allowlist', ['page' => 2, 'per_page' => 15])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->jobTokenScopeAllowlistProjects(1, ['page' => 2, 'per_page' => 15]));
+    }
+
+    #[Test]
+    public function shouldAddJobTokenScopeAllowlistProject(): void
+    {
+        $expectedArray = [
+            'source_project_id' => 1,
+            'target_project_id' => 42,
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/job_token_scope/allowlist', ['target_project_id' => 42])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->addJobTokenScopeAllowlistProject(1, 42));
+    }
+
+    #[Test]
+    public function shouldRemoveJobTokenScopeAllowlistProject(): void
+    {
+        $expectedString = '';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/job_token_scope/allowlist/42')
+            ->willReturn($expectedString);
+
+        $this->assertEquals($expectedString, $api->removeJobTokenScopeAllowlistProject(1, 42));
+    }
+
+    #[Test]
+    public function shouldGetJobTokenScopeAllowlistGroups(): void
+    {
+        $expectedArray = [[
+            'id' => 4,
+            'name' => 'namegroup',
+            'web_url' => 'https://gitlab.example.com/groups/diaspora/diaspora-group',
+        ]];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/job_token_scope/groups_allowlist', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->jobTokenScopeAllowlistGroups(1));
+    }
+
+    #[Test]
+    public function shouldGetJobTokenScopeAllowlistGroupsWithPagination(): void
+    {
+        $expectedArray = [[
+            'id' => 4,
+            'name' => 'namegroup',
+            'web_url' => 'https://gitlab.example.com/groups/diaspora/diaspora-group',
+        ]];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/job_token_scope/groups_allowlist', ['page' => 2, 'per_page' => 15])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->jobTokenScopeAllowlistGroups(1, ['page' => 2, 'per_page' => 15]));
+    }
+
+    #[Test]
+    public function shouldAddJobTokenScopeAllowlistGroup(): void
+    {
+        $expectedArray = [
+            'source_project_id' => 1,
+            'target_group_id' => 42,
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/job_token_scope/groups_allowlist', ['target_group_id' => 42])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->addJobTokenScopeAllowlistGroup(1, 42));
+    }
+
+    #[Test]
+    public function shouldRemoveJobTokenScopeAllowlistGroup(): void
+    {
+        $expectedString = '';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/job_token_scope/groups_allowlist/42')
+            ->willReturn($expectedString);
+
+        $this->assertEquals($expectedString, $api->removeJobTokenScopeAllowlistGroup(1, 42));
+    }
+
+    #[Test]
     public function shouldUploadAvatar(): void
     {
         $emptyPNGContents = 'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAACYElEQVR42u3UMQEAAAjDMFCO9GEAByQSerQrmQJeagMAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwADAAAwADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMAAzAAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwADMAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAMAAZwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAOCybrx+H1CTHLYAAAAASUVORK5CYII=';


### PR DESCRIPTION
Adds project CI/CD job token scope settings and allowlist management endpoints. Replaces #853.