### PR TITLE
[12.1] Add project deploy key update API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for `visibility` in `Groups::all`
 * Add support for personal access tokens
 * Add support for project integrations endpoints
+* Add support for `Projects::updateDeployKey`
 * Add support for group hook endpoints
 * Add support for `job_inputs` and `job_variables_attributes` in `Jobs::play`
 * Add support for `inputs` in `Projects::createPipeline`

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -613,6 +613,26 @@ class Projects extends AbstractApi
         ]);
     }
 
+    /**
+     * @param array $parameters {
+     *
+     *     @var bool   $can_push can deploy key push to the project's repository
+     *     @var string $title    new deploy key's title
+     * }
+     */
+    public function updateDeployKey(int|string $project_id, int $key_id, array $parameters = []): mixed
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefined('can_push')
+            ->setAllowedTypes('can_push', 'bool')
+        ;
+        $resolver->setDefined('title')
+            ->setAllowedTypes('title', 'string')
+        ;
+
+        return $this->put($this->getProjectPath($project_id, 'deploy_keys/'.self::encodePath($key_id)), $resolver->resolve($parameters));
+    }
+
     public function deleteDeployKey(int|string $project_id, int $key_id): mixed
     {
         return $this->delete($this->getProjectPath($project_id, 'deploy_keys/'.self::encodePath($key_id)));

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -1420,6 +1420,21 @@ class ProjectsTest extends TestCase
     }
 
     #[Test]
+    public function shouldUpdateDeployKey(): void
+    {
+        $expectedArray = ['id' => 3, 'title' => 'new-title', 'key' => 'ssh-rsa AAAA...', 'can_push' => true];
+        $parameters = ['can_push' => true, 'title' => 'new-title'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('put')
+            ->with('projects/1/deploy_keys/3', $parameters)
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->updateDeployKey(1, 3, $parameters));
+    }
+
+    #[Test]
     public function shouldDeleteDeployKey(): void
     {
         $expectedBool = true;


### PR DESCRIPTION
Adds `Projects::updateDeployKey` for updating project deploy key titles and push access.