### PR TITLE
[12.1] Remove manual pagination parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for container registry endpoints
 * Add support for `Environments::stopStale`
 * Add support for `last_activity_after` and `last_activity_before` in `Groups::projects`
+* Fix recent list endpoints to rely on the result pager for pagination
 * Fix `Projects::pipelines` date filters to include time information
 
 

--- a/src/Api/Deployments.php
+++ b/src/Api/Deployments.php
@@ -79,6 +79,13 @@ class Deployments extends AbstractApi
         return $this->get($this->getProjectPath($project_id, 'deployments/'.$deployment_id));
     }
 
+    /**
+     * @param array $parameters {
+     *
+     *     @var string $state  return all merge requests or just those that are opened, closed, locked, or merged
+     *     @var string $labels return merge requests matching a comma separated list of labels
+     * }
+     */
     public function mergeRequests(int|string $project_id, int $deployment_id, array $parameters = []): mixed
     {
         $resolver = new OptionsResolver();

--- a/src/Api/Deployments.php
+++ b/src/Api/Deployments.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Gitlab\Api;
 
 use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class Deployments extends AbstractApi
 {
@@ -80,6 +81,12 @@ class Deployments extends AbstractApi
 
     public function mergeRequests(int|string $project_id, int $deployment_id, array $parameters = []): mixed
     {
-        return $this->get($this->getProjectPath($project_id, 'deployments/'.$deployment_id.'/merge_requests'), $parameters);
+        $resolver = new OptionsResolver();
+        $resolver->setDefined('state')
+            ->setAllowedValues('state', ['all', 'merged', 'opened', 'closed', 'locked'])
+        ;
+        $resolver->setDefined('labels');
+
+        return $this->get($this->getProjectPath($project_id, 'deployments/'.$deployment_id.'/merge_requests'), $resolver->resolve($parameters));
     }
 }

--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -733,11 +733,9 @@ class Groups extends AbstractApi
         return $this->get('groups/'.self::encodePath($group_id).'/packages', $resolver->resolve($parameters));
     }
 
-    public function registryRepositories(int|string $group_id, array $parameters = []): mixed
+    public function registryRepositories(int|string $group_id): mixed
     {
-        $resolver = $this->createOptionsResolver();
-
-        return $this->get('groups/'.self::encodePath($group_id).'/registry/repositories', $resolver->resolve($parameters));
+        return $this->get('groups/'.self::encodePath($group_id).'/registry/repositories');
     }
 
     private function getGroupSearchResolver(): OptionsResolver

--- a/src/Api/PersonalAccessTokens.php
+++ b/src/Api/PersonalAccessTokens.php
@@ -37,7 +37,7 @@ class PersonalAccessTokens extends AbstractApi
      */
     public function all(array $parameters = []): mixed
     {
-        $resolver = $this->createOptionsResolver();
+        $resolver = new OptionsResolver();
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
             return $value->format('c');
         };

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -1165,7 +1165,7 @@ class Projects extends AbstractApi
      */
     public function projectAccessTokens(int|string $project_id, array $parameters = []): mixed
     {
-        $resolver = $this->createOptionsResolver();
+        $resolver = new OptionsResolver();
         $datetimeNormalizer = function (Options $resolver, \DateTimeInterface $value): string {
             return $value->format('c');
         };
@@ -1305,11 +1305,9 @@ class Projects extends AbstractApi
         return $this->patch($this->getProjectPath($project_id, 'job_token_scope'), ['enabled' => $enabled]);
     }
 
-    public function jobTokenScopeAllowlistProjects(int|string $project_id, array $parameters = []): mixed
+    public function jobTokenScopeAllowlistProjects(int|string $project_id): mixed
     {
-        $resolver = $this->createOptionsResolver();
-
-        return $this->get($this->getProjectPath($project_id, 'job_token_scope/allowlist'), $resolver->resolve($parameters));
+        return $this->get($this->getProjectPath($project_id, 'job_token_scope/allowlist'));
     }
 
     public function addJobTokenScopeAllowlistProject(int|string $project_id, int $target_project_id): mixed
@@ -1325,11 +1323,9 @@ class Projects extends AbstractApi
         return $this->delete($this->getProjectPath($project_id, 'job_token_scope/allowlist/'.self::encodePath($target_project_id)));
     }
 
-    public function jobTokenScopeAllowlistGroups(int|string $project_id, array $parameters = []): mixed
+    public function jobTokenScopeAllowlistGroups(int|string $project_id): mixed
     {
-        $resolver = $this->createOptionsResolver();
-
-        return $this->get($this->getProjectPath($project_id, 'job_token_scope/groups_allowlist'), $resolver->resolve($parameters));
+        return $this->get($this->getProjectPath($project_id, 'job_token_scope/groups_allowlist'));
     }
 
     public function addJobTokenScopeAllowlistGroup(int|string $project_id, int $target_group_id): mixed
