### PR TITLE
[12.1] Add missing group project and pipeline filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for project CI/CD job token scope endpoints
 * Add support for merge request resource label event endpoints
 * Add support for `Environments::stopStale`
+* Add support for `last_activity_after` and `last_activity_before` in `Groups::projects`
+* Fix `Projects::pipelines` date filters to include time information
 
 
 ## [12.0.0] - 2025-02-23

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -236,20 +236,22 @@ class Groups extends AbstractApi
     /**
      * @param array      $parameters {
      *
-     *     @var bool   $archived                    limit by archived status
-     *     @var string $visibility                  limit by visibility public, internal, or private
-     *     @var string $order_by                    Return projects ordered by id, name, path, created_at, updated_at, or last_activity_at fields.
-     *                                              Default is created_at.
-     *     @var string $sort                        Return projects sorted in asc or desc order (default is desc)
-     *     @var string $search                      return list of authorized projects matching the search criteria
-     *     @var bool   $simple                      return only the ID, URL, name, and path of each project
-     *     @var bool   $owned                       limit by projects owned by the current user
-     *     @var bool   $starred                     limit by projects starred by the current user
-     *     @var bool   $with_issues_enabled         Limit by projects with issues feature enabled (default is false)
-     *     @var bool   $with_merge_requests_enabled Limit by projects with merge requests feature enabled (default is false)
-     *     @var bool   $with_shared                 Include projects shared to this group (default is true)
-     *     @var bool   $include_subgroups           Include projects in subgroups of this group (default is false)
-     *     @var bool   $with_custom_attributes      Include custom attributes in response (admins only).
+     *     @var bool               $archived                    limit by archived status
+     *     @var string             $visibility                  limit by visibility public, internal, or private
+     *     @var string             $order_by                    Return projects ordered by id, name, path, created_at, updated_at, or last_activity_at fields.
+     *                                                          Default is created_at.
+     *     @var string             $sort                        Return projects sorted in asc or desc order (default is desc)
+     *     @var string             $search                      return list of authorized projects matching the search criteria
+     *     @var bool               $simple                      return only the ID, URL, name, and path of each project
+     *     @var bool               $owned                       limit by projects owned by the current user
+     *     @var bool               $starred                     limit by projects starred by the current user
+     *     @var bool               $with_issues_enabled         Limit by projects with issues feature enabled (default is false)
+     *     @var bool               $with_merge_requests_enabled Limit by projects with merge requests feature enabled (default is false)
+     *     @var bool               $with_shared                 Include projects shared to this group (default is true)
+     *     @var bool               $include_subgroups           Include projects in subgroups of this group (default is false)
+     *     @var bool               $with_custom_attributes      Include custom attributes in response (admins only).
+     *     @var \DateTimeInterface $last_activity_after         Limit by last_activity after specified time
+     *     @var \DateTimeInterface $last_activity_before        Limit by last_activity before specified time
      * }
      */
     public function projects(int|string $id, array $parameters = []): mixed
@@ -257,6 +259,9 @@ class Groups extends AbstractApi
         $resolver = $this->createOptionsResolver();
         $booleanNormalizer = function (Options $resolver, $value): string {
             return $value ? 'true' : 'false';
+        };
+        $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
+            return $value->format('c');
         };
 
         $resolver->setDefined('archived')
@@ -304,6 +309,14 @@ class Groups extends AbstractApi
         $resolver->setDefined('with_custom_attributes')
             ->setAllowedTypes('with_custom_attributes', 'bool')
             ->setNormalizer('with_custom_attributes', $booleanNormalizer)
+        ;
+        $resolver->setDefined('last_activity_after')
+            ->setAllowedTypes('last_activity_after', \DateTimeInterface::class)
+            ->setNormalizer('last_activity_after', $datetimeNormalizer)
+        ;
+        $resolver->setDefined('last_activity_before')
+            ->setAllowedTypes('last_activity_before', \DateTimeInterface::class)
+            ->setNormalizer('last_activity_before', $datetimeNormalizer)
         ;
 
         return $this->get('groups/'.self::encodePath($id).'/projects', $resolver->resolve($parameters));

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -249,7 +249,7 @@ class Groups extends AbstractApi
      *     @var bool               $with_merge_requests_enabled Limit by projects with merge requests feature enabled (default is false)
      *     @var bool               $with_shared                 Include projects shared to this group (default is true)
      *     @var bool               $include_subgroups           Include projects in subgroups of this group (default is false)
