### PR TITLE
[12.1] Add merge request removal API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for project CI/CD job token scope endpoints
 * Add support for merge request resource label event endpoints
 * Add support for merge request and merge request note award emoji endpoints
+* Add support for `MergeRequests::remove`
 * Add support for `Environments::stopStale`
 * Add support for `last_activity_after` and `last_activity_before` in `Groups::projects`
 * Fix `Projects::pipelines` date filters to include time information

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -308,6 +308,11 @@ class MergeRequests extends AbstractApi
         return $this->put($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid)), $parameters);
     }
 
+    public function remove(int|string $project_id, int $mr_iid): mixed
+    {
+        return $this->delete($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid)));
+    }
+
     public function merge(int|string $project_id, int $mr_iid, array $parameters = []): mixed
     {
         return $this->put($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/merge'), $parameters);

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -319,6 +319,20 @@ class MergeRequestsTest extends TestCase
     }
 
     #[Test]
+    public function shouldRemoveMergeRequest(): void
+    {
+        $expectedBool = true;
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/merge_requests/2')
+            ->willReturn($expectedBool);
+
+        $this->assertEquals($expectedBool, $api->remove(1, 2));
+    }
+
+    #[Test]
     public function shouldMergeMergeRequest(): void
     {
         $expectedArray = ['id' => 2, 'title' => 'Updated title'];


### PR DESCRIPTION
This adds `MergeRequests::remove` for deleting a merge request by project ID or path and merge request IID, using the documented `DELETE /projects/:id/merge_requests/:merge_request_iid` endpoint.