### PR TITLE
[12.1] Add merge request resource label events API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for `Users::usersContributedProjects`
 * Add support for additional filters and ordering options in `MergeRequests::all`
 * Add support for project CI/CD job token scope endpoints
+* Add support for merge request resource label event endpoints
 
 
 ## [12.0.0] - 2025-02-23

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -384,6 +384,16 @@ class MergeRequests extends AbstractApi
         return $this->get($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid)).'/participants');
     }
 
+    public function showResourceLabelEvents(int|string $project_id, int $mr_iid): mixed
+    {
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid)).'/resource_label_events');
+    }
+
+    public function showResourceLabelEvent(int|string $project_id, int $mr_iid, int $resource_label_event_id): mixed
+    {
+        return $this->get($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid)).'/resource_label_events/'.self::encodePath($resource_label_event_id));
+    }
+
     public function changes(int|string $project_id, int $mr_iid): mixed
     {
         return $this->get($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/changes'));

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -443,6 +443,39 @@ class MergeRequestsTest extends TestCase
     }
 
     #[Test]
+    public function shouldGetMergeRequestResourceLabelEvents(): void
+    {
+        $expectedArray = [
+            ['id' => 119, 'resource_type' => 'MergeRequest', 'action' => 'add'],
+            ['id' => 120, 'resource_type' => 'MergeRequest', 'action' => 'add'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/merge_requests/2/resource_label_events')
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->showResourceLabelEvents(1, 2));
+    }
+
+    #[Test]
+    public function shouldGetMergeRequestResourceLabelEvent(): void
+    {
+        $expectedArray = ['id' => 119, 'resource_type' => 'MergeRequest', 'action' => 'add'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/merge_requests/2/resource_label_events/3')
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->showResourceLabelEvent(1, 2, 3));
+    }
+
+    #[Test]
     public function shouldGetMergeRequestChanges(): void
     {
         $expectedArray = ['id' => 1, 'title' => 'A merge request'];


### PR DESCRIPTION
Adds support for merge request resource label event endpoints. Replaces #804.