-     *     @var bool               $with_custom_attributes      Include custom attributes in response (admins only).
+     *     @var bool               $with_custom_attributes      include custom attributes in response (admins only)
      *     @var \DateTimeInterface $last_activity_after         Limit by last_activity after specified time
      *     @var \DateTimeInterface $last_activity_before        Limit by last_activity before specified time
      * }

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -277,16 +277,18 @@ class Projects extends AbstractApi
     /**
      * @param array      $parameters {
      *
-     *     @var string $scope       the scope of pipelines, one of: running, pending, finished, branches, tags
-     *     @var string $status      the status of pipelines, one of: running, pending, success, failed, canceled, skipped
-     *     @var string $ref         the ref of pipelines
-     *     @var string $sha         the sha of pipelines
-     *     @var bool   $yaml_errors returns pipelines with invalid configurations
-     *     @var string $name        the name of the user who triggered pipelines
-     *     @var string $username    the username of the user who triggered pipelines
-     *     @var string $order_by    order pipelines by id, status, ref, updated_at, or user_id (default: id)
-     *     @var string $order       sort pipelines in asc or desc order (default: desc)
-     *     @var string $source      the source of the pipeline
+     *     @var string             $scope          the scope of pipelines, one of: running, pending, finished, branches, tags
+     *     @var string             $status         the status of pipelines, one of: running, pending, success, failed, canceled, skipped
+     *     @var string             $ref            the ref of pipelines
+     *     @var string             $sha            the sha of pipelines
+     *     @var bool               $yaml_errors    returns pipelines with invalid configurations
+     *     @var string             $name           the name of the user who triggered pipelines
+     *     @var string             $username       the username of the user who triggered pipelines
+     *     @var \DateTimeInterface $updated_after  Return pipelines updated on or after the given date and time
+     *     @var \DateTimeInterface $updated_before Return pipelines updated on or before the given date and time
+     *     @var string             $order_by       order pipelines by id, status, ref, updated_at, or user_id (default: id)
+     *     @var string             $sort           sort pipelines in asc or desc order (default: desc)
+     *     @var string             $source         the source of the pipeline
      * }
      */
     public function pipelines(int|string $project_id, array $parameters = []): mixed
@@ -296,7 +298,7 @@ class Projects extends AbstractApi
             return $value ? 'true' : 'false';
         };
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
-            return $value->format('Y-m-d');
+            return $value->format('c');
         };
 
         $resolver->setDefined('scope')
@@ -314,12 +316,12 @@ class Projects extends AbstractApi
         $resolver->setDefined('name');
         $resolver->setDefined('username');
         $resolver->setDefined('updated_after')
-                 ->setAllowedTypes('updated_after', \DateTimeInterface::class)
-                 ->setNormalizer('updated_after', $datetimeNormalizer)
+            ->setAllowedTypes('updated_after', \DateTimeInterface::class)
+            ->setNormalizer('updated_after', $datetimeNormalizer)
         ;
         $resolver->setDefined('updated_before')
-                 ->setAllowedTypes('updated_before', \DateTimeInterface::class)
-                 ->setNormalizer('updated_before', $datetimeNormalizer)
+            ->setAllowedTypes('updated_before', \DateTimeInterface::class)
+            ->setNormalizer('updated_before', $datetimeNormalizer)
         ;
         $resolver->setDefined('order_by')
             ->setAllowedValues('order_by', ['id', 'status', 'ref', 'updated_at', 'user_id'])

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -664,6 +664,46 @@ class GroupsTest extends TestCase
     }
 
     #[Test]
+    public function shouldGetAllGroupProjectsWithLastActivityAfter(): void
+    {
+        $lastActivityAfter = new DateTime('2018-01-01 00:00:00');
+
+        $expectedArray = [
+            ['id' => 1, 'name' => 'A project'],
+            ['id' => 2, 'name' => 'Another project'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/projects', ['last_activity_after' => $lastActivityAfter->format('c')])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->projects(1, ['last_activity_after' => $lastActivityAfter]));
+    }
+
+    #[Test]
+    public function shouldGetAllGroupProjectsWithLastActivityBefore(): void
+    {
+        $lastActivityBefore = new DateTime('2018-01-31 00:00:00');
+
+        $expectedArray = [
+            ['id' => 1, 'name' => 'A project'],
+            ['id' => 2, 'name' => 'Another project'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/projects', ['last_activity_before' => $lastActivityBefore->format('c')])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->projects(1, ['last_activity_before' => $lastActivityBefore]));
+    }
+
+    #[Test]
     public function shouldGetIterations(): void
     {
         $expectedArray = [

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -761,12 +761,12 @@ class ProjectsTest extends TestCase
             ['id' => 3, 'status' => 'pending', 'ref' => 'test-pipeline'],
         ];
 
-        $updated_after = new DateTime('2018-01-01 00:00:00');
-        $updated_before = new DateTime('2018-01-31 00:00:00');
+        $updatedAfter = new DateTime('2018-01-01 00:00:00');
+        $updatedBefore = new DateTime('2018-01-31 00:00:00');
 
         $expectedWithArray = [
-            'updated_after' => $updated_after->format('Y-m-d'),
-            'updated_before' => $updated_before->format('Y-m-d'),
+            'updated_after' => $updatedAfter->format('c'),
+            'updated_before' => $updatedBefore->format('c'),
         ];
 
         $api = $this->getApiMock();
@@ -776,8 +776,8 @@ class ProjectsTest extends TestCase
             ->willReturn($expectedArray);
 
         $this->assertEquals($expectedArray, $api->pipelines(1, [
-            'updated_after' => $updated_after,
-            'updated_before' => $updated_before,
+            'updated_after' => $updatedAfter,
+            'updated_before' => $updatedBefore,
         ]));
     }
 


### PR DESCRIPTION
This adds `last_activity_after` and `last_activity_before` support to `Groups::projects`, matching the datetime serialization used by project listing filters. It also updates `Projects::pipelines` to serialize `updated_after` and `updated_before` with full datetime information and corrects the PHPDoc parameter name from `order` to `sort`.