### PR TITLE
[12.1] Add container registry API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for merge request resource label event endpoints
 * Add support for merge request and merge request note award emoji endpoints
 * Add support for `MergeRequests::remove`
+* Add support for container registry endpoints
 * Add support for `Environments::stopStale`
 * Add support for `last_activity_after` and `last_activity_before` in `Groups::projects`
 * Fix `Projects::pipelines` date filters to include time information

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -733,6 +733,13 @@ class Groups extends AbstractApi
         return $this->get('groups/'.self::encodePath($group_id).'/packages', $resolver->resolve($parameters));
     }
 
+    public function registryRepositories(int|string $group_id, array $parameters = []): mixed
+    {
+        $resolver = $this->createOptionsResolver();
+
+        return $this->get('groups/'.self::encodePath($group_id).'/registry/repositories', $resolver->resolve($parameters));
+    }
+
     private function getGroupSearchResolver(): OptionsResolver
     {
         $resolver = $this->getSubgroupSearchResolver();

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1345,6 +1345,32 @@ class Projects extends AbstractApi
         return $this->delete($this->getProjectPath($project_id, 'job_token_scope/groups_allowlist/'.self::encodePath($target_group_id)));
     }
 
+    /**
+     * @param array $parameters {
+     *
+     *     @var bool $tags       include an array of tags in each repository
+     *     @var bool $tags_count include tags_count in each repository
+     * }
+     */
+    public function registryRepositories(int|string $project_id, array $parameters = []): mixed
+    {
+        $resolver = $this->createOptionsResolver();
+        $booleanNormalizer = function (Options $resolver, $value): string {
+            return $value ? 'true' : 'false';
+        };
+
+        $resolver->setDefined('tags')
+            ->setAllowedTypes('tags', 'bool')
+            ->setNormalizer('tags', $booleanNormalizer)
+        ;
+        $resolver->setDefined('tags_count')
+            ->setAllowedTypes('tags_count', 'bool')
+            ->setNormalizer('tags_count', $booleanNormalizer)
+        ;
+
+        return $this->get($this->getProjectPath($project_id, 'registry/repositories'), $resolver->resolve($parameters));
+    }
+
     public function protectedTags(int|string $project_id): mixed
     {
         return $this->get('projects/'.self::encodePath($project_id).'/protected_tags');

--- a/src/Api/Registry.php
+++ b/src/Api/Registry.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Api;
+
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class Registry extends AbstractApi
+{
+    /**
+     * @param array $parameters {
+     *
+     *     @var bool $tags       include an array of tags in the response
+     *     @var bool $tags_count include tags_count in the response
+     *     @var bool $size       include the deduplicated size in the response
+     * }
+     */
+    public function repository(int|string $repository_id, array $parameters = []): mixed
+    {
+        $resolver = self::createRepositoryResolver();
+
+        return $this->get('registry/repositories/'.self::encodePath($repository_id), $resolver->resolve($parameters));
+    }
+
+    public function removeRepository(int|string $project_id, int $repository_id): mixed
+    {
+        return $this->delete($this->getProjectPath($project_id, 'registry/repositories/'.self::encodePath($repository_id)));
+    }
+
+    public function repositoryTags(int|string $project_id, int $repository_id, array $parameters = []): mixed
+    {
+        $resolver = $this->createOptionsResolver();
+
+        return $this->get(
+            $this->getProjectPath($project_id, 'registry/repositories/'.self::encodePath($repository_id).'/tags'),
+            $resolver->resolve($parameters)
+        );
+    }
+
+    public function repositoryTag(int|string $project_id, int $repository_id, string $tag_name): mixed
+    {
+        return $this->get($this->getProjectPath(
+            $project_id,
+            'registry/repositories/'.self::encodePath($repository_id).'/tags/'.self::encodePath($tag_name)
+        ));
+    }
+
+    public function removeRepositoryTag(int|string $project_id, int $repository_id, string $tag_name): mixed
+    {
+        return $this->delete($this->getProjectPath(
+            $project_id,
+            'registry/repositories/'.self::encodePath($repository_id).'/tags/'.self::encodePath($tag_name)
+        ));
+    }
+
+    /**
+     * @param array $parameters {
+     *
+     *     @var string $name_regex_delete regex of tag names to delete
+     *     @var string $name_regex_keep   regex of tag names to keep
+     *     @var int    $keep_n            number of latest matching tags to keep
+     *     @var string $older_than        delete tags older than this human-readable duration
+     * }
+     */
+    public function removeRepositoryTags(int|string $project_id, int $repository_id, array $parameters): mixed
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setRequired('name_regex_delete')
+            ->setAllowedTypes('name_regex_delete', 'string')
+        ;
+        $resolver->setDefined('name_regex_keep')
+            ->setAllowedTypes('name_regex_keep', 'string')
+        ;
+        $resolver->setDefined('keep_n')
+            ->setAllowedTypes('keep_n', 'int')
+        ;
+        $resolver->setDefined('older_than')
+            ->setAllowedTypes('older_than', 'string')
+        ;
+
+        return $this->delete(
+            $this->getProjectPath($project_id, 'registry/repositories/'.self::encodePath($repository_id).'/tags'),
+            $resolver->resolve($parameters)
+        );
+    }
+
+    private static function createRepositoryResolver(): OptionsResolver
+    {
+        $resolver = new OptionsResolver();
+        $booleanNormalizer = function (Options $resolver, $value): string {
+            return $value ? 'true' : 'false';
+        };
+
+        $resolver->setDefined('tags')
+            ->setAllowedTypes('tags', 'bool')
+            ->setNormalizer('tags', $booleanNormalizer)
+        ;
+        $resolver->setDefined('tags_count')
+            ->setAllowedTypes('tags_count', 'bool')
+            ->setNormalizer('tags_count', $booleanNormalizer)
+        ;
+        $resolver->setDefined('size')
+            ->setAllowedTypes('size', 'bool')
+            ->setNormalizer('size', $booleanNormalizer)
+        ;
+
+        return $resolver;
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -33,6 +33,7 @@ use Gitlab\Api\Milestones;
 use Gitlab\Api\PersonalAccessTokens;
 use Gitlab\Api\ProjectNamespaces;
 use Gitlab\Api\Projects;
+use Gitlab\Api\Registry;
 use Gitlab\Api\Repositories;
 use Gitlab\Api\RepositoryFiles;
 use Gitlab\Api\ResourceIterationEvents;
@@ -249,6 +250,11 @@ class Client
     public function projects(): Projects
     {
         return new Projects($this);
+    }
+
+    public function registry(): Registry
+    {
+        return new Registry($this);
     }
 
     public function repositories(): Repositories

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -772,6 +772,42 @@ class GroupsTest extends TestCase
     }
 
     #[Test]
+    public function shouldGetGroupRegistryRepositories(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'A registry'],
+            ['id' => 2, 'name' => 'Another registry'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/registry/repositories', [])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->registryRepositories(1));
+    }
+
+    #[Test]
+    public function shouldGetGroupRegistryRepositoriesWithPagination(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'A registry'],
+            ['id' => 2, 'name' => 'Another registry'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('groups/1/registry/repositories', ['page' => 2, 'per_page' => 15])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->registryRepositories(1, ['page' => 2, 'per_page' => 15]));
+    }
+
+    #[Test]
     public function shouldGetGroupMergeRequests(): void
     {
         $expectedArray = [

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -3001,6 +3001,57 @@ class ProjectsTest extends TestCase
     }
 
     #[Test]
+    public function shouldGetProjectRegistryRepositories(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'A registry'],
+            ['id' => 2, 'name' => 'Another registry'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/123/registry/repositories', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->registryRepositories(123));
+    }
+
+    #[Test]
+    public function shouldGetProjectRegistryRepositoriesWithTags(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'A registry', 'tags' => ['1.0', '1.1'], 'tags_count' => 2],
+            ['id' => 2, 'name' => 'Another registry', 'tags' => ['2.0', '2.1'], 'tags_count' => 2],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/123/registry/repositories', ['tags' => 'true', 'tags_count' => 'true'])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->registryRepositories(123, ['tags' => true, 'tags_count' => true]));
+    }
+
+    #[Test]
+    public function shouldGetProjectRegistryRepositoriesWithPagination(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'name' => 'A registry'],
+            ['id' => 2, 'name' => 'Another registry'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/123/registry/repositories', ['page' => 2, 'per_page' => 15])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->registryRepositories(123, ['page' => 2, 'per_page' => 15]));
+    }
+
+    #[Test]
     public function shouldUploadAvatar(): void
     {
         $emptyPNGContents = 'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAACYElEQVR42u3UMQEAAAjDMFCO9GEAByQSerQrmQJeagMAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwADAAAwADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMAAzAAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwADMAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAMAAZwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAwAAAAwAMADAAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMADAAAADAAwAMAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAMAAAAMADAAwAOCybrx+H1CTHLYAAAAASUVORK5CYII=';

--- a/tests/Api/RegistryTest.php
+++ b/tests/Api/RegistryTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Gitlab API library.
+ *
+ * (c) Matt Humphrey <matth@windsor-telecom.co.uk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gitlab\Tests\Api;
+
+use Gitlab\Api\Registry;
+use PHPUnit\Framework\Attributes\Test;
+
+final class RegistryTest extends TestCase
+{
+    #[Test]
+    public function shouldGetRepository(): void
+    {
+        $expectedArray = ['id' => 1, 'name' => 'A registry'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('registry/repositories/1', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->repository(1));
+    }
+
+    #[Test]
+    public function shouldGetRepositoryWithParams(): void
+    {
+        $expectedArray = ['id' => 1, 'name' => 'A registry', 'tags' => ['tag1', 'tag2'], 'tags_count' => 2, 'size' => 12345];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('registry/repositories/1', ['tags' => 'true', 'tags_count' => 'true', 'size' => 'true'])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->repository(1, ['tags' => true, 'tags_count' => true, 'size' => true]));
+    }
+
+    #[Test]
+    public function shouldRemoveRepository(): void
+    {
+        $expectedString = '';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/registry/repositories/2')
+            ->willReturn($expectedString);
+
+        $this->assertEquals($expectedString, $api->removeRepository(1, 2));
+    }
+
+    #[Test]
+    public function shouldGetRepositoryTags(): void
+    {
+        $expectedArray = [
+            ['name' => 'v1.0.0', 'path' => 'group/project:v1.0.0'],
+            ['name' => 'v1.1.0', 'path' => 'group/project:v1.1.0'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/registry/repositories/2/tags', [])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->repositoryTags(1, 2));
+    }
+
+    #[Test]
+    public function shouldGetRepositoryTagsWithPagination(): void
+    {
+        $expectedArray = [
+            ['name' => 'v1.0.0', 'path' => 'group/project:v1.0.0'],
+            ['name' => 'v1.1.0', 'path' => 'group/project:v1.1.0'],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/registry/repositories/2/tags', ['page' => 2, 'per_page' => 15])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->repositoryTags(1, 2, ['page' => 2, 'per_page' => 15]));
+    }
+
+    #[Test]
+    public function shouldGetRepositoryTag(): void
+    {
+        $expectedArray = ['name' => 'v1.0.0', 'path' => 'group/project:v1.0.0'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/registry/repositories/2/tags/v1.0.0')
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->repositoryTag(1, 2, 'v1.0.0'));
+    }
+
+    #[Test]
+    public function shouldRemoveRepositoryTag(): void
+    {
+        $expectedString = '';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/registry/repositories/2/tags/v1.0.0')
+            ->willReturn($expectedString);
+
+        $this->assertEquals($expectedString, $api->removeRepositoryTag(1, 2, 'v1.0.0'));
+    }
+
+    #[Test]
+    public function shouldRemoveRepositoryTags(): void
+    {
+        $expectedString = '';
+        $parameters = [
+            'name_regex_delete' => '.*',
+            'name_regex_keep' => 'stable.*',
+            'keep_n' => 5,
+            'older_than' => '2d',
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('delete')
+            ->with('projects/1/registry/repositories/2/tags', $parameters)
+            ->willReturn($expectedString);
+
+        $this->assertEquals($expectedString, $api->removeRepositoryTags(1, 2, $parameters));
+    }
+
+    protected function getApiClass(): string
+    {
+        return Registry::class;
+    }
+}


### PR DESCRIPTION
This adds container registry repository and tag operations, including group and project repository listings, repository details and deletion, tag listing and details, and single or bulk tag deletion.