### PR TITLE
[12.1] Add merge request merge train API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for merge request resource label event endpoints
 * Add support for merge request and merge request note award emoji endpoints
 * Add support for `MergeRequests::remove`
+* Add support for `MergeRequests::addToMergeTrain`
 * Add support for container registry endpoints
 * Add support for `Environments::stopStale`
 * Add support for `last_activity_after` and `last_activity_before` in `Groups::projects`

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -318,6 +318,11 @@ class MergeRequests extends AbstractApi
         return $this->put($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/merge'), $parameters);
     }
 
+    public function addToMergeTrain(int|string $project_id, int $mr_iid, array $parameters = []): mixed
+    {
+        return $this->post($this->getProjectPath($project_id, 'merge_trains/merge_requests/'.self::encodePath($mr_iid)), $parameters);
+    }
+
     public function showNotes(int|string $project_id, int $mr_iid): mixed
     {
         return $this->get($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/notes'));

--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -17,6 +17,7 @@ namespace Gitlab\Api;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class MergeRequests extends AbstractApi
 {
@@ -318,9 +319,32 @@ class MergeRequests extends AbstractApi
         return $this->put($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/merge'), $parameters);
     }
 
+    /**
+     * @param array $parameters {
+     *
+     *     @var bool   $auto_merge             add the merge request to the merge train when checks pass
+     *     @var string $sha                    must match the HEAD of the source branch if present
+     *     @var bool   $squash                 squash commits into a single commit on merge
+     *     @var bool   $when_pipeline_succeeds deprecated in GitLab 17.11. Use auto_merge instead.
+     * }
+     */
     public function addToMergeTrain(int|string $project_id, int $mr_iid, array $parameters = []): mixed
     {
-        return $this->post($this->getProjectPath($project_id, 'merge_trains/merge_requests/'.self::encodePath($mr_iid)), $parameters);
+        $resolver = new OptionsResolver();
+        $resolver->setDefined('auto_merge')
+            ->setAllowedTypes('auto_merge', 'bool')
+        ;
+        $resolver->setDefined('sha')
+            ->setAllowedTypes('sha', 'string')
+        ;
+        $resolver->setDefined('squash')
+            ->setAllowedTypes('squash', 'bool')
+        ;
+        $resolver->setDefined('when_pipeline_succeeds')
+            ->setAllowedTypes('when_pipeline_succeeds', 'bool')
+        ;
+
+        return $this->post($this->getProjectPath($project_id, 'merge_trains/merge_requests/'.self::encodePath($mr_iid)), $resolver->resolve($parameters));
     }
 
     public function showNotes(int|string $project_id, int $mr_iid): mixed

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -348,6 +348,29 @@ class MergeRequestsTest extends TestCase
     }
 
     #[Test]
+    public function shouldAddMergeRequestToMergeTrain(): void
+    {
+        $expectedArray = ['id' => 267, 'target_branch' => 'main', 'status' => 'idle'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/merge_trains/merge_requests/2', [
+                'auto_merge' => true,
+                'sha' => 'abc123',
+                'squash' => true,
+            ])
+            ->willReturn($expectedArray)
+        ;
+
+        $this->assertEquals($expectedArray, $api->addToMergeTrain(1, 2, [
+            'auto_merge' => true,
+            'sha' => 'abc123',
+            'squash' => true,
+        ]));
+    }
+
+    #[Test]
     public function shouldGetNotes(): void
     {
         $expectedArray = [

--- a/tests/Api/MergeRequestsTest.php
+++ b/tests/Api/MergeRequestsTest.php
@@ -350,7 +350,7 @@ class MergeRequestsTest extends TestCase
     #[Test]
     public function shouldAddMergeRequestToMergeTrain(): void
     {
-        $expectedArray = ['id' => 267, 'target_branch' => 'main', 'status' => 'idle'];
+        $expectedArray = [['id' => 267, 'target_branch' => 'main', 'status' => 'idle']];
 
         $api = $this->getApiMock();
         $api->expects($this->once())
@@ -359,6 +359,7 @@ class MergeRequestsTest extends TestCase
                 'auto_merge' => true,
                 'sha' => 'abc123',
                 'squash' => true,
+                'when_pipeline_succeeds' => false,
             ])
             ->willReturn($expectedArray)
         ;
@@ -367,6 +368,7 @@ class MergeRequestsTest extends TestCase
             'auto_merge' => true,
             'sha' => 'abc123',
             'squash' => true,
+            'when_pipeline_succeeds' => false,
         ]));
     }
 


### PR DESCRIPTION
This adds `MergeRequests::addToMergeTrain` for adding a merge request to a merge train using the documented `POST /projects/:id/merge_trains/merge_requests/:merge_request_iid` endpoint.