@@ -1354,7 +1350,7 @@ class Projects extends AbstractApi
      */
     public function registryRepositories(int|string $project_id, array $parameters = []): mixed
     {
-        $resolver = $this->createOptionsResolver();
+        $resolver = new OptionsResolver();
         $booleanNormalizer = function (Options $resolver, $value): string {
             return $value ? 'true' : 'false';
         };

--- a/src/Api/Registry.php
+++ b/src/Api/Registry.php
@@ -39,14 +39,9 @@ class Registry extends AbstractApi
         return $this->delete($this->getProjectPath($project_id, 'registry/repositories/'.self::encodePath($repository_id)));
     }
 
-    public function repositoryTags(int|string $project_id, int $repository_id, array $parameters = []): mixed
+    public function repositoryTags(int|string $project_id, int $repository_id): mixed
     {
-        $resolver = $this->createOptionsResolver();
-
-        return $this->get(
-            $this->getProjectPath($project_id, 'registry/repositories/'.self::encodePath($repository_id).'/tags'),
-            $resolver->resolve($parameters)
-        );
+        return $this->get($this->getProjectPath($project_id, 'registry/repositories/'.self::encodePath($repository_id).'/tags'));
     }
 
     public function repositoryTag(int|string $project_id, int $repository_id, string $tag_name): mixed

--- a/src/Api/Users.php
+++ b/src/Api/Users.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Gitlab\Api;
 
 use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class Users extends AbstractApi
 {
@@ -177,7 +178,7 @@ class Users extends AbstractApi
      */
     public function usersContributedProjects(int|string $id, array $parameters = []): mixed
     {
-        $resolver = $this->createOptionsResolver();
+        $resolver = new OptionsResolver();
         $booleanNormalizer = function (Options $resolver, $value): string {
             return $value ? 'true' : 'false';
         };

--- a/tests/Api/DeploymentsTest.php
+++ b/tests/Api/DeploymentsTest.php
@@ -135,8 +135,6 @@ See merge request !2',
         $parameters = [
             'state' => 'merged',
             'labels' => 'release,backend',
-            'page' => 2,
-            'per_page' => 25,
         ];
 
         $api = $this->getApiMock();

--- a/tests/Api/GroupsTest.php
+++ b/tests/Api/GroupsTest.php
@@ -782,29 +782,11 @@ class GroupsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('groups/1/registry/repositories', [])
+            ->with('groups/1/registry/repositories')
             ->willReturn($expectedArray)
         ;
 
         $this->assertEquals($expectedArray, $api->registryRepositories(1));
-    }
-
-    #[Test]
-    public function shouldGetGroupRegistryRepositoriesWithPagination(): void
-    {
-        $expectedArray = [
-            ['id' => 1, 'name' => 'A registry'],
-            ['id' => 2, 'name' => 'Another registry'],
-        ];
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('groups/1/registry/repositories', ['page' => 2, 'per_page' => 15])
-            ->willReturn($expectedArray)
-        ;
-
-        $this->assertEquals($expectedArray, $api->registryRepositories(1, ['page' => 2, 'per_page' => 15]));
     }
 
     #[Test]

--- a/tests/Api/PersonalAccessTokensTest.php
+++ b/tests/Api/PersonalAccessTokensTest.php
@@ -65,8 +65,6 @@ class PersonalAccessTokensTest extends TestCase
                 'last_used_after' => $lastUsedAfter->format('c'),
                 'last_used_before' => $lastUsedBefore->format('c'),
                 'sort' => 'name_desc',
-                'page' => 1,
-                'per_page' => 10,
             ])
             ->willReturn($expectedArray)
         ;
@@ -83,8 +81,6 @@ class PersonalAccessTokensTest extends TestCase
             'last_used_after' => $lastUsedAfter,
             'last_used_before' => $lastUsedBefore,
             'sort' => 'name_desc',
-            'page' => 1,
-            'per_page' => 10,
         ]));
     }
 

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -2678,8 +2678,6 @@ class ProjectsTest extends TestCase
                 'last_used_after' => $lastUsedAfter->format('c'),
                 'last_used_before' => $lastUsedBefore->format('c'),
                 'sort' => 'name_desc',
-                'page' => 1,
-                'per_page' => 10,
             ])
             ->willReturn($expectedArray);
 
@@ -2694,8 +2692,6 @@ class ProjectsTest extends TestCase
             'last_used_after' => $lastUsedAfter,
             'last_used_before' => $lastUsedBefore,
             'sort' => 'name_desc',
-            'page' => 1,
-            'per_page' => 10,
         ]));
     }
 
@@ -2878,28 +2874,10 @@ class ProjectsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/job_token_scope/allowlist', [])
+            ->with('projects/1/job_token_scope/allowlist')
             ->willReturn($expectedArray);
 
         $this->assertEquals($expectedArray, $api->jobTokenScopeAllowlistProjects(1));
