### PR TITLE
[12.1] Mark authentication parameters sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add PHP 8.5 support
 * Add support for `symfony/options-resolver:^8.0`
+* Add sensitive parameter annotations for authentication, trigger tokens, and user passwords
 * Add support for `force` in `Repositories::createCommit`
 * Add support for personal access tokens
 * Add support for project access token filters and rotation

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
         "psr/http-message": "^1.1 || ^2.0",
-        "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+        "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/polyfill-php82": "^1.27"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -251,7 +251,7 @@ class Projects extends AbstractApi
         return $this->delete($this->getProjectPath($project_id, 'triggers/'.self::encodePath($trigger_id)));
     }
 
-    public function triggerPipeline(int|string $project_id, string $ref, string $token, array $variables = []): mixed
+    public function triggerPipeline(int|string $project_id, string $ref, #[\SensitiveParameter] string $token, array $variables = []): mixed
     {
         return $this->post($this->getProjectPath($project_id, 'trigger/pipeline'), [
             'ref' => $ref,

--- a/src/Api/Users.php
+++ b/src/Api/Users.php
@@ -281,7 +281,7 @@ class Users extends AbstractApi
         return $this->get('user');
     }
 
-    public function create(string $email, string $password, array $params = []): mixed
+    public function create(string $email, #[\SensitiveParameter] string $password, array $params = []): mixed
     {
         $params['email'] = $email;
         $params['password'] = $password;

--- a/src/Client.php
+++ b/src/Client.php
@@ -325,7 +325,7 @@ class Client
      * @param string      $token      Gitlab private token
      * @param string      $authMethod One of the AUTH_* class constants
      */
-    public function authenticate(string $token, string $authMethod, ?string $sudo = null): void
+    public function authenticate(#[\SensitiveParameter] string $token, string $authMethod, ?string $sudo = null): void
     {
         $this->getHttpClientBuilder()->removePlugin(Authentication::class);
         $this->getHttpClientBuilder()->addPlugin(new Authentication($authMethod, $token, $sudo));

--- a/src/HttpClient/Plugin/Authentication.php
+++ b/src/HttpClient/Plugin/Authentication.php
@@ -36,7 +36,7 @@ final class Authentication implements Plugin
      */
     private readonly array $headers;
 
-    public function __construct(string $method, string $token, ?string $sudo = null)
+    public function __construct(string $method, #[\SensitiveParameter] string $token, ?string $sudo = null)
     {
         $this->headers = self::buildHeaders($method, $token, $sudo);
     }
@@ -62,7 +62,7 @@ final class Authentication implements Plugin
      *
      * @return array<string,string>
      */
-    private static function buildHeaders(string $method, string $token, ?string $sudo = null): array
+    private static function buildHeaders(string $method, #[\SensitiveParameter] string $token, ?string $sudo = null): array
     {
         $headers = [];
 


### PR DESCRIPTION
Mark authentication, trigger, and user password parameters as sensitive to avoid stack-trace leaks. Closes #859.