### PR TITLE
[12.1] Add pipeline inputs support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for project integrations endpoints
 * Add support for group hook endpoints
 * Add support for `job_inputs` and `job_variables_attributes` in `Jobs::play`
+* Add support for `inputs` in `Projects::createPipeline`
 * Add support for filters in `Projects::projectAccessTokens`
 * Add support for `Projects::rotateProjectAccessToken`
 * Add support for listing merge requests associated with a commit

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -368,6 +368,7 @@ class Projects extends AbstractApi
      *     @var mixed $value           The value of the variable
      *     @var string $variable_type  env_var (default) or file
      * }
+     *
      * @param array $parameters {
      *
      *     @var array $inputs Inputs to use when creating the pipeline.

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -368,10 +368,19 @@ class Projects extends AbstractApi
      *     @var mixed $value           The value of the variable
      *     @var string $variable_type  env_var (default) or file
      * }
+     * @param array $parameters {
+     *
+     *     @var array $inputs Inputs to use when creating the pipeline.
+     * }
      */
-    public function createPipeline(int|string $project_id, string $commit_ref, ?array $variables = null): mixed
+    public function createPipeline(int|string $project_id, string $commit_ref, ?array $variables = null, array $parameters = []): mixed
     {
-        $parameters = [];
+        $resolver = new OptionsResolver();
+        $resolver->setDefined('inputs')
+            ->setAllowedTypes('inputs', 'array')
+        ;
+
+        $parameters = $resolver->resolve($parameters);
 
         if (null !== $variables) {
             $parameters['variables'] = $variables;

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -940,6 +940,53 @@ class ProjectsTest extends TestCase
     }
 
     #[Test]
+    public function shouldCreatePipelineWithInputs(): void
+    {
+        $expectedArray = [
+            ['id' => 4, 'status' => 'created', 'ref' => 'test-pipeline'],
+        ];
+        $inputs = [
+            'environment' => 'production',
+            'scan_security' => false,
+            'level' => 3,
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/pipeline', ['inputs' => $inputs], [], [], ['ref' => 'test-pipeline'])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->createPipeline(1, 'test-pipeline', null, ['inputs' => $inputs]));
+    }
+
+    #[Test]
+    public function shouldCreatePipelineWithVariablesAndInputs(): void
+    {
+        $expectedArray = [
+            ['id' => 4, 'status' => 'created', 'ref' => 'test-pipeline'],
+        ];
+        $variables = [
+            [
+                'key' => 'test_var_1',
+                'value' => 'test_value_1',
+            ],
+        ];
+        $inputs = [
+            'environment' => 'production',
+            'scan_security' => false,
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/pipeline', ['inputs' => $inputs, 'variables' => $variables], [], [], ['ref' => 'test-pipeline'])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->createPipeline(1, 'test-pipeline', $variables, ['inputs' => $inputs]));
+    }
+
+    #[Test]
     public function shouldRetryPipeline(): void
     {
         $expectedArray = [


### PR DESCRIPTION
Adds support for `inputs` in `Projects::createPipeline`. Replaces #833.