-    }
-
-    #[Test]
-    public function shouldGetJobTokenScopeAllowlistProjectsWithPagination(): void
-    {
-        $expectedArray = [[
-            'id' => 4,
-            'name' => 'Diaspora Client',
-            'web_url' => 'https://gitlab.example.com/diaspora/diaspora-client',
-        ]];
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('projects/1/job_token_scope/allowlist', ['page' => 2, 'per_page' => 15])
-            ->willReturn($expectedArray);
-
-        $this->assertEquals($expectedArray, $api->jobTokenScopeAllowlistProjects(1, ['page' => 2, 'per_page' => 15]));
     }
 
     #[Test]
@@ -2945,28 +2923,10 @@ class ProjectsTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/job_token_scope/groups_allowlist', [])
+            ->with('projects/1/job_token_scope/groups_allowlist')
             ->willReturn($expectedArray);
 
         $this->assertEquals($expectedArray, $api->jobTokenScopeAllowlistGroups(1));
-    }
-
-    #[Test]
-    public function shouldGetJobTokenScopeAllowlistGroupsWithPagination(): void
-    {
-        $expectedArray = [[
-            'id' => 4,
-            'name' => 'namegroup',
-            'web_url' => 'https://gitlab.example.com/groups/diaspora/diaspora-group',
-        ]];
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('projects/1/job_token_scope/groups_allowlist', ['page' => 2, 'per_page' => 15])
-            ->willReturn($expectedArray);
-
-        $this->assertEquals($expectedArray, $api->jobTokenScopeAllowlistGroups(1, ['page' => 2, 'per_page' => 15]));
     }
 
     #[Test]
@@ -3032,23 +2992,6 @@ class ProjectsTest extends TestCase
             ->willReturn($expectedArray);
 
         $this->assertEquals($expectedArray, $api->registryRepositories(123, ['tags' => true, 'tags_count' => true]));
-    }
-
-    #[Test]
-    public function shouldGetProjectRegistryRepositoriesWithPagination(): void
-    {
-        $expectedArray = [
-            ['id' => 1, 'name' => 'A registry'],
-            ['id' => 2, 'name' => 'Another registry'],
-        ];
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('projects/123/registry/repositories', ['page' => 2, 'per_page' => 15])
-            ->willReturn($expectedArray);
-
-        $this->assertEquals($expectedArray, $api->registryRepositories(123, ['page' => 2, 'per_page' => 15]));
     }
 
     #[Test]

--- a/tests/Api/RegistryTest.php
+++ b/tests/Api/RegistryTest.php
@@ -72,27 +72,10 @@ final class RegistryTest extends TestCase
         $api = $this->getApiMock();
         $api->expects($this->once())
             ->method('get')
-            ->with('projects/1/registry/repositories/2/tags', [])
+            ->with('projects/1/registry/repositories/2/tags')
             ->willReturn($expectedArray);
 
         $this->assertEquals($expectedArray, $api->repositoryTags(1, 2));
-    }
-
-    #[Test]
-    public function shouldGetRepositoryTagsWithPagination(): void
-    {
-        $expectedArray = [
-            ['name' => 'v1.0.0', 'path' => 'group/project:v1.0.0'],
-            ['name' => 'v1.1.0', 'path' => 'group/project:v1.1.0'],
-        ];
-
-        $api = $this->getApiMock();
-        $api->expects($this->once())
-            ->method('get')
-            ->with('projects/1/registry/repositories/2/tags', ['page' => 2, 'per_page' => 15])
-            ->willReturn($expectedArray);
-
-        $this->assertEquals($expectedArray, $api->repositoryTags(1, 2, ['page' => 2, 'per_page' => 15]));
     }
 
     #[Test]

--- a/tests/Api/UsersTest.php
+++ b/tests/Api/UsersTest.php
@@ -308,16 +308,6 @@ class UsersTest extends TestCase
     }
 
     #[Test]
-    public function shouldShowUsersContributedProjectsWithLimit(): void
-    {
-        $expectedArray = [$this->getUsersProjectsData()[0]];
-
-        $api = $this->getUsersProjectsRequestMock('users/1/contributed_projects', $expectedArray, ['per_page' => 1]);
-
-        $this->assertEquals($expectedArray, $api->usersContributedProjects(1, ['per_page' => 1]));
-    }
-
-    #[Test]
     public function shouldGetAllUsersContributedProjectsSortedByStars(): void
     {
         $expectedArray = $this->getUsersProjectsData();
@@ -325,12 +315,12 @@ class UsersTest extends TestCase
         $api = $this->getUsersProjectsRequestMock(
             'users/1/contributed_projects',
             $expectedArray,
-            ['page' => 1, 'per_page' => 5, 'order_by' => 'star_count', 'sort' => 'desc']
+            ['order_by' => 'star_count', 'sort' => 'desc']
         );
 
         $this->assertEquals(
             $expectedArray,
-            $api->usersContributedProjects(1, ['page' => 1, 'per_page' => 5, 'order_by' => 'star_count', 'sort' => 'desc'])
+            $api->usersContributedProjects(1, ['order_by' => 'star_count', 'sort' => 'desc'])
         );
     }
 


### PR DESCRIPTION
Removes recently added manual pagination parameters from list endpoints so pagination remains handled by the result pager.