### PR TITLE
Projects: add support for missing hook endpoints

### DIFF
--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -513,6 +513,27 @@ class Projects extends AbstractApi
     }
 
     /**
+     * List all events for a specified project webhook in the past 7 days from the start date.
+     *
+     * See https://docs.gitlab.com/api/project_webhooks/#list-project-webhook-events for more info.
+     *
+     * @param array $parameters {
+     *
+     *     @var int|string $status Response status code, for example 200 or 500, or a category of status
+     *                             codes: successful, client_failure, or server_failure.
+     * }
+     */
+    public function hookEvents(int|string $project_id, int $hook_id, array $parameters = []): mixed
+    {
+        $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('status')
+            ->setAllowedTypes('status', ['int', 'string'])
+        ;
+
+        return $this->get($this->getProjectPath($project_id, 'hooks/'.self::encodePath($hook_id).'/events'), $resolver->resolve($parameters));
+    }
+
+    /**
      * Get project users.
      *
      * See https://docs.gitlab.com/ee/api/projects.html#get-project-users for more info.

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -534,6 +534,22 @@ class Projects extends AbstractApi
     }
 
     /**
+     * See https://docs.gitlab.com/api/project_webhooks/#resend-a-project-webhook-event for more info.
+     */
+    public function resendHookEvent(int|string $project_id, int $hook_id, int $hook_event_id): mixed
+    {
+        return $this->post($this->getProjectPath($project_id, 'hooks/'.self::encodePath($hook_id).'/events/'.self::encodePath($hook_event_id).'/resend'));
+    }
+
+    /**
+     * See https://docs.gitlab.com/api/project_webhooks/#trigger-a-test-project-webhook for more info.
+     */
+    public function testHook(int|string $project_id, int $hook_id, string $trigger): mixed
+    {
+        return $this->post($this->getProjectPath($project_id, 'hooks/'.self::encodePath($hook_id).'/test/'.self::encodePath($trigger)));
+    }
+
+    /**
      * Get project users.
      *
      * See https://docs.gitlab.com/ee/api/projects.html#get-project-users for more info.

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -1326,6 +1326,39 @@ class ProjectsTest extends TestCase
     }
 
     #[Test]
+    public function shouldGetHookEvents(): void
+    {
+        $expectedArray = [
+            ['id' => 1, 'url' => 'http://example.com', 'response_status' => 200],
+            ['id' => 2, 'url' => 'http://example.com', 'response_status' => 500],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/hooks/2/events')
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->hookEvents(1, 2));
+    }
+
+    #[Test]
+    public function shouldGetHookEventsWithStatusFilter(): void
+    {
+        $expectedArray = [
+            ['id' => 2, 'url' => 'http://example.com', 'response_status' => 500],
+        ];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('projects/1/hooks/2/events', ['status' => 'server_failure'])
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->hookEvents(1, 2, ['status' => 'server_failure']));
+    }
+
+    #[Test]
     public function shouldAddHook(): void
     {
         $expectedArray = ['id' => 3, 'name' => 'A new hook', 'url' => 'http://www.example.com'];

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -1359,6 +1359,34 @@ class ProjectsTest extends TestCase
     }
 
     #[Test]
+    public function shouldResendHookEvent(): void
+    {
+        $expectedArray = ['message' => '201 Created'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/hooks/2/events/3/resend')
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->resendHookEvent(1, 2, 3));
+    }
+
+    #[Test]
+    public function shouldTestHook(): void
+    {
+        $expectedArray = ['message' => '201 Created'];
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('post')
+            ->with('projects/1/hooks/2/test/push_events')
+            ->willReturn($expectedArray);
+
+        $this->assertEquals($expectedArray, $api->testHook(1, 2, 'push_events'));
+    }
+
+    #[Test]
     public function shouldAddHook(): void
     {
         $expectedArray = ['id' => 3, 'name' => 'A new hook', 'url' => 'http://www.example.com'];


### PR DESCRIPTION
Adds support for:
* test
* resendEvent
* events

Similar to how this is already available for GroupsHooks.